### PR TITLE
ci: add sccache compile cache to cmake-multi-platform

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 
+    # sccache uses the GitHub Actions cache as its storage backend. The action
+    # injects the required credentials when SCCACHE_GHA_ENABLED is set.
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
@@ -58,6 +63,20 @@ jobs:
     - name: Verify CMake version
       run: cmake --version
 
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
+
+    # On Windows we replace the default Visual Studio generator with Ninja so
+    # that CMAKE_*_COMPILER_LAUNCHER (the sccache hook) is honoured — MSBuild
+    # ignores compiler launchers. ilammy/msvc-dev-cmd puts cl.exe on PATH so
+    # Ninja can find the MSVC toolchain.
+    - name: Set up MSVC environment
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Set up sccache
+      uses: mozilla-actions/sccache-action@v0.0.7
+
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings
@@ -66,13 +85,14 @@ jobs:
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      # Use Ninja on Linux (parallelizes by default; much faster than the Unix Makefiles default).
-      # Leave Windows on its default Visual Studio generator, which already parallelizes via MSBuild.
+      # Single-config Ninja generator on both platforms so CMAKE_*_COMPILER_LAUNCHER
+      # (sccache) takes effect. Ninja parallelises by default; on Windows we rely
+      # on the MSVC env from ilammy/msvc-dev-cmd above.
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        ${{ runner.os == 'Linux' && '-G Ninja' || '' }}
+        -G Ninja
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -85,10 +105,15 @@ jobs:
         path: ${{ steps.strings.outputs.build-output-dir }}/build_system_info.log
 
     - name: Build
-      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      # --parallel: explicitly request a parallel build. Ninja (Linux) and MSBuild (Windows) both
-      # respect this; without it, Unix Makefiles would default to single-threaded.
+      # --parallel is redundant with Ninja (which parallelises by default) but
+      # kept as a belt-and-suspenders.
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} --parallel
+
+    - name: Show sccache stats
+      # Hit rate / miss count for this run; useful for spotting cold/warm
+      # transitions and cache-thrash regressions in PRs that touch many TUs.
+      if: always()
+      run: sccache --show-stats
 
     - name: Test
       working-directory: ${{ steps.strings.outputs.build-output-dir }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -77,6 +77,20 @@ jobs:
     - name: Set up sccache
       uses: mozilla-actions/sccache-action@v0.0.7
 
+    # Probe the sccache backend before relying on it. If GitHub Actions Cache
+    # is having an incident the sccache server refuses to start, so falling
+    # back to a plain build is strictly better than failing the whole job.
+    # Only when this probe succeeds do we set SCCACHE_LAUNCHER, which the
+    # Configure step uses to conditionally wire CMAKE_*_COMPILER_LAUNCHER.
+    - name: Probe sccache backend
+      shell: bash
+      run: |
+        if sccache --start-server; then
+          echo "SCCACHE_LAUNCHER=sccache" >> "$GITHUB_ENV"
+        else
+          echo "::warning::sccache backend unavailable; building without compile cache"
+        fi
+
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings
@@ -87,12 +101,12 @@ jobs:
     - name: Configure CMake
       # Single-config Ninja generator on both platforms so CMAKE_*_COMPILER_LAUNCHER
       # (sccache) takes effect. Ninja parallelises by default; on Windows we rely
-      # on the MSVC env from ilammy/msvc-dev-cmd above.
+      # on the MSVC env from ilammy/msvc-dev-cmd above. The launcher flags are
+      # injected only when the sccache probe succeeded (see previous step).
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -G Ninja
-        -DCMAKE_C_COMPILER_LAUNCHER=sccache
-        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        ${{ env.SCCACHE_LAUNCHER && format('-DCMAKE_C_COMPILER_LAUNCHER={0} -DCMAKE_CXX_COMPILER_LAUNCHER={0}', env.SCCACHE_LAUNCHER) || '' }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -112,7 +126,8 @@ jobs:
     - name: Show sccache stats
       # Hit rate / miss count for this run; useful for spotting cold/warm
       # transitions and cache-thrash regressions in PRs that touch many TUs.
-      if: always()
+      # Skipped when the backend probe failed and we built without sccache.
+      if: env.SCCACHE_LAUNCHER
       run: sccache --show-stats
 
     - name: Test


### PR DESCRIPTION
## Summary
Adds sccache to `.github/workflows/cmake-multi-platform.yml` so warm CI runs reuse compiled object files. Implements #7.

### Changes
- `SCCACHE_GHA_ENABLED=true` job-level env so sccache uses GitHub Actions cache as its backend.
- Install Ninja on both OSes via `seanmiddleditch/gha-setup-ninja`.
- On Windows: set up MSVC env via `ilammy/msvc-dev-cmd` so Ninja can locate `cl.exe`. This replaces the default Visual Studio generator.
- Install sccache via `mozilla-actions/sccache-action@v0.0.7`.
- Configure with `-G Ninja` and `-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache` on both platforms.
- Add `sccache --show-stats` post-build step for visibility into cache hit rate.

### Why Ninja on Windows too
`CMAKE_*_COMPILER_LAUNCHER` is honoured by Ninja and Make but **not** by MSBuild. To get sccache working on Windows we have to switch off the Visual Studio generator, which means setting up the MSVC environment manually.

### Expected impact (warm cache, post-merge)

| Job | Cold (today) | Warm (est.) |
|---|---:|---:|
| ubuntu-latest gcc | ~6 min | ~1-2 min |
| ubuntu-latest clang | ~9 min | ~1-3 min |
| windows-latest cl | ~19 min | ~5-7 min |

First run on this PR will be cold for all three jobs — that's the population step, not a regression.

## Test plan
- [ ] CI first run on this PR (cold cache): all three builds should succeed; sccache stats should show high miss rate.
- [ ] Trigger a second run (push a no-op commit or rerun): hit rate should climb sharply; build times should drop.
- [ ] Confirm Windows test output is unchanged from the VS-generator era (test #46 should still pass — was just fixed in #6).

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)