### PR TITLE
fix(tests): widen tile_bytes param to uint64_t (#23 Phase 2c-1)

### DIFF
--- a/tests/dataflow/test_c_stationary_matmul.cpp
+++ b/tests/dataflow/test_c_stationary_matmul.cpp
@@ -1569,11 +1569,11 @@ struct BandwidthAnalysis {
         return a_input_tiles + b_input_tiles + c_partial_reads + c_partial_writes + c_output_tiles;
     }
 
-    uint64_t total_dma_bytes(uint32_t tile_bytes) const {
+    uint64_t total_dma_bytes(uint64_t tile_bytes) const {
         return total_dma_tiles() * tile_bytes;
     }
 
-    uint64_t total_mesh_bytes(uint32_t tile_bytes) const {
+    uint64_t total_mesh_bytes(uint64_t tile_bytes) const {
         return mesh_tiles * tile_bytes;
     }
 


### PR DESCRIPTION
Third MSVC-warning cleanup PR (#23 Phase 2c-1 — the \`uint64_t → uint32_t\` cluster).

## What & why
Two-line signature fix in \`tests/dataflow/test_c_stationary_matmul.cpp\`. The bandwidth-analysis struct declared:

\`\`\`cpp
uint64_t total_dma_bytes(uint32_t tile_bytes) const;
uint64_t total_mesh_bytes(uint32_t tile_bytes) const;
\`\`\`

But every caller (lines 1758, 1760, 1835-1842, 1847-1849, 1897-1899) passes the file-local \`uint64_t tile_bytes\` from line 1741 (which itself comes from \`cfg.tile_bytes()\` widened on assignment). The signature mismatch triggers **17 MSVC C4244 warnings** — every \`uint64_t → uint32_t\` warning in this file traces back to these two parameters.

Widening both to \`uint64_t\` matches the actual call-site type with no behaviour change (the value is in the MB range and fits in \`uint32_t\` regardless).

## Local verification
\`\`\`
c_stationary_matmul_test: 14/14 cases, 24/24 assertions
\`\`\`

## Status of #23 Phase 2 after this lands
- ✅ Phase 2a: 1 library-side C4244 (#25, open)
- ✅ Phase 2b: 8 C4267 \`size_t\` narrowings (#26, open)
- ✅ Phase 2c-1: 17 \`uint64_t → uint32_t\` narrowings (this PR)
- ⏳ Phase 2c-2: 30 \`uint16_t → uint8_t\` narrowings in the same test. Pure test-side fix: change mesh-iteration loops from \`uint16_t\` → \`uint8_t\` and add \`static_cast<uint8_t>\` on a handful of \`node_id = i * mesh_cols + j\` expressions (where C integer-promotion forces narrowing regardless of operand types).

After 2c-2: 0 of 56 MSVC warnings remaining, and we can think about \`/WX\` in CI.

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)