### PR TITLE
ci: add windows-msvc testPreset with jobs:4 cap

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -257,6 +257,20 @@
           "label": "performance"
         }
       }
+    },
+    {
+      "name": "windows-msvc",
+      "displayName": "Windows MSVC Tests (capped concurrency)",
+      "description": "ctest preset bound to the windows-msvc configure preset. Visual Studio's Test Explorer picks this up automatically when the windows-msvc configure preset is active, so the parallel-job cap below is honoured for manual test runs inside the IDE. The cap exists because LPDDR5MemoryController, behavioral_matmul, systolic_array_test, and friends can saturate a Windows workstation's RAM when allowed to fan out unconstrained.",
+      "configurePreset": "windows-msvc",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false,
+        "jobs": 4
+      }
     }
   ],
   "packagePresets": [


### PR DESCRIPTION
## Problem
The existing \`default\` testPreset has \`"jobs": 4\` but is bound to the \`default\` configurePreset. Visual Studio's Test Explorer matches testPresets against the **currently active configurePreset**, so a contributor running the IDE with the \`windows-msvc\` configure preset never picks up the existing cap. Manual test runs then fan out unconstrained, exhausting Windows-workstation RAM and causing resource-contention failures on `LPDDR5MemoryController`, `behavioral_matmul`, the systolic-array suite, etc.

## Fix
Add a \`windows-msvc\` testPreset that mirrors the default execution settings and binds to the \`windows-msvc\` configurePreset. VS Test Explorer will now honour \`jobs: 4\` for IDE-driven test runs against that configure.

```jsonc
{
  "name": "windows-msvc",
  "configurePreset": "windows-msvc",
  "execution": { "jobs": 4, "noTestsAction": "error", "stopOnFailure": false }
}
```

## Test plan
- [x] `python3 -c "import json; json.load(open('CMakePresets.json'))"` — JSON is valid.
- [ ] Open the project in Visual Studio with the \`windows-msvc\` configure preset selected → in Test Explorer, verify the new "Windows MSVC Tests (capped concurrency)" preset is selectable → run all tests and confirm at most 4 run concurrently.

## Not in this PR
- \`windows-msvc-python\` and \`windows-clang\` configure presets also lack matching testPresets and will need the same treatment if anyone hits the same resource problem there. Easy follow-up; deliberately scoped narrow because the user only flagged the MSVC path.
- The \`jobs: 4\` line on the existing \`default\` preset uses a tab while the rest of the file uses spaces. Not touched here to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)