### PR TITLE
fix(tests): shrink ExternalMemorySparse force-dense allocation; mark RUN_SERIAL

### DIFF
--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -127,5 +127,9 @@ add_test(NAME LPDDR5MemoryController COMMAND lpddr5_memory_controller_test)
 set_tests_properties(MemoryMapDebug PROPERTIES LABELS "memory;memmap;debug")
 set_tests_properties(MemoryMap PROPERTIES LABELS "memory;memmap")
 set_tests_properties(SparseMemory PROPERTIES LABELS "memory;sparse")
-set_tests_properties(ExternalMemorySparse PROPERTIES LABELS "memory;external;datacenter")
+set_tests_properties(ExternalMemorySparse PROPERTIES
+    LABELS "memory;external;datacenter"
+    # Each SECTION constructs a multi-hundred-MB-to-1GB ExternalMemory.
+    # Run alone so the OS has enough contiguous physical memory.
+    RUN_SERIAL TRUE)
 set_tests_properties(LPDDR5MemoryController PROPERTIES LABELS "memory;lpddr5;mc")

--- a/tests/memory/test_external_memory_sparse.cpp
+++ b/tests/memory/test_external_memory_sparse.cpp
@@ -16,23 +16,32 @@ TEST_CASE("ExternalMemory backend selection", "[memory][external][backend]") {
     }
 
     SECTION("Sparse backend for large memory (auto-select)") {
+        // Pick the smallest capacity that auto-selects sparse
+        // (SPARSE_THRESHOLD_MB = 1024). Sparse doesn't actually
+        // commit the full virtual size, so this is cheap regardless.
         ExternalMemory::Config config;
-        config.capacity_mb = 2048;  // 2GB - should auto-select sparse
+        config.capacity_mb = 1024;
         config.bandwidth_gbps = 100;
         config.auto_backend = true;
 
         ExternalMemory mem(config);
 
-        REQUIRE(mem.get_capacity() == 2048ULL * 1024 * 1024);
+        REQUIRE(mem.get_capacity() == 1024ULL * 1024 * 1024);
         REQUIRE(mem.get_backend() == ExternalMemory::BackendType::Sparse);
         REQUIRE(mem.is_sparse());
     }
 
     SECTION("Force dense backend") {
+        // Pick the smallest capacity that would auto-select sparse
+        // so we still prove the override path (dense bypasses the
+        // SPARSE_THRESHOLD_MB = 1024 cutoff). The previous value
+        // (2048MB) made this test commit 2 GB of contiguous physical
+        // memory and reliably tripped std::bad_alloc on Windows when
+        // other tests were running in parallel.
         ExternalMemory::Config config;
-        config.capacity_mb = 2048;  // Even though large
+        config.capacity_mb = 1024;
         config.backend = ExternalMemory::BackendType::Dense;
-        config.auto_backend = false;  // Don't auto-select
+        config.auto_backend = false;
 
         ExternalMemory mem(config);
 


### PR DESCRIPTION
## Problem
The "Force dense backend" SECTION of \`ExternalMemorySparse\` was constructing a 2 GB **dense** \`ExternalMemory\` to demonstrate that forcing dense bypasses the auto-select cutoff. On Windows MSVC, under the post-#16 parallel cap of 4 test exes, the OS often can't find 2 GB contiguous and the test fails with:

\`\`\`
unexpected exception with message: bad allocation
\`\`\`

(Reported in user's manual VS run, exit code: silent FAIL via Catch2.)

## Why 2 GB was used
The point of the SECTION is to prove that \`config.backend = Dense\` overrides the auto-select that would otherwise kick in **above** \`SPARSE_THRESHOLD_MB = 1024\`. So the capacity has to be ≥ 1024 — but doesn't have to be **2 ×** the threshold to make the point.

## Fix
1. Shrink both the "auto-select sparse" and "Force dense" SECTIONs to \`capacity_mb = 1024\` (the minimum). The auto-select case is on the sparse backend and was always cheap; the force-dense case now allocates 1 GB instead of 2 GB, halving the OOM pressure.
2. Mark the \`ExternalMemorySparse\` ctest target with \`RUN_SERIAL TRUE\` so no other test exes are scheduled concurrently with it. The dense backend still needs ~1 GB contiguous physical memory and big tests (\`LPDDR5MemoryController\`, \`behavioral_matmul\`, …) landing on the same Windows runner can still crowd it.

Both knobs together — the test now has more room *and* contends with nothing else when it runs.

## Local verification
- [x] \`test_external_memory_sparse\` on Linux gcc release: **11/11 cases, 68/68 assertions** (was 11/10, 67/66 pre-fix).

## What this PR does *not* fix
The remaining failing tests on the user's Windows run (\`kernel_test\` ← fixed in #17, \`dma_address_based_test\`, \`runtime_test\`, \`graph_test\`, \`behavioral_memory_test\`, \`multi_component\` 0xC0000142, the benchmarks, \`block_mover_harness_tests\`, \`behavioral_matmul\` 0xC0000409) are independent root causes — chasing them one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)