### PR TITLE
fix(dataflow): widen mesh_rows to uint16_t in block_mover_flow_executor

### DIFF
--- a/include/sw/kpu/models/dataflow/block_mover_flow_executor.hpp
+++ b/include/sw/kpu/models/dataflow/block_mover_flow_executor.hpp
@@ -472,8 +472,12 @@ public:
         auto push_b = graph_.add_fire(Operation::PUSH_TO_L2, {b_l3}, {b_l2}, "push_B");
         graph_.add_edge(join_b, push_b);
 
-        // Forward B south (if not bottom row)
-        uint8_t mesh_rows = graph_.m_tiles;  // Assume square mesh or use m_tiles
+        // Forward B south (if not bottom row).
+        // graph_.m_tiles is uint16_t; using uint8_t here would silently
+        // wrap to 0 for any mesh >= 256 rows and break the bounds check,
+        // so match the source type. Also fixes MSVC C4244 narrowing
+        // warning that propagated to every TU including this header.
+        uint16_t mesh_rows = graph_.m_tiles;  // assumes square mesh
         if (i + 1 < mesh_rows) {
             auto b_south = tile_b(k, j, Location::L3, node_id + mesh_cols_);
             auto send_b = graph_.add_fire(Operation::SEND_SOUTH, {b_l3}, {b_south}, "send_B_south");


### PR DESCRIPTION
First MSVC-warning cleanup PR (#23 Phase 2a — the only library-side warning).

## What & why
\`OperandFlowGraph::m_tiles\` is \`uint16_t\` (\`operand_flow_graph.hpp:364\`). But \`block_mover_flow_executor.hpp:476\` was assigning it into a local \`uint8_t mesh_rows\`:

\`\`\`cpp
uint8_t mesh_rows = graph_.m_tiles;   // <-- narrowing
if (i + 1 < mesh_rows) { … }          // <-- the bounds check that breaks if m_tiles >= 256
\`\`\`

For the default 4×4 mesh this is harmless. For any mesh with ≥ 256 rows the value wraps to 0 and the \`i + 1 < mesh_rows\` bounds check on the next line becomes always-false — a latent correctness bug, not just a noise warning.

Widening the local to \`uint16_t\` to match the source type fixes the narrowing **and** removes the latent bug.

## Impact
- Eliminates the only library-side MSVC C4244 warning. The warning was being reported twice in the user's build log because two TUs include the header (\`test_c_stationary_matmul.cpp\` and \`test_flow_graph_executors.cpp\`) — same source, double the noise.
- Zero behaviour change for the typical 4×4 mesh.

## Verified locally
\`\`\`
c_stationary_matmul_test: 14/14 cases,  24/24 assertions
flow_graph_executor_test: 21/21 cases, 106/106 assertions
\`\`\`

## Next from #23 Phase 2
- Phase 2b: 8 C4267 \`size_t\` narrowings across 3 timing/DMA test files. Mechanical static_cast.
- Phase 2c: 47 narrowings concentrated in \`test_c_stationary_matmul.cpp\`. Worth understanding the root cause before mechanical fixes — likely one upstream type that flows through many call sites.

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)