### PR TITLE
fix(tests): shrink DMA-test bank capacity from 64-128 MB to 4 MB

### DIFF
--- a/tests/dma/test_dma_basic.cpp
+++ b/tests/dma/test_dma_basic.cpp
@@ -18,9 +18,15 @@ public:
     std::unique_ptr<KPUSimulator> sim;
 
     DMATestFixture() {
-        // Standard test configuration
+        // Standard test configuration.
+        // Max transfer in this file is half an L3 tile = 128 KB
+        // (see TEST_CASE "DMA Large Transfer"). 4 MB per bank gives
+        // a 32x safety margin and avoids OOM on Windows under
+        // parallel test runs - the previous 64 MB was 500x what
+        // the tests use and triggered std::bad_alloc when other
+        // tests landed on the same runner.
         config.memory_bank_count = 2;
-        config.memory_bank_capacity_mb = 64;
+        config.memory_bank_capacity_mb = 4;
         config.memory_bandwidth_gbps = 8;
         config.l3_tile_count = 4;
         config.l3_tile_capacity_kb = 256;

--- a/tests/dma/test_dma_debug.cpp
+++ b/tests/dma/test_dma_debug.cpp
@@ -10,7 +10,7 @@ using namespace sw::kpu;
 TEST_CASE("DMA Debug - Component Status", "[dma][debug]") {
     KPUSimulator::Config config;
     config.memory_bank_count = 2;
-    config.memory_bank_capacity_mb = 64;
+    config.memory_bank_capacity_mb = 4;
     config.l3_tile_count = 2;
     config.l3_tile_capacity_kb = 256;
     config.dma_engine_count = 2;
@@ -32,7 +32,7 @@ TEST_CASE("DMA Debug - Component Status", "[dma][debug]") {
 TEST_CASE("DMA Debug - Transfer Verification", "[dma][debug]") {
     KPUSimulator::Config config;
     config.memory_bank_count = 1;
-    config.memory_bank_capacity_mb = 64;
+    config.memory_bank_capacity_mb = 4;
     config.l3_tile_count = 1;
     config.l3_tile_capacity_kb = 256;
     config.dma_engine_count = 1;

--- a/tests/dma/test_dma_performance.cpp
+++ b/tests/dma/test_dma_performance.cpp
@@ -16,8 +16,11 @@ public:
     std::unique_ptr<KPUSimulator> sim;
 
     DMAPerformanceFixture() {
+        // Max transfer in this file is 8 KB. 4 MB per bank gives
+        // ample headroom and avoids the parallel-test OOM seen on
+        // Windows with the previous 128 MB.
         config.memory_bank_count = 2;
-        config.memory_bank_capacity_mb = 128;
+        config.memory_bank_capacity_mb = 4;
         config.memory_bandwidth_gbps = 100;
         config.l3_tile_count = 4;
         config.l3_tile_capacity_kb = 512;

--- a/tests/dma/test_dma_tensor_movement.cpp
+++ b/tests/dma/test_dma_tensor_movement.cpp
@@ -15,8 +15,11 @@ public:
     std::unique_ptr<KPUSimulator> sim;
 
     TensorMovementFixture() {
+        // Max transfer in this file is 128x128 floats = 64 KB.
+        // 4 MB per bank gives ample headroom and avoids the
+        // parallel-test OOM seen on Windows with the previous 128 MB.
         config.memory_bank_count = 2;
-        config.memory_bank_capacity_mb = 128;
+        config.memory_bank_capacity_mb = 4;
         config.memory_bandwidth_gbps = 100;
         config.l3_tile_count = 4;
         config.l3_tile_capacity_kb = 512;


### PR DESCRIPTION
## Problem
Every DMA test fixture allocates 64-128 MB per memory bank, but the actual DMA transfers max out at ~128 KB. That's 500-1000× over-provisioning per fixture instance, and \`TEST_CASE_METHOD\` re-instantiates the fixture for **each** test case. On Windows MSVC under the post-#16 parallel-test cap, \`dma_basic_test\` reliably fails with \`std::bad_alloc\` during fixture construction.

User-reported failure:

\`\`\`
F:\\...\\tests\\dma\\test_dma_basic.cpp(57): FAILED:
due to unexpected exception with message:
  bad allocation
test cases: 5 | 4 passed | 1 failed
\`\`\`

## Fix
Drop the bank capacity in all four DMA test fixtures to 4 MB.

| File | Was | Now | Max transfer in tests |
|---|---:|---:|---:|
| \`test_dma_basic.cpp\` | 64 MB | 4 MB | 128 KB (half L3 tile) |
| \`test_dma_performance.cpp\` | 128 MB | 4 MB | 8 KB |
| \`test_dma_tensor_movement.cpp\` | 128 MB | 4 MB | 64 KB (128×128 floats) |
| \`test_dma_debug.cpp\` | 64 MB | 4 MB | 256 B |

4 MB still gives **32× headroom** over the largest transfer in the suite, plus room for the small address offsets the tests use.

## Local verification
\`\`\`
dma_basic_test:        5/5 cases,  12/12 assertions
dma_performance_test:  3/3 cases,  13/13 assertions
dma_tensor_test:       4/4 cases,   8/8 assertions
dma_debug_test:        2/2 cases,   6/6 assertions
\`\`\`

## What this PR does *not* fix
Other failing tests on the user's Windows run (\`dma_address_based_test\`, \`runtime_test\`, \`graph_test\`, \`behavioral_memory_test\`, \`multi_component\` 0xC0000142, benchmarks, \`block_mover_harness_tests\`, \`behavioral_matmul\` 0xC0000409) are independent. Same approach will likely apply to the over-allocating ones; the \`0xC...\` exit codes need different diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)