### PR TITLE
ci: use Ninja on Linux and parallel build to cut CI time

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -68,8 +68,11 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      # Use Ninja on Linux (parallelizes by default; much faster than the Unix Makefiles default).
+      # Leave Windows on its default Visual Studio generator, which already parallelizes via MSBuild.
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        ${{ runner.os == 'Linux' && '-G Ninja' || '' }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -83,7 +86,9 @@ jobs:
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      # --parallel: explicitly request a parallel build. Ninja (Linux) and MSBuild (Windows) both
+      # respect this; without it, Unix Makefiles would default to single-threaded.
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} --parallel
 
     - name: Test
       working-directory: ${{ steps.strings.outputs.build-output-dir }}


### PR DESCRIPTION
## Summary
- Linux CI build was running **single-threaded** because the workflow used the default Unix Makefiles generator and didn't pass `-j`, so `cmake --build` invoked `make` with one job. Latest run: configure 43s, build **18m 6s**, test 11s.
- This PR switches Linux to the Ninja generator (preinstalled on `ubuntu-latest`) and adds `--parallel` to `cmake --build` on all platforms.
- Windows is unchanged in spirit — the Visual Studio generator already parallelizes via MSBuild; `--parallel` is a no-op there.

## Expected impact
On a 4-core runner with no other bottlenecks, the Linux build should drop from ~18 min to roughly **4-5 min**. Total CI time per push goes from ~20 min to ~7 min.

Further wins (not in this PR) if more speedup is needed later:
- ccache / sccache with `actions/cache` (fast warm rebuilds across runs)
- Cache `build/_deps/` so FetchContent doesn't re-clone/rebuild Catch2, fmt, spdlog, json, gtest, universal every push
- Split the Python bindings TU (`kpu_bindings.cpp` is the heaviest single object at ~8.7 MB)

## Test plan
- [ ] Watch the CI run on this PR; confirm Linux gcc + clang `Build` step drops below ~6 minutes.
- [ ] Confirm Windows MSBuild build time is unchanged (or marginally improved).
- [ ] Confirm tests still pass on Linux (the Windows failures are pre-existing and tracked in #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)