### PR TITLE
fix(tests): portable temp path for trace export tests

### DIFF
--- a/tests/timing/test_concurrent_timing_executor.cpp
+++ b/tests/timing/test_concurrent_timing_executor.cpp
@@ -8,6 +8,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <filesystem>
+
 #include <sw/kpu/timing/concurrent_timing_executor.hpp>
 
 using namespace sw::kpu::timing;
@@ -391,7 +393,7 @@ TEST_CASE("ConcurrentTimingExecutor Chrome trace export", "[timing][executor]") 
     executor.run();
 
     // Export to temp file
-    std::string temp_file = "/tmp/test_trace.json";
+    std::string temp_file = (std::filesystem::temp_directory_path() / "test_trace.json").string();
     executor.export_chrome_trace(temp_file);
 
     // Verify file exists and has content
@@ -412,7 +414,7 @@ TEST_CASE("ConcurrentTimingExecutor CSV export", "[timing][executor]") {
     executor.run();
 
     // Export to temp file
-    std::string temp_file = "/tmp/test_trace.csv";
+    std::string temp_file = (std::filesystem::temp_directory_path() / "test_trace.csv").string();
     executor.export_csv(temp_file);
 
     // Verify file exists and has content


### PR DESCRIPTION
## Summary
- Replaces hardcoded `/tmp/test_trace.{json,csv}` in `tests/timing/test_concurrent_timing_executor.cpp` with `std::filesystem::temp_directory_path()`.
- Fixes the first of two pre-existing Windows CI failures tracked in #3 (the `REQUIRE(file.is_open())` failures at lines 399 and 420).
- Stack-buffer-overrun failure in `test_transactional_program_executor` is **not** addressed here; it needs separate investigation.

## Test plan
- [x] Build: `cmake --build --preset release --target test_concurrent_timing_executor` — succeeds.
- [x] Local run: `./build/tests/timing/test_concurrent_timing_executor "[executor]"` — 19/19 test cases, 80/80 assertions pass.
- [x] Confirmed files written to `/tmp/test_trace.json` and `/tmp/test_trace.csv` on Linux (unchanged behavior).
- [ ] CI: `build (windows-latest, Release, cl)` should now lose the two `file.is_open()` failures.

Refs #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)