### PR TITLE
fix(kernel): minimal placeholder matmul in create_{elementwise,pool2d,softmax}

### DIFF
--- a/src/system/simulator/kernel.cpp
+++ b/src/system/simulator/kernel.cpp
@@ -359,12 +359,16 @@ Kernel Kernel::create_batchnorm(Size batch_size, Size num_features,
 
 Kernel Kernel::create_elementwise(const ElementwiseConfig& config, DataType dtype) {
     compiler::KernelCompiler compiler;
-    Size total = config.total_elements();
 
-    // Elementwise is simple, compile a small matmul as placeholder
+    // Use a 1x1x1 matmul as the placeholder kernel framework — op_type
+    // and elementwise_config_ are overridden immediately below, so the
+    // placeholder's dimensions don't matter and any per-tile bookkeeping
+    // proportional to N would just be wasted (and large for big shapes:
+    // a vocab head softmax with N ~ 50k blows hundreds of MB on Windows
+    // MSVC). See kernel_test "Language model output" SECTION.
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-    Kernel kernel = compiler.compile_matmul(1, total, 1, opts);
+    Kernel kernel = compiler.compile_matmul(1, 1, 1, opts);
 
     // Override operation type and config
     kernel.op_type_ = KernelOpType::ELEMENTWISE;
@@ -430,12 +434,10 @@ Kernel Kernel::create_elementwise_scalar(ElementwiseOp op,
 Kernel Kernel::create_pool2d(const Pool2DConfig& config, DataType dtype) {
     compiler::KernelCompiler compiler;
 
-    // Pool2D is a spatial reduction operation
-    // Use a small matmul as placeholder for the program
-    Size out_elems = config.output_elements();
+    // 1x1x1 placeholder matmul — see comment in create_elementwise.
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-    Kernel kernel = compiler.compile_matmul(1, out_elems, 1, opts);
+    Kernel kernel = compiler.compile_matmul(1, 1, 1, opts);
 
     // Override operation type and config
     kernel.op_type_ = KernelOpType::POOL2D;
@@ -526,11 +528,10 @@ Kernel Kernel::create_global_avg_pool2d(Size batch_size, Size channels,
 Kernel Kernel::create_softmax(const SoftmaxConfig& config, DataType dtype) {
     compiler::KernelCompiler compiler;
 
-    // Softmax is a reduction operation - use small matmul as placeholder
-    Size total = config.total_elements();
+    // 1x1x1 placeholder matmul — see comment in create_elementwise.
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-    Kernel kernel = compiler.compile_matmul(1, total, 1, opts);
+    Kernel kernel = compiler.compile_matmul(1, 1, 1, opts);
 
     // Override operation type and config
     kernel.op_type_ = KernelOpType::SOFTMAX;


### PR DESCRIPTION
## Root cause
\`Kernel::create_softmax\`, \`create_elementwise\`, and \`create_pool2d\` each call \`compile_matmul\` purely to get a Kernel framework (program metadata, etc.) — \`op_type_\` and the corresponding \`*_config_\` are overridden on the very next lines. The placeholder matmul's actual shape is throwaway.

But the existing code sized the placeholder to the **total number of output positions**:

\`\`\`cpp
// src/system/simulator/kernel.cpp:530-533 (pre-fix)
Size total = config.total_elements();
...
Kernel kernel = compiler.compile_matmul(1, total, 1, opts);
\`\`\`

For the user-reported failing test:

\`\`\`cpp
Kernel::create_softmax({1, 1024, 50257}, -1);   // GPT-2 vocab head
// -> compile_matmul(1, 51463168, 1, ...)
\`\`\`

That's ~51M tiles' worth of bookkeeping for instructions we throw away one line later. Linux happens to fit; Windows MSVC trips a \`std::bad_alloc\` (one \`kernel_test\` SECTION at \`tests/driver/test_kernel.cpp:2679\`, "Softmax common use cases / Language model output").

## Fix
Use a \`1x1x1\` placeholder in all three sites. The matmul exists only to seed the Kernel struct, so 1x1x1 is sufficient.

## Local verification
- [x] \`kernel_test\` (Linux gcc release): 73/73 test cases, 655/655 assertions pass (was 72/73, 653/654 before).
- [x] No callers depend on the placeholder shape — \`total_flops()\` reads \`softmax_config_\` / \`elementwise_config_\` / \`pool_config_\`, not the underlying matmul.

## Note on lines 239, 288, 328
These also use \`compile_matmul(1, D, D, opts)\` as a placeholder, but D is a feature/channel dimension that doesn't scale with total tensor size — not at risk. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)