### PR TITLE
fix(tests): close ifstream before remove() on Windows

### DIFF
--- a/include/sw/kpu/timing/process_interface.hpp
+++ b/include/sw/kpu/timing/process_interface.hpp
@@ -164,12 +164,14 @@ struct TimingEvent {
         json += "\"tile\":\"" + tile_id.to_string() + "\"";
         if (matrix_base_address != 0) {
             char hex[32];
-            snprintf(hex, sizeof(hex), "0x%lX", matrix_base_address);
+            snprintf(hex, sizeof(hex), "0x%llX",
+                     static_cast<unsigned long long>(matrix_base_address));
             json += ",\"base\":\"" + std::string(hex) + "\"";
         }
         if (dram_address != 0) {
             char hex[32];
-            snprintf(hex, sizeof(hex), "0x%lX", dram_address);
+            snprintf(hex, sizeof(hex), "0x%llX",
+                     static_cast<unsigned long long>(dram_address));
             json += ",\"addr\":\"" + std::string(hex) + "\"";
         }
         if (slot_id > 0) {

--- a/include/sw/kpu/timing/tile_descriptor.hpp
+++ b/include/sw/kpu/timing/tile_descriptor.hpp
@@ -145,7 +145,8 @@ struct TileDescriptor {
         std::string s = tile_id.to_string();
         if (matrix_base_address != 0) {
             char hex[32];
-            snprintf(hex, sizeof(hex), " @ 0x%lX", matrix_base_address);
+            snprintf(hex, sizeof(hex), " @ 0x%llX",
+                     static_cast<unsigned long long>(matrix_base_address));
             s += hex;
         }
         return s;

--- a/tests/isa/test_transactional_program_executor.cpp
+++ b/tests/isa/test_transactional_program_executor.cpp
@@ -291,9 +291,11 @@ void test_multi_tile_timing_reasonable() {
 // ============================================================================
 
 void test_export_chrome_trace() {
-    std::cout << "test_export_chrome_trace:\n";
+    std::cout << "test_export_chrome_trace:\n" << std::flush;
 
     TestHardware hw;
+    std::cout << "  [DBG] hw built\n" << std::flush;
+
     const Size M = 16, N = 16, K = 16;
     const Size Ti = 16, Tj = 16, Tk = 16;
 
@@ -308,16 +310,24 @@ void test_export_chrome_trace() {
     hw.ext_mem.write(a_base, a_data.data(), a_data.size() * sizeof(float));
     hw.ext_mem.write(b_base, b_data.data(), b_data.size() * sizeof(float));
     hw.ext_mem.write(c_base, c_zero.data(), c_zero.size() * sizeof(float));
+    std::cout << "  [DBG] memory primed\n" << std::flush;
 
     auto sched = matmul_output_stationary(M, N, K, Ti, Tj, Tk);
     DMProgram prog = compile_schedule(sched);
+    std::cout << "  [DBG] program compiled\n" << std::flush;
 
     TransactionalProgramExecutor exec(hw.context());
     exec.load_program(prog, a_base, b_base, c_base);
+    std::cout << "  [DBG] program loaded\n" << std::flush;
+
     exec.run();
+    std::cout << "  [DBG] run() returned\n" << std::flush;
 
     std::string trace_file = (std::filesystem::temp_directory_path() / "test_transactional_trace.json").string();
+    std::cout << "  [DBG] trace_file path: " << trace_file << "\n" << std::flush;
+
     exec.export_chrome_trace(trace_file);
+    std::cout << "  [DBG] export_chrome_trace returned\n" << std::flush;
 
     check(std::filesystem::exists(trace_file), "Trace file created");
 
@@ -660,11 +670,15 @@ void test_loop_timing_config() {
 // Main
 // ============================================================================
 
-// Run a subtest and flush stdout afterward. On Windows MSVC a stack
-// buffer-overrun (0xC0000409) aborts via __fastfail without flushing
-// stdio, so without an explicit flush we can't tell which subtest
-// crashed. See issue #3.
-#define RUN_SUBTEST(fn) do { fn(); std::cout << std::flush; } while (0)
+// Bracket each subtest with flushed entry/exit markers. On Windows MSVC
+// a stack buffer-overrun (0xC0000409) aborts via __fastfail without
+// flushing stdio, so without explicit flushes we can't tell where the
+// crash is. See issue #3.
+#define RUN_SUBTEST(fn) do {                                          \
+    std::cout << ">>> entering " #fn "\n" << std::flush;              \
+    fn();                                                             \
+    std::cout << "<<< exited "   #fn "\n" << std::flush;              \
+} while (0)
 
 int main() {
     std::cout << "=== TransactionalProgramExecutor Tests ===\n\n" << std::flush;

--- a/tests/isa/test_transactional_program_executor.cpp
+++ b/tests/isa/test_transactional_program_executor.cpp
@@ -236,7 +236,7 @@ void test_multi_tile_matmul_correctness() {
 }
 
 void test_multi_tile_timing_reasonable() {
-    std::cout << "test_multi_tile_timing_reasonable:\n" << std::flush;
+    std::cout << "test_multi_tile_timing_reasonable:\n";
 
     TestHardware hw;
     const Size M = 32, N = 32, K = 32;
@@ -253,26 +253,15 @@ void test_multi_tile_timing_reasonable() {
     hw.ext_mem.write(a_base, a_data.data(), a_data.size() * sizeof(float));
     hw.ext_mem.write(b_base, b_data.data(), b_data.size() * sizeof(float));
     hw.ext_mem.write(c_base, c_zero.data(), c_zero.size() * sizeof(float));
-    std::cout << "  [DBG] memory primed\n" << std::flush;
 
     auto sched = matmul_output_stationary(M, N, K, Ti, Tj, Tk);
-    std::cout << "  [DBG] schedule built\n" << std::flush;
-
     DMProgram prog = compile_schedule(sched);
-    std::cout << "  [DBG] schedule compiled (" << prog.instructions.size()
-              << " instructions)\n" << std::flush;
 
     TransactionalProgramExecutor exec(hw.context());
-    std::cout << "  [DBG] executor constructed\n" << std::flush;
-
     exec.load_program(prog, a_base, b_base, c_base);
-    std::cout << "  [DBG] program loaded\n" << std::flush;
-
     exec.run();
-    std::cout << "  [DBG] run() returned\n" << std::flush;
 
     auto stats = exec.get_timing_stats();
-    std::cout << "  [DBG] stats fetched\n" << std::flush;
 
     check(stats.total_cycles > 0, "Total cycles is positive");
     check(stats.total_cycles < 1000000, "Total cycles is reasonable (< 1M)");
@@ -291,11 +280,9 @@ void test_multi_tile_timing_reasonable() {
 // ============================================================================
 
 void test_export_chrome_trace() {
-    std::cout << "test_export_chrome_trace:\n" << std::flush;
+    std::cout << "test_export_chrome_trace:\n";
 
     TestHardware hw;
-    std::cout << "  [DBG] hw built\n" << std::flush;
-
     const Size M = 16, N = 16, K = 16;
     const Size Ti = 16, Tj = 16, Tk = 16;
 
@@ -310,46 +297,37 @@ void test_export_chrome_trace() {
     hw.ext_mem.write(a_base, a_data.data(), a_data.size() * sizeof(float));
     hw.ext_mem.write(b_base, b_data.data(), b_data.size() * sizeof(float));
     hw.ext_mem.write(c_base, c_zero.data(), c_zero.size() * sizeof(float));
-    std::cout << "  [DBG] memory primed\n" << std::flush;
 
     auto sched = matmul_output_stationary(M, N, K, Ti, Tj, Tk);
     DMProgram prog = compile_schedule(sched);
-    std::cout << "  [DBG] program compiled\n" << std::flush;
 
     TransactionalProgramExecutor exec(hw.context());
     exec.load_program(prog, a_base, b_base, c_base);
-    std::cout << "  [DBG] program loaded\n" << std::flush;
-
     exec.run();
-    std::cout << "  [DBG] run() returned\n" << std::flush;
 
     std::string trace_file = (std::filesystem::temp_directory_path() / "test_transactional_trace.json").string();
-    std::cout << "  [DBG] trace_file path: " << trace_file << "\n" << std::flush;
-
     exec.export_chrome_trace(trace_file);
-    std::cout << "  [DBG] export_chrome_trace returned\n" << std::flush;
 
-    bool exists = std::filesystem::exists(trace_file);
-    std::cout << "  [DBG] exists()=" << exists << "\n" << std::flush;
-    check(exists, "Trace file created");
-    std::cout << "  [DBG] after check exists\n" << std::flush;
+    check(std::filesystem::exists(trace_file), "Trace file created");
 
     auto file_size = std::filesystem::file_size(trace_file);
-    std::cout << "  [DBG] file_size()=" << file_size << "\n" << std::flush;
     check(file_size > 0, "Trace file is not empty");
-    std::cout << "  [DBG] after check size\n" << std::flush;
 
     // Check JSON format
-    std::ifstream in(trace_file);
-    std::cout << "  [DBG] ifstream opened: " << in.is_open() << "\n" << std::flush;
-    char first = 0;
-    in >> first;
-    std::cout << "  [DBG] first char=" << first << "\n" << std::flush;
-    check(first == '{', "Trace file starts with '{'");
-    std::cout << "  [DBG] after check json\n" << std::flush;
+    // Scope the ifstream so it closes before we try to remove the file —
+    // on Windows std::filesystem::remove() throws filesystem_error if the
+    // file is still open, the uncaught exception propagates out of main(),
+    // and MSVC's std::terminate fast-fails with STATUS_STACK_BUFFER_OVERRUN
+    // (0xC0000409). Linux happily unlinks an open file, hence the
+    // platform-specific behaviour. See issue #3.
+    {
+        std::ifstream in(trace_file);
+        char first = 0;
+        in >> first;
+        check(first == '{', "Trace file starts with '{'");
+    }
 
     std::filesystem::remove(trace_file);
-    std::cout << "  [DBG] remove() returned\n" << std::flush;
 }
 
 // ============================================================================
@@ -679,15 +657,11 @@ void test_loop_timing_config() {
 // Main
 // ============================================================================
 
-// Bracket each subtest with flushed entry/exit markers. On Windows MSVC
-// a stack buffer-overrun (0xC0000409) aborts via __fastfail without
-// flushing stdio, so without explicit flushes we can't tell where the
-// crash is. See issue #3.
-#define RUN_SUBTEST(fn) do {                                          \
-    std::cout << ">>> entering " #fn "\n" << std::flush;              \
-    fn();                                                             \
-    std::cout << "<<< exited "   #fn "\n" << std::flush;              \
-} while (0)
+// Flush stdout after each subtest. Required on Windows MSVC because
+// fatal exits via __fastfail() do not flush stdio buffers — any
+// unflushed output would be lost from the CI log, masking which
+// subtest hit the failure.
+#define RUN_SUBTEST(fn) do { fn(); std::cout << std::flush; } while (0)
 
 int main() {
     std::cout << "=== TransactionalProgramExecutor Tests ===\n\n" << std::flush;

--- a/tests/isa/test_transactional_program_executor.cpp
+++ b/tests/isa/test_transactional_program_executor.cpp
@@ -649,35 +649,41 @@ void test_loop_timing_config() {
 // Main
 // ============================================================================
 
+// Run a subtest and flush stdout afterward. On Windows MSVC a stack
+// buffer-overrun (0xC0000409) aborts via __fastfail without flushing
+// stdio, so without an explicit flush we can't tell which subtest
+// crashed. See issue #3.
+#define RUN_SUBTEST(fn) do { fn(); std::cout << std::flush; } while (0)
+
 int main() {
-    std::cout << "=== TransactionalProgramExecutor Tests ===\n\n";
+    std::cout << "=== TransactionalProgramExecutor Tests ===\n\n" << std::flush;
 
     // Basic tests
-    test_constructs_with_defaults();
-    test_constructs_with_custom_timing();
+    RUN_SUBTEST(test_constructs_with_defaults);
+    RUN_SUBTEST(test_constructs_with_custom_timing);
 
     // Single-tile tests
-    test_single_tile_matmul_correctness();
-    test_single_tile_generates_timing();
+    RUN_SUBTEST(test_single_tile_matmul_correctness);
+    RUN_SUBTEST(test_single_tile_generates_timing);
 
     // Multi-tile tests
-    test_multi_tile_matmul_correctness();
-    test_multi_tile_timing_reasonable();
+    RUN_SUBTEST(test_multi_tile_matmul_correctness);
+    RUN_SUBTEST(test_multi_tile_timing_reasonable);
 
     // Export tests
-    test_export_chrome_trace();
-    test_generate_timeline();
+    RUN_SUBTEST(test_export_chrome_trace);
+    RUN_SUBTEST(test_generate_timeline);
 
     // Configuration tests
-    test_different_timing_configs();
+    RUN_SUBTEST(test_different_timing_configs);
 
     // Special cases
-    test_identity_matrix_multiplication();
+    RUN_SUBTEST(test_identity_matrix_multiplication);
 
     // Loop timing tests
-    test_loop_timing_overhead();
-    test_nested_loop_timing();
-    test_loop_timing_config();
+    RUN_SUBTEST(test_loop_timing_overhead);
+    RUN_SUBTEST(test_nested_loop_timing);
+    RUN_SUBTEST(test_loop_timing_config);
 
     // Summary
     std::cout << "\n=== Summary ===\n";

--- a/tests/isa/test_transactional_program_executor.cpp
+++ b/tests/isa/test_transactional_program_executor.cpp
@@ -236,7 +236,7 @@ void test_multi_tile_matmul_correctness() {
 }
 
 void test_multi_tile_timing_reasonable() {
-    std::cout << "test_multi_tile_timing_reasonable:\n";
+    std::cout << "test_multi_tile_timing_reasonable:\n" << std::flush;
 
     TestHardware hw;
     const Size M = 32, N = 32, K = 32;
@@ -253,15 +253,26 @@ void test_multi_tile_timing_reasonable() {
     hw.ext_mem.write(a_base, a_data.data(), a_data.size() * sizeof(float));
     hw.ext_mem.write(b_base, b_data.data(), b_data.size() * sizeof(float));
     hw.ext_mem.write(c_base, c_zero.data(), c_zero.size() * sizeof(float));
+    std::cout << "  [DBG] memory primed\n" << std::flush;
 
     auto sched = matmul_output_stationary(M, N, K, Ti, Tj, Tk);
+    std::cout << "  [DBG] schedule built\n" << std::flush;
+
     DMProgram prog = compile_schedule(sched);
+    std::cout << "  [DBG] schedule compiled (" << prog.instructions.size()
+              << " instructions)\n" << std::flush;
 
     TransactionalProgramExecutor exec(hw.context());
+    std::cout << "  [DBG] executor constructed\n" << std::flush;
+
     exec.load_program(prog, a_base, b_base, c_base);
+    std::cout << "  [DBG] program loaded\n" << std::flush;
+
     exec.run();
+    std::cout << "  [DBG] run() returned\n" << std::flush;
 
     auto stats = exec.get_timing_stats();
+    std::cout << "  [DBG] stats fetched\n" << std::flush;
 
     check(stats.total_cycles > 0, "Total cycles is positive");
     check(stats.total_cycles < 1000000, "Total cycles is reasonable (< 1M)");

--- a/tests/isa/test_transactional_program_executor.cpp
+++ b/tests/isa/test_transactional_program_executor.cpp
@@ -329,18 +329,27 @@ void test_export_chrome_trace() {
     exec.export_chrome_trace(trace_file);
     std::cout << "  [DBG] export_chrome_trace returned\n" << std::flush;
 
-    check(std::filesystem::exists(trace_file), "Trace file created");
+    bool exists = std::filesystem::exists(trace_file);
+    std::cout << "  [DBG] exists()=" << exists << "\n" << std::flush;
+    check(exists, "Trace file created");
+    std::cout << "  [DBG] after check exists\n" << std::flush;
 
     auto file_size = std::filesystem::file_size(trace_file);
+    std::cout << "  [DBG] file_size()=" << file_size << "\n" << std::flush;
     check(file_size > 0, "Trace file is not empty");
+    std::cout << "  [DBG] after check size\n" << std::flush;
 
     // Check JSON format
     std::ifstream in(trace_file);
-    char first;
+    std::cout << "  [DBG] ifstream opened: " << in.is_open() << "\n" << std::flush;
+    char first = 0;
     in >> first;
+    std::cout << "  [DBG] first char=" << first << "\n" << std::flush;
     check(first == '{', "Trace file starts with '{'");
+    std::cout << "  [DBG] after check json\n" << std::flush;
 
     std::filesystem::remove(trace_file);
+    std::cout << "  [DBG] remove() returned\n" << std::flush;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Two changes targeting the remaining Windows MSVC failure (test #46 `test_transactional_program_executor`, exit `0xC0000409` = `STATUS_STACK_BUFFER_OVERRUN`) tracked in #3.

### 1. `%lX` → `%llX` for `Address` (real bug fix)
Three `snprintf` call sites format a `uint64_t Address` with `%lX`:
- `include/sw/kpu/timing/tile_descriptor.hpp:148`
- `include/sw/kpu/timing/process_interface.hpp:167`
- `include/sw/kpu/timing/process_interface.hpp:172`

On MSVC, `long` is 32-bit, so passing a 64-bit value through varargs with a `%lX` specifier is undefined behavior. It works on Linux (where `long` is 64-bit) and breaks on Windows. The MSVC build log explicitly warned (`C4477`). Fixed to `%llX` with an explicit cast to `unsigned long long`.

**Caveat:** these call sites are only used by `ConcurrentTimingExecutor::export_chrome_trace`, **not** by `TransactionalProgramExecutor`. So this is unlikely to resolve the specific failing test by itself — but it is a real latent bug that would have bitten something eventually.

### 2. Diagnostic stdout flushes (test plumbing)
`STATUS_STACK_BUFFER_OVERRUN` is delivered via `__fastfail` on Windows, which terminates the process without flushing stdio buffers. As a result the CI log shows zero captured output for the crashing test, and we can't tell which of the 13 subtests fired the bug.

Added a `RUN_SUBTEST` macro that flushes `std::cout` after each subtest. The next CI run should print every subtest name that started, with the last printed name being the one that crashed — that pinpoints the code path to investigate.

## Test plan
- [x] Local Linux build + run of `test_transactional_program_executor`: 33/33 pass.
- [x] Local Linux run of `test_concurrent_timing_executor [executor]`: 80/80 assertions, 19/19 cases (covers the `%lX` paths in `to_chrome_trace_json`).
- [ ] **Watch CI on Windows.** Two outcomes:
   - Best case: the `%lX` fix happens to resolve the crash (unlikely given the call graph but possible if I missed an indirect call).
   - Expected case: still crashes, but now the log prints every subtest name up to the crashing one. That tells us exactly where to dig next.

Refs #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)