### PR TITLE
fix(tests): convert mesh iteration to uint8_t in c_stationary_matmul (#23 Phase 2c-2)

### DIFF
--- a/tests/dataflow/test_c_stationary_matmul.cpp
+++ b/tests/dataflow/test_c_stationary_matmul.cpp
@@ -38,9 +38,12 @@ using namespace sw::kpu::dataflow;
 // ============================================================================
 
 struct MatmulConfig {
-    uint16_t mesh_rows = 2;
-    uint16_t mesh_cols = 2;
-    uint16_t k_tiles = 2;
+    // mesh_rows / mesh_cols match the dataflow library's uint8_t convention
+    // (BlockMoverExecutorConfig, StreamerExecutorConfig). k_tiles stays
+    // uint16_t because K can grow well past 256.
+    uint8_t  mesh_rows = 2;
+    uint8_t  mesh_cols = 2;
+    uint16_t k_tiles   = 2;
 
     // Latencies (cycles)
     uint16_t dma_load_latency = 100;
@@ -209,14 +212,14 @@ private:
 
     void build_dma_graphs() {
         // West edge DMAs load A tiles
-        for (uint16_t i = 0; i < config_.mesh_rows; ++i) {
+        for (uint8_t i = 0; i < config_.mesh_rows; ++i) {
             DMAFlowGraphBuilder builder;
             builder.set_node_id(i)
                    .set_dimensions(config_.mesh_rows, config_.mesh_cols, config_.k_tiles);
 
             // Load all A[i,k] tiles for this row
             for (uint16_t k = 0; k < config_.k_tiles; ++k) {
-                uint8_t dest_l3 = i * config_.mesh_cols;  // First column
+                uint8_t dest_l3 = static_cast<uint8_t>(i * config_.mesh_cols);  // First column
                 builder.add_load_a(i, k, dest_l3);
             }
 
@@ -225,7 +228,7 @@ private:
         }
 
         // North edge DMAs load B tiles
-        for (uint16_t j = 0; j < config_.mesh_cols; ++j) {
+        for (uint8_t j = 0; j < config_.mesh_cols; ++j) {
             DMAFlowGraphBuilder builder;
             builder.set_node_id(j)
                    .set_dimensions(config_.mesh_rows, config_.mesh_cols, config_.k_tiles);
@@ -242,9 +245,9 @@ private:
     }
 
     void build_block_mover_graphs() {
-        for (uint16_t i = 0; i < config_.mesh_rows; ++i) {
-            for (uint16_t j = 0; j < config_.mesh_cols; ++j) {
-                uint8_t node_id = i * config_.mesh_cols + j;
+        for (uint8_t i = 0; i < config_.mesh_rows; ++i) {
+            for (uint8_t j = 0; j < config_.mesh_cols; ++j) {
+                uint8_t node_id = static_cast<uint8_t>(i * config_.mesh_cols + j);
 
                 BlockMoverFlowGraphBuilder builder;
                 builder.set_position(i, j, config_.mesh_cols)
@@ -259,9 +262,9 @@ private:
     }
 
     void build_streamer_graphs() {
-        for (uint16_t i = 0; i < config_.mesh_rows; ++i) {
-            for (uint16_t j = 0; j < config_.mesh_cols; ++j) {
-                uint8_t node_id = i * config_.mesh_cols + j;
+        for (uint8_t i = 0; i < config_.mesh_rows; ++i) {
+            for (uint8_t j = 0; j < config_.mesh_cols; ++j) {
+                uint8_t node_id = static_cast<uint8_t>(i * config_.mesh_cols + j);
 
                 StreamerFlowGraphBuilder builder;
                 builder.set_position(i, j, config_.mesh_cols)
@@ -318,7 +321,7 @@ private:
     void run_dma_phase() {
         // Inject L3 buffer availability and run DMAs
         for (auto& [id, dma] : dma_west_) {
-            uint8_t dest_l3 = id * config_.mesh_cols;
+            uint8_t dest_l3 = static_cast<uint8_t>(id * config_.mesh_cols);
             for (uint16_t k = 0; k < config_.k_tiles; ++k) {
                 dma->inject_buffer_available(Location::L3, dest_l3);
             }
@@ -699,9 +702,9 @@ private:
         // C[i,j] partial sums reduce West→East along row i
 
         // Build BlockMover graphs
-        for (uint16_t i = 0; i < config_.mesh_rows; ++i) {
-            for (uint16_t k = 0; k < config_.mesh_cols; ++k) {
-                uint8_t node_id = i * config_.mesh_cols + k;
+        for (uint8_t i = 0; i < config_.mesh_rows; ++i) {
+            for (uint8_t k = 0; k < config_.mesh_cols; ++k) {
+                uint8_t node_id = static_cast<uint8_t>(i * config_.mesh_cols + k);
 
                 AStationaryBlockMoverBuilder builder;
                 builder.set_position(i, k, config_.mesh_cols)
@@ -714,9 +717,9 @@ private:
         }
 
         // Build Streamer graphs
-        for (uint16_t i = 0; i < config_.mesh_rows; ++i) {
-            for (uint16_t k = 0; k < config_.mesh_cols; ++k) {
-                uint8_t node_id = i * config_.mesh_cols + k;
+        for (uint8_t i = 0; i < config_.mesh_rows; ++i) {
+            for (uint8_t k = 0; k < config_.mesh_cols; ++k) {
+                uint8_t node_id = static_cast<uint8_t>(i * config_.mesh_cols + k);
 
                 AStationaryStreamerBuilder builder;
                 builder.set_position(i, k, config_.mesh_cols)
@@ -732,9 +735,9 @@ private:
         // A-stationary data flow:
         //   - A[i,k] loads to node (i,k) - stationary, one per node
         //   - B[k,j] loads to north edge only (i=0), then flows N→S
-        for (uint16_t i = 0; i < config_.mesh_rows; ++i) {
-            for (uint16_t k = 0; k < config_.mesh_cols; ++k) {
-                uint8_t node_id = i * config_.mesh_cols + k;
+        for (uint8_t i = 0; i < config_.mesh_rows; ++i) {
+            for (uint8_t k = 0; k < config_.mesh_cols; ++k) {
+                uint8_t node_id = static_cast<uint8_t>(i * config_.mesh_cols + k);
 
                 DMAFlowGraphBuilder builder;
                 builder.set_node_id(node_id)
@@ -1095,9 +1098,9 @@ private:
         // C[i,j] partial sums reduce North→South along column j
 
         // Build BlockMover graphs
-        for (uint16_t k = 0; k < config_.mesh_rows; ++k) {
-            for (uint16_t j = 0; j < config_.mesh_cols; ++j) {
-                uint8_t node_id = k * config_.mesh_cols + j;
+        for (uint8_t k = 0; k < config_.mesh_rows; ++k) {
+            for (uint8_t j = 0; j < config_.mesh_cols; ++j) {
+                uint8_t node_id = static_cast<uint8_t>(k * config_.mesh_cols + j);
 
                 BStationaryBlockMoverBuilder builder;
                 builder.set_position(k, j, config_.mesh_cols)
@@ -1110,9 +1113,9 @@ private:
         }
 
         // Build Streamer graphs
-        for (uint16_t k = 0; k < config_.mesh_rows; ++k) {
-            for (uint16_t j = 0; j < config_.mesh_cols; ++j) {
-                uint8_t node_id = k * config_.mesh_cols + j;
+        for (uint8_t k = 0; k < config_.mesh_rows; ++k) {
+            for (uint8_t j = 0; j < config_.mesh_cols; ++j) {
+                uint8_t node_id = static_cast<uint8_t>(k * config_.mesh_cols + j);
 
                 BStationaryStreamerBuilder builder;
                 builder.set_position(k, j, config_.mesh_cols)
@@ -1128,9 +1131,9 @@ private:
         // B-stationary data flow:
         //   - B[k,j] loads to node (k,j) - stationary, one per node
         //   - A[i,k] loads to west edge only (j=0), then flows W→E
-        for (uint16_t k = 0; k < config_.mesh_rows; ++k) {
-            for (uint16_t j = 0; j < config_.mesh_cols; ++j) {
-                uint8_t node_id = k * config_.mesh_cols + j;
+        for (uint8_t k = 0; k < config_.mesh_rows; ++k) {
+            for (uint8_t j = 0; j < config_.mesh_cols; ++j) {
+                uint8_t node_id = static_cast<uint8_t>(k * config_.mesh_cols + j);
 
                 DMAFlowGraphBuilder builder;
                 builder.set_node_id(node_id)


### PR DESCRIPTION
Final MSVC-warning cleanup PR for #23 Phase 2.

## What & why
Three coordinated changes to \`tests/dataflow/test_c_stationary_matmul.cpp\` that together eliminate the remaining **30 \`uint16_t → uint8_t\` narrowings**:

### 1. Match the library's mesh-position convention in \`MatmulConfig\`
The dataflow library uses \`uint8_t\` for mesh positions throughout (\`BlockMoverExecutorConfig\`, \`StreamerExecutorConfig\`, \`Builder::set_position\`, \`Builder::set_node_id\`). The test's local \`MatmulConfig\` had declared them \`uint16_t\` — anomalous.

\`\`\`cpp
// before
uint16_t mesh_rows = 2;
uint16_t mesh_cols = 2;
uint16_t k_tiles   = 2;

// after
uint8_t  mesh_rows = 2;
uint8_t  mesh_cols = 2;
uint16_t k_tiles   = 2;  // K can grow well past 256; stays wide
\`\`\`

### 2. Convert mesh-iteration loops to \`uint8_t\`
\`for (uint16_t i = 0; i < mesh_rows; ...)\` → \`for (uint8_t i = ...)\`. Done bulk via \`sed\`, then verified that the only remaining \`uint16_t\` loops are the \`k_tiles\` ones (which stay wide intentionally).

### 3. Add \`static_cast<uint8_t>\` to arithmetic-narrowing assignments
\`\`\`cpp
// before
uint8_t node_id = i * config_.mesh_cols + j;

// after
uint8_t node_id = static_cast<uint8_t>(i * config_.mesh_cols + j);
\`\`\`

Even with \`uint8_t\` operands, C integer-promotion bumps the multiplication to \`int\` before assignment, so the narrowing back to \`uint8_t\` is unavoidable without the explicit cast. 10 such sites.

## Local verification
\`\`\`
c_stationary_matmul_test: 14/14 cases,  24/24 assertions
flow_graph_executor_test: 21/21 cases, 106/106 assertions  (sibling regression check)
\`\`\`

## #23 Phase 2 status — DONE after this lands
| Phase | What | PR |
|---|---|---|
| 2a | Library-side mesh_rows narrowing | #25 |
| 2b | 8 \`size_t\` narrowings across 3 test files | #26 |
| 2c-1 | 17 \`uint64_t → uint32_t\` narrowings (signature widening) | #27 |
| **2c-2** | **30 \`uint16_t → uint8_t\` narrowings (this PR)** | **#28** |

Total: **56/56 MSVC C4244 + C4267 warnings eliminated** once all four land. CI can flip on \`/WX\` (and \`-Werror\` on the Linux side after the Phase 1 \`-Wstringop-overflow\` suppression).

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)