### PR TITLE
fix(tests): silence MSVC C4267 size_t narrowings (#23 Phase 2b)

### DIFF
--- a/tests/dma/test_dma_memory_noc_integration.cpp
+++ b/tests/dma/test_dma_memory_noc_integration.cpp
@@ -457,7 +457,7 @@ TEST_CASE("DMA System with placement", "[dma][system][integration]") {
             transfer.src_type = DMAMemoryType::DEVICE_MEMORY;
             transfer.src_addr = 0x10000 * row;
             transfer.dst_type = DMAMemoryType::L3_TILE;
-            transfer.dst_id = row * 4 + 3;  // East edge of each row
+            transfer.dst_id = static_cast<uint32_t>(row * 4 + 3);  // East edge of each row
             transfer.size = 64;
 
             system.west_dmas[row]->submit(transfer, [&completed_count]() {
@@ -495,7 +495,7 @@ TEST_CASE("DMA System with placement", "[dma][system][integration]") {
             transfer.src_type = DMAMemoryType::DEVICE_MEMORY;
             transfer.src_addr = 0x20000 * col;
             transfer.dst_type = DMAMemoryType::L3_TILE;
-            transfer.dst_id = 12 + col;  // South edge
+            transfer.dst_id = static_cast<uint32_t>(12 + col);  // South edge
             transfer.size = 64;
 
             system.north_dmas[col]->submit(transfer, [&completed_count]() {
@@ -534,7 +534,7 @@ TEST_CASE("DMA System with placement", "[dma][system][integration]") {
             transfer.src_type = DMAMemoryType::DEVICE_MEMORY;
             transfer.src_addr = 0x10000 * row;
             transfer.dst_type = DMAMemoryType::L3_TILE;
-            transfer.dst_id = row * 4 + 2;
+            transfer.dst_id = static_cast<uint32_t>(row * 4 + 2);
             transfer.size = 64;
 
             system.west_dmas[row]->submit(transfer, [&west_completed]() {
@@ -548,7 +548,7 @@ TEST_CASE("DMA System with placement", "[dma][system][integration]") {
             transfer.src_type = DMAMemoryType::DEVICE_MEMORY;
             transfer.src_addr = 0x20000 * col;
             transfer.dst_type = DMAMemoryType::L3_TILE;
-            transfer.dst_id = 8 + col;
+            transfer.dst_id = static_cast<uint32_t>(8 + col);
             transfer.size = 64;
 
             system.north_dmas[col]->submit(transfer, [&north_completed]() {

--- a/tests/timing/test_dma_engine_process.cpp
+++ b/tests/timing/test_dma_engine_process.cpp
@@ -362,12 +362,12 @@ TEST_CASE("DMAEngineProcess sees MC command bus serialization", "[timing][dma_pr
 
     // First MC tick - only ONE command issued
     auto mc_events = mc.tick(0);
-    int load_starts_at_0 = count_events(mc_events, EventType::DMA_LOAD_START);
+    size_t load_starts_at_0 = count_events(mc_events, EventType::DMA_LOAD_START);
     REQUIRE(load_starts_at_0 == 1);
 
     // Second MC tick - other command issued
     mc_events = mc.tick(1);
-    int load_starts_at_1 = count_events(mc_events, EventType::DMA_LOAD_START);
+    size_t load_starts_at_1 = count_events(mc_events, EventType::DMA_LOAD_START);
     REQUIRE(load_starts_at_1 == 1);
 
     // Total: 2 commands serialized over 2 cycles

--- a/tests/timing/test_memory_controller.cpp
+++ b/tests/timing/test_memory_controller.cpp
@@ -137,14 +137,14 @@ TEST_CASE("MemoryController command bus serializes requests", "[memory_controlle
 
     // First tick: only ONE command should be issued
     auto events0 = mc.tick(0);
-    int load_starts_at_0 = count_events(events0, EventType::DMA_LOAD_START);
+    size_t load_starts_at_0 = count_events(events0, EventType::DMA_LOAD_START);
 
     // Critical check: only 1 LOAD_START at cycle 0, not 2
     REQUIRE(load_starts_at_0 == 1);
 
     // Second tick: the other command should be issued
     auto events1 = mc.tick(1);
-    int load_starts_at_1 = count_events(events1, EventType::DMA_LOAD_START);
+    size_t load_starts_at_1 = count_events(events1, EventType::DMA_LOAD_START);
 
     REQUIRE(load_starts_at_1 == 1);
 


### PR DESCRIPTION
Second MSVC-warning cleanup PR (#23 Phase 2b — the 8 \`C4267\` \`size_t\` narrowings).

## What & why
Eight call sites across three test files where a \`size_t\` value flowed into a narrower destination. Two patterns:

### Pattern A — \`int\` should have been \`size_t\` (4 sites)
- \`tests/timing/test_memory_controller.cpp:140, 147\`
- \`tests/timing/test_dma_engine_process.cpp:365, 370\`

Each stores \`count_events()\`'s \`size_t\` return into a local \`int\`. Widening the local to \`size_t\` matches the source type with no cast at the call site.

\`\`\`cpp
// before
int load_starts_at_0 = count_events(events0, EventType::DMA_LOAD_START);

// after
size_t load_starts_at_0 = count_events(events0, EventType::DMA_LOAD_START);
\`\`\`

The subsequent \`REQUIRE(x == 1)\` still compiles cleanly.

### Pattern B — explicit static_cast for safe-but-narrowing assignment (4 sites)
- \`tests/dma/test_dma_memory_noc_integration.cpp:460, 498, 537, 551\`

Each computes a node ID from a \`size_t\` loop variable and assigns it to \`DMATransfer::dst_id\`, which is \`uint32_t\` (\`dma_engine_interface.hpp:60\`). The truncation is safe in practice — these tests use 4×4 = 16-node grids; the value never approaches 2³² — but should be made explicit with \`static_cast<uint32_t>\` at the assignment.

\`\`\`cpp
// before
transfer.dst_id = row * 4 + 3;

// after
transfer.dst_id = static_cast<uint32_t>(row * 4 + 3);
\`\`\`

## Local verification
\`\`\`
test_memory_controller:           12/12 cases,  51/51 assertions
test_dma_engine_process:          13/13 cases,  54/54 assertions
dma_memory_noc_integration_test:   8/8 cases,  61/61 assertions
\`\`\`

## Status of #23 Phase 2 after this lands
- ✅ Phase 2a: single library-side C4244 in \`block_mover_flow_executor.hpp\` (#25, open).
- ✅ Phase 2b: 8 C4267 \`size_t\` narrowings (this PR).
- ⏳ Phase 2c: 47 narrowings in \`test_c_stationary_matmul.cpp\`. Worth understanding the upstream type that flows through before doing mechanical fixes.

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)