### PR TITLE
refactor(tests): tests/common/test_configs.hpp - right-sized fixture factories

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,23 +20,33 @@ endif()
 function(kpu_add_component_test test_name test_category)
     # Create the test executable
     add_executable(${test_name} ${ARGN})
-    
+
     # Link against our core library and Catch2
     target_link_libraries(${test_name}
         PRIVATE
         kpu_simulator       # Includes all component libraries
         Catch2::Catch2WithMain
     )
-    
+
+    # Make tests/common/ available via #include <test_configs.hpp>
+    # for the shared right-sized KPUSimulator::Config factories.
+    # CMAKE_SOURCE_DIR points at the repo root; inside this function
+    # CMAKE_CURRENT_SOURCE_DIR resolves to the caller's subdir, which
+    # is wrong.
+    target_include_directories(${test_name}
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/tests/common
+    )
+
     # Set folder organization in Solution Explorer
     set_target_properties(${test_name} PROPERTIES FOLDER "Tests/${test_category}")
-    
+
     # Add the test to CTest with category label
     add_test(NAME ${test_name} COMMAND ${test_name})
     set_tests_properties(${test_name} PROPERTIES LABELS ${test_category})
-    
+
     # Install test executable (optional)
-    install(TARGETS ${test_name} 
+    install(TARGETS ${test_name}
         DESTINATION bin/tests
         OPTIONAL
     )

--- a/tests/common/test_configs.hpp
+++ b/tests/common/test_configs.hpp
@@ -1,0 +1,99 @@
+// ============================================================================
+// tests/common/test_configs.hpp
+// Right-sized KPUSimulator::Config factories for the regression suite.
+//
+// Why this exists
+// ---------------
+// Every test fixture used to inline its own Config with hand-picked sizes,
+// almost always over-provisioned by 100x-1000x (e.g. 64-128 MB memory banks
+// for tests that transfer at most ~128 KB). Multiplied across the parallel
+// test cap (4) and a developer workstation that already has the IDE,
+// browser, VS Code, and Node.js consuming 10-20 GB, the cumulative
+// allocation reliably tripped std::bad_alloc in TEST_CASE_METHOD fixture
+// constructors on Windows. Issue: #21.
+//
+// Memory budget
+// -------------
+// The goal: under a 4-way parallel test schedule on a 32 GB workstation
+// with ~8-12 GB actually free, each per-test allocation should fit
+// comfortably under ~100 MB and the total live allocation across the four
+// parallel slots should never approach the contiguous-allocation ceiling
+// the OS can satisfy.
+//
+//   minimal_config()  ~ 1 MB total   - metadata/wiring tests
+//   small_config()    ~ 9 MB total   - typical data-moving tests (<=128 KB transfers)
+//   medium_config()   ~ 36 MB total  - bigger tile / fabric tests
+//
+// All three return by value; copy the returned Config and override
+// specific fields if a test legitimately needs a non-default detail
+// (e.g. more DMA engines, a specific systolic-array topology).
+//
+// SPDX-License-Identifier: MIT
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/kpu_simulator.hpp>
+
+namespace sw::kpu::test_utils {
+
+// Smallest viable simulator.
+// Use for tests that only verify wiring/metadata or transfer <=1 MB.
+// Total external memory: ~1 MB. Total fixture allocation: ~1.1 MB.
+inline KPUSimulator::Config minimal_config() {
+    KPUSimulator::Config c;
+    c.memory_bank_count         = 1;
+    c.memory_bank_capacity_mb   = 1;
+    c.memory_bandwidth_gbps     = 8;
+    c.l3_tile_count             = 1;
+    c.l3_tile_capacity_kb       = 64;
+    c.l2_bank_count             = 1;
+    c.l2_bank_capacity_kb       = 32;
+    c.l1_buffer_count           = 1;
+    c.l1_buffer_capacity_kb     = 32;
+    c.compute_tile_count        = 1;
+    c.dma_engine_count          = 1;
+    return c;
+}
+
+// Typical data-moving config.
+// Use for DMA / streamer / block-mover unit tests with transfers up to ~128 KB.
+// Total external memory: ~8 MB. Total fixture allocation: ~9 MB.
+inline KPUSimulator::Config small_config() {
+    KPUSimulator::Config c;
+    c.memory_bank_count         = 2;
+    c.memory_bank_capacity_mb   = 4;
+    c.memory_bandwidth_gbps     = 8;
+    c.l3_tile_count             = 4;
+    c.l3_tile_capacity_kb       = 256;
+    c.l2_bank_count             = 4;
+    c.l2_bank_capacity_kb       = 128;
+    c.l1_buffer_count           = 2;
+    c.l1_buffer_capacity_kb     = 64;
+    c.compute_tile_count        = 2;
+    c.dma_engine_count          = 4;
+    return c;
+}
+
+// Larger working-set config.
+// Use for fabric / systolic / multi-tile tests that need bigger tiles or
+// multi-MB transfers. Prefer small_config() and override individual fields
+// before reaching for this.
+// Total external memory: ~32 MB. Total fixture allocation: ~36 MB.
+inline KPUSimulator::Config medium_config() {
+    KPUSimulator::Config c;
+    c.memory_bank_count         = 2;
+    c.memory_bank_capacity_mb   = 16;
+    c.memory_bandwidth_gbps     = 16;
+    c.l3_tile_count             = 4;
+    c.l3_tile_capacity_kb       = 1024;
+    c.l2_bank_count             = 4;
+    c.l2_bank_capacity_kb       = 512;
+    c.l1_buffer_count           = 4;
+    c.l1_buffer_capacity_kb     = 256;
+    c.compute_tile_count        = 4;
+    c.dma_engine_count          = 8;
+    return c;
+}
+
+} // namespace sw::kpu::test_utils

--- a/tests/dma/test_dma_basic.cpp
+++ b/tests/dma/test_dma_basic.cpp
@@ -8,6 +8,8 @@
 #include <catch2/catch_approx.hpp>
 #include <sw/kpu/kpu_simulator.hpp>
 
+#include <test_configs.hpp>  // tests/common/
+
 using namespace sw::kpu;
 
 // Test fixture for DMA tests
@@ -17,23 +19,13 @@ public:
     KPUSimulator::Config config;
     std::unique_ptr<KPUSimulator> sim;
 
-    DMATestFixture() {
-        // Standard test configuration.
-        // Max transfer in this file is half an L3 tile = 128 KB
-        // (see TEST_CASE "DMA Large Transfer"). 4 MB per bank gives
-        // a 32x safety margin and avoids OOM on Windows under
-        // parallel test runs - the previous 64 MB was 500x what
-        // the tests use and triggered std::bad_alloc when other
-        // tests landed on the same runner.
-        config.memory_bank_count = 2;
-        config.memory_bank_capacity_mb = 4;
-        config.memory_bandwidth_gbps = 8;
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 256;
-        config.compute_tile_count = 1;
-        config.dma_engine_count = 4;
-
-        sim = std::make_unique<KPUSimulator>(config);
+    DMATestFixture()
+        : config(test_utils::small_config())
+        , sim(std::make_unique<KPUSimulator>(config)) {
+        // small_config() = 2 banks x 4 MB + 4 L3 tiles x 256 KB + ...
+        // ~9 MB total. Suitable for transfers up to ~128 KB
+        // (the "DMA Large Transfer" case here uses half an L3 tile).
+        // See tests/common/test_configs.hpp for the budget rationale.
     }
 
     // Helper to generate test data

--- a/tests/dma/test_dma_basic.cpp
+++ b/tests/dma/test_dma_basic.cpp
@@ -18,9 +18,15 @@ public:
     std::unique_ptr<KPUSimulator> sim;
 
     DMATestFixture() {
-        // Standard test configuration
+        // Standard test configuration.
+        // Max transfer in this file is half an L3 tile = 128 KB
+        // (see TEST_CASE "DMA Large Transfer"). 4 MB per bank gives
+        // a 32x safety margin and avoids OOM on Windows under
+        // parallel test runs - the previous 64 MB was 500x what
+        // the tests use and triggered std::bad_alloc when other
+        // tests landed on the same runner.
         config.memory_bank_count = 2;
-        config.memory_bank_capacity_mb = 64;
+        config.memory_bank_capacity_mb = 4;
         config.memory_bandwidth_gbps = 8;
         config.l3_tile_count = 4;
         config.l3_tile_capacity_kb = 256;

--- a/tests/dma/test_dma_debug.cpp
+++ b/tests/dma/test_dma_debug.cpp
@@ -10,7 +10,7 @@ using namespace sw::kpu;
 TEST_CASE("DMA Debug - Component Status", "[dma][debug]") {
     KPUSimulator::Config config;
     config.memory_bank_count = 2;
-    config.memory_bank_capacity_mb = 64;
+    config.memory_bank_capacity_mb = 4;
     config.l3_tile_count = 2;
     config.l3_tile_capacity_kb = 256;
     config.dma_engine_count = 2;
@@ -32,7 +32,7 @@ TEST_CASE("DMA Debug - Component Status", "[dma][debug]") {
 TEST_CASE("DMA Debug - Transfer Verification", "[dma][debug]") {
     KPUSimulator::Config config;
     config.memory_bank_count = 1;
-    config.memory_bank_capacity_mb = 64;
+    config.memory_bank_capacity_mb = 4;
     config.l3_tile_count = 1;
     config.l3_tile_capacity_kb = 256;
     config.dma_engine_count = 1;

--- a/tests/dma/test_dma_performance.cpp
+++ b/tests/dma/test_dma_performance.cpp
@@ -16,8 +16,11 @@ public:
     std::unique_ptr<KPUSimulator> sim;
 
     DMAPerformanceFixture() {
+        // Max transfer in this file is 8 KB. 4 MB per bank gives
+        // ample headroom and avoids the parallel-test OOM seen on
+        // Windows with the previous 128 MB.
         config.memory_bank_count = 2;
-        config.memory_bank_capacity_mb = 128;
+        config.memory_bank_capacity_mb = 4;
         config.memory_bandwidth_gbps = 100;
         config.l3_tile_count = 4;
         config.l3_tile_capacity_kb = 512;

--- a/tests/dma/test_dma_tensor_movement.cpp
+++ b/tests/dma/test_dma_tensor_movement.cpp
@@ -15,8 +15,11 @@ public:
     std::unique_ptr<KPUSimulator> sim;
 
     TensorMovementFixture() {
+        // Max transfer in this file is 128x128 floats = 64 KB.
+        // 4 MB per bank gives ample headroom and avoids the
+        // parallel-test OOM seen on Windows with the previous 128 MB.
         config.memory_bank_count = 2;
-        config.memory_bank_capacity_mb = 128;
+        config.memory_bank_capacity_mb = 4;
         config.memory_bandwidth_gbps = 100;
         config.l3_tile_count = 4;
         config.l3_tile_capacity_kb = 512;


### PR DESCRIPTION
## Why
\`std::bad_alloc\` failures across the Catch2 suite on Windows (#17, #19, #20) all share the same root cause: every fixture hand-rolls a \`KPUSimulator::Config\` with over-provisioned memory banks (64-512 MB per bank for tests that move at most ~128 KB). Under the parallel-test cap of 4 on a developer workstation already loaded by browser + IDE + VS Code + Node.js (regularly 15-20 GB in use on a 32 GB box), the cumulative allocation across fixture constructors reliably exhausts contiguous physical memory.

So far we have been patching one fixture at a time. This PR drafts the infrastructure for fixing it systemically.

## What this PR introduces
New header **\`tests/common/test_configs.hpp\`** exposing three documented, right-sized factories:

\`\`\`cpp
namespace sw::kpu::test_utils {
    KPUSimulator::Config minimal_config();  // ~1  MB  - wiring/metadata tests
    KPUSimulator::Config small_config();    // ~9  MB  - typical data-moving (≤128 KB)
    KPUSimulator::Config medium_config();   // ~36 MB  - bigger tile / fabric tests
}
\`\`\`

Each is an inline function returning a \`Config\` by value, so callers can override individual fields without buying into a base class or traits machinery:

\`\`\`cpp
DMATestFixture()
    : config(test_utils::small_config())
    , sim(std::make_unique<KPUSimulator>(config)) {}
\`\`\`

\`kpu_add_component_test\` in \`tests/CMakeLists.txt\` now adds \`tests/common\` to every test target's include path, so contributors don't need any per-target wiring.

## Memory budget
The goal: under a 4-way parallel schedule on a \"realistic dev box\" (32 GB total, 10-15 GB actually free), per-fixture allocation stays well under 100 MB and total live allocation across the four parallel slots stays under 200 MB. Worst-case at \`medium_config()\`: 4 × 36 MB = 144 MB. Plenty of headroom.

## Proof-point migration
\`tests/dma/test_dma_basic.cpp\` now uses \`small_config()\` instead of inlining the same values with hand-rolled comments. 5/5 cases, 12/12 assertions pass on Linux gcc release.

## Out of scope (tracked separately)
This PR does **not** sweep the other ~9 fixture files. That follow-up is intentionally separated so the helper API can be reviewed independently of the mechanical migration. Tracking issue: filed alongside this PR.

It also doesn't touch \`test_utils::generate_multi_bank_config\` in the production code, which has the same anti-pattern (sets 512 MB despite a comment claiming \"smaller banks\"). Also flagged in the sweep issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)