### PR TITLE
deps: upgrade spdlog v1.12.0 -> v1.15.3 (fixes build on MSVC 14.51+)

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -49,30 +49,13 @@ endif()
 
 kpu_add_dependency(spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.12.0
+    GIT_TAG v1.15.3
     TARGETS spdlog spdlog_header_only
 )
-
-# Configure spdlog to suppress MSVC warnings about deprecated iterators
-# _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING - Specifically silences the stdext::checked_array_iterator deprecation warnings
-# _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS - Silences all Microsoft extension deprecation warnings as a broader catch-all
-#
-#  These definitions are applied to both the spdlog and spdlog_header_only targets, using PRIVATE for the compiled
-#  library and INTERFACE for the header-only version to ensure the definitions propagate to consuming targets.
-
-if(TARGET spdlog AND MSVC)
-    target_compile_definitions(spdlog PRIVATE
-        _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
-        _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS
-    )
-endif()
-
-if(TARGET spdlog_header_only AND MSVC)
-    target_compile_definitions(spdlog_header_only INTERFACE
-        _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
-        _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS
-    )
-endif()
+# Note: v1.15.3 bundles fmt v11, which no longer references
+# stdext::checked_array_iterator. Earlier versions (1.12 bundled fmt v9)
+# required _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING on MSVC, and
+# eventually broke entirely on MSVC 14.51+ where the symbol was removed.
 
 kpu_add_dependency(nlohmann_json
     GIT_REPOSITORY https://github.com/nlohmann/json.git


### PR DESCRIPTION
## Summary
- Bumps spdlog from **v1.12.0** to **v1.15.3** in `cmake/Dependencies.cmake`.
- Removes the now-redundant `_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING` / `_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS` blocks.
- Net diff: 5 insertions, 22 deletions.

## Why
spdlog v1.12.0 bundles **fmt v9**, which uses `stdext::checked_array_iterator` inside `fmt::detail::make_checked`. That Microsoft non-standard extension was deprecated for years and has been **removed from the headers in MSVC 14.51** (Visual Studio 2026). Surfaces as:

```
error C2653: 'stdext': is not a class or namespace name
error C2061: syntax error: identifier 'checked_array_iterator'
error C7568: argument list missing after assumed function template 'checked_ptr'
```

The existing silence macros only suppress *deprecation warnings*; they can't resurrect a symbol the SDK no longer ships. spdlog v1.15.3 bundles **fmt v11**, which dropped the checked-iterator path entirely, so the build works on both old and new MSVC.

## CI compatibility
GitHub's `windows-latest` runner currently ships MSVC ~14.39, where v1.12.0 still compiles (which is why this isn't on fire in CI yet). The upgrade is forward-compatible there and prevents the build from breaking the moment the runner image catches up.

## Test plan
- [x] Local Linux build with the new spdlog (cleared `_deps/spdlog-*` and reconfigured) — succeeds.
- [x] `test_transactional_program_executor`: 33/33 pass.
- [x] `test_concurrent_timing_executor [executor]`: 80/80 assertions, 19/19 cases.
- [ ] CI: Linux gcc + clang + Windows MSVC all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)