### PR TITLE
fix: silence all remaining gcc -Wunused-* and -Wcomment warnings (#23 Phase 1b)

### DIFF
--- a/examples/basic/kernel_graph_demo.cpp
+++ b/examples/basic/kernel_graph_demo.cpp
@@ -129,9 +129,9 @@ void demo_diamond_pattern() {
 
     // Diamond pattern:
     //       input
-    //       /   \
-    //    left   right
-    //       \   /
+    //       /   '\'
+    //    left    right
+    //       '\' /
     //       merge
     //
     // This tests parallel execution opportunities

--- a/examples/schedule/csp_pipeline_demo.cpp
+++ b/examples/schedule/csp_pipeline_demo.cpp
@@ -513,7 +513,7 @@ int main(int argc, char* argv[]) {
 
     // Track stall summary per component/tile pair
     std::map<std::pair<std::string, std::string>, std::pair<Cycle, Cycle>> stall_ranges;
-    Cycle last_action_cycle = 0;
+    [[maybe_unused]] Cycle last_action_cycle = 0;
 
     for (const auto& entry : log) {
         bool is_stall = entry.event.find("STALL") != std::string::npos;

--- a/include/sw/kpu/models/dataflow/block_mover_flow_executor.hpp
+++ b/include/sw/kpu/models/dataflow/block_mover_flow_executor.hpp
@@ -248,7 +248,7 @@ protected:
         }
     }
 
-    bool can_fire(uint32_t node_id, const FlowNode& node) const override {
+    bool can_fire([[maybe_unused]] uint32_t node_id, const FlowNode& node) const override {
         // For PUSH_TO_L2, check L2 bank availability
         if (node.operation == Operation::PUSH_TO_L2) {
             for (const auto& output : node.outputs) {
@@ -287,7 +287,7 @@ private:
         }
     }
 
-    void execute_push_to_l2(uint32_t node_id, const FlowNode& node) {
+    void execute_push_to_l2([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         for (const auto& output : node.outputs) {
             if (output.location == Location::L2) {
                 uint8_t bank_id = output.node_id;
@@ -313,7 +313,7 @@ private:
         }
     }
 
-    void execute_pull_from_l2(uint32_t node_id, const FlowNode& node) {
+    void execute_pull_from_l2([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         for (const auto& input : node.inputs) {
             if (input.location == Location::L2) {
                 uint8_t bank_id = input.node_id;
@@ -339,7 +339,7 @@ private:
         }
     }
 
-    void execute_send(uint32_t node_id, const FlowNode& node, std::optional<uint8_t> dest_node) {
+    void execute_send([[maybe_unused]] uint32_t node_id, const FlowNode& node, std::optional<uint8_t> dest_node) {
         if (!dest_node) return;
 
         for (const auto& input : node.inputs) {
@@ -366,7 +366,7 @@ private:
         }
     }
 
-    void execute_receive(uint32_t node_id, const FlowNode& node) {
+    void execute_receive([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         // RECEIVE is mostly a synchronization point - the tile is already
         // marked ready by the sender's SEND operation
         // We just need to make the tile available locally

--- a/include/sw/kpu/models/dataflow/dma_flow_executor.hpp
+++ b/include/sw/kpu/models/dataflow/dma_flow_executor.hpp
@@ -149,7 +149,7 @@ protected:
         }
     }
 
-    bool can_fire(uint32_t node_id, const FlowNode& node) const override {
+    bool can_fire([[maybe_unused]] uint32_t node_id, const FlowNode& node) const override {
         // Check if we have capacity for more outstanding transfers
         if (node.operation == Operation::LOAD || node.operation == Operation::STORE) {
             if (active_transfers_.size() >= config_.max_outstanding) {
@@ -160,7 +160,7 @@ protected:
     }
 
 private:
-    void execute_load(uint32_t node_id, const FlowNode& node) {
+    void execute_load([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         // LOAD: Memory -> L3
         // Inputs: BUFFER_AVAILABLE(L3[node])
         // Outputs: TILE_READY(T @ L3[node])
@@ -184,7 +184,7 @@ private:
         }
     }
 
-    void execute_store(uint32_t node_id, const FlowNode& node) {
+    void execute_store([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         // STORE: L3 -> Memory
         // Inputs: TILE_READY(T @ L3[node])
         // Outputs: (completion signal, buffer becomes available)

--- a/include/sw/kpu/models/dataflow/flow_graph_executor.hpp
+++ b/include/sw/kpu/models/dataflow/flow_graph_executor.hpp
@@ -339,7 +339,7 @@ protected:
     // ========== Virtual Methods for Specialization ==========
 
     /// Called when a node fires - override to implement actual operations
-    virtual void execute_operation(uint32_t node_id, const FlowNode& node) {
+    virtual void execute_operation([[maybe_unused]] uint32_t node_id, [[maybe_unused]] const FlowNode& node) {
         // Default: just mark completion after latency
         // Subclasses override to perform actual memory/compute operations
     }
@@ -351,7 +351,7 @@ protected:
 
     /// Check if a node can fire (beyond just having inputs ready)
     /// Override for additional constraints like resource availability
-    virtual bool can_fire(uint32_t node_id, const FlowNode& node) const {
+    virtual bool can_fire([[maybe_unused]] uint32_t node_id, [[maybe_unused]] const FlowNode& node) const {
         return true;
     }
 

--- a/include/sw/kpu/models/dataflow/streamer_flow_executor.hpp
+++ b/include/sw/kpu/models/dataflow/streamer_flow_executor.hpp
@@ -192,7 +192,7 @@ protected:
         }
     }
 
-    bool can_fire(uint32_t node_id, const FlowNode& node) const override {
+    bool can_fire([[maybe_unused]] uint32_t node_id, const FlowNode& node) const override {
         // For MATMUL, check that both A and B tiles are ready
         if (node.operation == Operation::MATMUL ||
             node.operation == Operation::ACCUMULATE) {
@@ -214,7 +214,7 @@ protected:
     }
 
 private:
-    void execute_feed(uint32_t node_id, const FlowNode& node, bool is_a_operand) {
+    void execute_feed([[maybe_unused]] uint32_t node_id, const FlowNode& node, [[maybe_unused]] bool is_a_operand) {
         // Feed tile from L2 to L1 edge registers
         for (const auto& input : node.inputs) {
             if (input.location == Location::L2 && input.type != OperandType::BUFFER_TOKEN) {
@@ -234,9 +234,10 @@ private:
         }
     }
 
-    void execute_matmul(uint32_t node_id, const FlowNode& node) {
+    void execute_matmul([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         // Get tile coordinates from inputs
-        uint16_t i = 0, j = 0, k = 0;
+        uint16_t i = 0, j = 0;
+        [[maybe_unused]] uint16_t k = 0;
         for (const auto& input : node.inputs) {
             if (input.type == OperandType::TILE_A) {
                 i = input.coord.i;
@@ -276,7 +277,7 @@ private:
         execute_matmul(node_id, node);
     }
 
-    void execute_drain(uint32_t node_id, const FlowNode& node) {
+    void execute_drain([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         // Drain result from accumulator to L2
         uint16_t i = accumulator_.i;
         uint16_t j = accumulator_.j;
@@ -301,7 +302,7 @@ private:
         }
     }
 
-    void execute_bias(uint32_t node_id, const FlowNode& node) {
+    void execute_bias([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         // Bias addition happens in-place in accumulator
         // Outputs the same C tile location as input
         for (const auto& output : node.outputs) {
@@ -309,7 +310,7 @@ private:
         }
     }
 
-    void execute_activate(uint32_t node_id, const FlowNode& node) {
+    void execute_activate([[maybe_unused]] uint32_t node_id, const FlowNode& node) {
         // Activation happens in-place
         for (const auto& output : node.outputs) {
             output_events_.add_ready(output, current_cycle_ + config_.activation_latency);
@@ -419,8 +420,8 @@ public:
 
     /// Add bias and activation after drain
     StreamerFlowGraphBuilder& add_bias_activation() {
-        uint16_t i = graph_.mesh_row;
-        uint16_t j = graph_.mesh_col;
+        [[maybe_unused]] uint16_t i = graph_.mesh_row;
+        [[maybe_unused]] uint16_t j = graph_.mesh_col;
 
         // These would be added after drain
         // For now, just a placeholder

--- a/include/sw/kpu/models/temporal/datamovement/dma_placement.hpp
+++ b/include/sw/kpu/models/temporal/datamovement/dma_placement.hpp
@@ -121,8 +121,8 @@ struct DMASystemConfig {
     }
 
     /// Create minimal configuration (one DMA per edge direction)
-    static DMASystemConfig create_minimal(uint8_t mesh_rows,
-                                           uint8_t mesh_cols) {
+    static DMASystemConfig create_minimal([[maybe_unused]] uint8_t mesh_rows,
+                                           [[maybe_unused]] uint8_t mesh_cols) {
         DMASystemConfig config;
 
         // Just one west DMA (position 0)

--- a/include/sw/kpu/timing/livelock_detector.hpp
+++ b/include/sw/kpu/timing/livelock_detector.hpp
@@ -266,8 +266,8 @@ public:
      *
      * Call periodically to catch livelock conditions early.
      */
-    bool verify_invariants(const CreditPool& l3_credits,
-                          const CreditPool& l2_credits,
+    bool verify_invariants([[maybe_unused]] const CreditPool& l3_credits,
+                          [[maybe_unused]] const CreditPool& l2_credits,
                           const TagCAM& l3_cam,
                           const TagCAM& l2_cam,
                           Cycle current_cycle,

--- a/include/sw/xue/event_counter.hpp
+++ b/include/sw/xue/event_counter.hpp
@@ -207,7 +207,7 @@ struct EventStats {
      * @param observation_cycles Total cycles of observation (T)
      * @return Average delay in cycles
      */
-    double average_delay(uint64_t observation_cycles = 0) const {
+    double average_delay([[maybe_unused]] uint64_t observation_cycles = 0) const {
         uint64_t c = count.load(std::memory_order_relaxed);
         if (c == 0) return 0.0;
 

--- a/patterns/dma/gemm/a_tile_row_major.cpp
+++ b/patterns/dma/gemm/a_tile_row_major.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[]) {
     std::cout << "  - Rows are separated by K×elem_size bytes (pitch)" << std::endl;
 
     // Calculate expected page behavior
-    size_t tile_row_bytes = K_TILE * ELEM_SIZE;  // 256 bytes per tile row
+    [[maybe_unused]] size_t tile_row_bytes = K_TILE * ELEM_SIZE;  // 256 bytes per tile row
     size_t rows_per_page = PAGE_SIZE / A_matrix.pitch_bytes;
     size_t estimated_conflicts = A_matrix.estimate_page_conflicts(M_TILE);
 

--- a/python/kpu/_native/kpu_native.cpp
+++ b/python/kpu/_native/kpu_native.cpp
@@ -2314,7 +2314,7 @@ private:
 
             // Determine normalization dimensions (default: last dims matching normalized_shape)
             py::ssize_t norm_size = 1;
-            int norm_dims = 1;  // Default: normalize over last dimension
+            [[maybe_unused]] int norm_dims = 1;  // Default: normalize over last dimension
             if (attrs.contains("normalized_shape")) {
                 auto shape_list = attrs["normalized_shape"].cast<py::list>();
                 norm_dims = static_cast<int>(py::len(shape_list));

--- a/src/software/compiler/kernel_compiler.cpp
+++ b/src/software/compiler/kernel_compiler.cpp
@@ -473,7 +473,7 @@ isa::OutputStationaryProgramBuilder::Config KernelCompiler::build_program_config
     return config;
 }
 
-DataflowStrategy KernelCompiler::select_dataflow(Size M, Size N, Size K) const {
+DataflowStrategy KernelCompiler::select_dataflow([[maybe_unused]] Size M, [[maybe_unused]] Size N, [[maybe_unused]] Size K) const {
     // Heuristic for dataflow selection:
     // - Output-stationary: balanced M, N, K (general purpose)
     // - Weight-stationary: large M (batch inference), small K*N (weights)

--- a/tests/dataflow/test_c_stationary_matmul.cpp
+++ b/tests/dataflow/test_c_stationary_matmul.cpp
@@ -326,7 +326,7 @@ private:
                 dma->inject_buffer_available(Location::L3, dest_l3);
             }
 
-            bool success = dma->run();
+            [[maybe_unused]] bool success = dma->run();
             std::cout << "  DMA West[" << id << "]: "
                       << dma->loads_completed() << " loads, "
                       << dma->bytes_transferred() << " bytes\n";
@@ -343,7 +343,7 @@ private:
                 dma->inject_buffer_available(Location::L3, dest_l3);
             }
 
-            bool success = dma->run();
+            [[maybe_unused]] bool success = dma->run();
             std::cout << "  DMA North[" << id << "]: "
                       << dma->loads_completed() << " loads, "
                       << dma->bytes_transferred() << " bytes\n";
@@ -2054,7 +2054,7 @@ DoubleBufferTiming analyze_c_stationary_double_buffer(
     uint64_t tiles_per_c_block = cfg.K_tiles * (cfg.mesh_rows + cfg.mesh_cols);
     uint64_t matmuls_per_c_block = cfg.K_tiles * cfg.mesh_rows * cfg.mesh_cols;
 
-    uint64_t total_tiles = (uint64_t)total_c_blocks * tiles_per_c_block;
+    [[maybe_unused]] uint64_t total_tiles = (uint64_t)total_c_blocks * tiles_per_c_block;
     uint64_t total_matmuls = (uint64_t)total_c_blocks * matmuls_per_c_block;
 
     // With double-buffering at the K-iteration level:

--- a/tests/dma/test_dma_memory_noc_integration.cpp
+++ b/tests/dma/test_dma_memory_noc_integration.cpp
@@ -178,7 +178,7 @@ TEST_CASE("DMA-Memory integration basic", "[dma][memory][integration]") {
         REQUIRE(dma->pending_count() == NUM_TRANSFERS);
 
         // Co-simulate
-        uint64_t cycles = cosimulate(*dma, mc.get(), nullptr, 50000);
+        [[maybe_unused]] uint64_t cycles = cosimulate(*dma, mc.get(), nullptr, 50000);
 
         REQUIRE(completed_count == NUM_TRANSFERS);
         REQUIRE_FALSE(dma->has_pending());
@@ -218,7 +218,7 @@ TEST_CASE("DMA-Memory backpressure handling", "[dma][memory][integration][backpr
         }
 
         // Co-simulate - all should eventually complete
-        uint64_t cycles = cosimulate(*dma, mc.get(), nullptr, 100000);
+        [[maybe_unused]] uint64_t cycles = cosimulate(*dma, mc.get(), nullptr, 100000);
 
         REQUIRE(completed_count == NUM_TRANSFERS);
         REQUIRE_FALSE(dma->has_pending());
@@ -251,9 +251,9 @@ TEST_CASE("DMA-NoC integration basic", "[dma][noc][integration]") {
 
         // Set up NoC delivery callback
         noc->set_delivery_callback(5, [&noc_delivered](
-            const TileDescriptor& tile,
-            uint8_t src, uint8_t dst,
-            uint64_t inject_cycle, uint64_t deliver_cycle)
+            [[maybe_unused]] const TileDescriptor& tile,
+            [[maybe_unused]] uint8_t src, [[maybe_unused]] uint8_t dst,
+            [[maybe_unused]] uint64_t inject_cycle, [[maybe_unused]] uint64_t deliver_cycle)
         {
             noc_delivered = true;
         });
@@ -276,7 +276,7 @@ TEST_CASE("DMA-NoC integration basic", "[dma][noc][integration]") {
         auto mc = create_behavioral_memory_controller();
         dma->bind_memory_controller(mc.get());
 
-        uint64_t cycles = cosimulate(*dma, mc.get(), noc.get(), 10000);
+        [[maybe_unused]] uint64_t cycles = cosimulate(*dma, mc.get(), noc.get(), 10000);
 
         // DMA should complete
         REQUIRE(dma_completed);
@@ -323,7 +323,7 @@ TEST_CASE("DMA-NoC backpressure handling", "[dma][noc][integration][backpressure
         }
 
         // Co-simulate
-        uint64_t cycles = cosimulate(*dma, mc.get(), noc.get(), 50000);
+        [[maybe_unused]] uint64_t cycles = cosimulate(*dma, mc.get(), noc.get(), 50000);
 
         REQUIRE(completed_count == NUM_TRANSFERS);
         REQUIRE_FALSE(dma->has_pending());
@@ -350,8 +350,8 @@ TEST_CASE("Full DMA-Memory-NoC pipeline", "[dma][memory][noc][integration][full]
 
         // Track NoC delivery
         noc->set_delivery_callback(5, [&](
-            const TileDescriptor& tile,
-            uint8_t src, uint8_t dst,
+            [[maybe_unused]] const TileDescriptor& tile,
+            [[maybe_unused]] uint8_t src, [[maybe_unused]] uint8_t dst,
             uint64_t inject_cycle, uint64_t deliver_cycle)
         {
             delivery_latency = deliver_cycle - inject_cycle;
@@ -410,7 +410,7 @@ TEST_CASE("Full DMA-Memory-NoC pipeline", "[dma][memory][noc][integration][full]
         REQUIRE(dma->pending_count() == 4);
 
         // Co-simulate
-        uint64_t cycles = cosimulate(*dma, mc.get(), noc.get(), 100000);
+        [[maybe_unused]] uint64_t cycles = cosimulate(*dma, mc.get(), noc.get(), 100000);
 
         REQUIRE(completed_count == 4);
         REQUIRE_FALSE(dma->has_pending());
@@ -592,7 +592,7 @@ TEST_CASE("DMA-Memory-NoC latency measurement", "[dma][memory][noc][integration]
     dma->bind_noc(noc.get(), 0);
 
     SECTION("Measure single transfer latency") {
-        uint64_t start_cycle = 0;
+        [[maybe_unused]] uint64_t start_cycle = 0;
         uint64_t end_cycle = 0;
 
         DMATransfer transfer;

--- a/tests/driver/test_kernel_graph.cpp
+++ b/tests/driver/test_kernel_graph.cpp
@@ -200,9 +200,9 @@ TEST_CASE("KernelGraph execution order", "[kernel_graph][execution]") {
 
     SECTION("Diamond pattern order") {
         //     k1
-        //    /  \
-        //   k2   k3
-        //    \  /
+        //    /  '\'
+        //   k2    k3
+        //    '\' /
         //     k4
         size_t k1 = graph.add_kernel(Kernel::create_matmul(64, 64, 64), "top");
         size_t k2 = graph.add_kernel(Kernel::create_matmul(64, 64, 64), "left");

--- a/tests/driver/test_resource_api.cpp
+++ b/tests/driver/test_resource_api.cpp
@@ -487,7 +487,7 @@ TEST_CASE("PoolAllocator operations", "[allocator]") {
 
     SECTION("Deallocate and reuse") {
         Address addr1 = pool.allocate();
-        Address addr2 = pool.allocate();
+        [[maybe_unused]] Address addr2 = pool.allocate();
 
         REQUIRE(pool.get_allocated_count() == 2);
         REQUIRE(pool.get_free_count() == 8);

--- a/tests/timing/test_memory_controller.cpp
+++ b/tests/timing/test_memory_controller.cpp
@@ -235,7 +235,8 @@ TEST_CASE("Row hit is faster than row miss", "[memory_controller][timing]") {
 
     Cycle cycle = 0;
     Cycle first_start = 0, first_complete = 0;
-    Cycle second_start = 0, second_complete = 0;
+    Cycle second_start = 0;
+    [[maybe_unused]] Cycle second_complete = 0;
 
     while (!mc.is_complete()) {
         auto events = mc.tick(cycle);

--- a/tests/timing/test_schedule_generators.cpp
+++ b/tests/timing/test_schedule_generators.cpp
@@ -389,7 +389,7 @@ TEST_CASE("MatMulScheduleGenerator large problem", "[timing][schedule][matmul]")
     // 16x16x16 = 4096 output tiles
     Size m_tiles = 256 / 16;  // 16
     Size n_tiles = 256 / 16;  // 16
-    Size k_tiles = 256 / 16;  // 16
+    [[maybe_unused]] Size k_tiles = 256 / 16;  // 16
 
     REQUIRE(result.metadata.c_tiles == m_tiles * n_tiles);
     REQUIRE(result.size() > 10000);  // Large schedule

--- a/tests/xue/test_xue.cpp
+++ b/tests/xue/test_xue.cpp
@@ -403,7 +403,7 @@ TEST_CASE("XUE Operational Analysis (v0.4.0)", "[xue][analysis][v040]") {
         events.record_compute(EventType::OP_MATMUL, flops);
 
         // Memory traffic (simplified)
-        uint64_t bytes = 3 * M * N * 4;  // A, B, C in float
+        [[maybe_unused]] uint64_t bytes = 3 * M * N * 4;  // A, B, C in float
         events.record_memory(EventType::DRAM_READ, 2 * M * K * 4);
         events.record_memory(EventType::DRAM_WRITE, M * N * 4);
 


### PR DESCRIPTION
Final Linux-side cleanup PR for #23. **108 warnings → 0** across 19 files.

## What & how
Three coordinated edits:

### 1. \`[[maybe_unused]]\` on 53 unused params / locals
Applied programmatically via a small Python helper (\`/tmp/apply_maybe_unused_v2.py\`, kept locally for reference): for each warning, walk backward from the identifier position to the previous declaration delimiter (\`,\`, \`(\`, \`{\`, \`;\`, or start-of-line), and insert \`[[maybe_unused]] \` at the type position.

**Subtle gotcha caught in iteration:** inserting the attribute **between** the type and the identifier (\`int [[maybe_unused]] x\`) triggers \`-Wattributes\` "attribute ignored" — the attribute applies to the *type* there, not to the *parameter*. The correct position is before the type (\`[[maybe_unused]] int x\`).

**Two multi-declarator statements** required hand-splitting because \`[[maybe_unused]]\` is not allowed between declarators in a comma list:
\`\`\`cpp
// before — invalid
Cycle a = 0, [[maybe_unused]] b = 0;

// after
Cycle a = 0;
[[maybe_unused]] Cycle b = 0;
\`\`\`
Same pattern in \`streamer_flow_executor.hpp:239\` (\`uint16_t i, j, k\` declaration where only \`k\` is unused).

### 2. One stray unused local
\`patterns/dma/gemm/a_tile_row_major.cpp:91\` — wasn't in the warning capture from the first build pass but appeared after re-touching headers. Added \`[[maybe_unused]]\`.

### 3. Two ASCII-art diamond comments
\`tests/driver/test_kernel_graph.cpp:203\` and \`examples/basic/kernel_graph_demo.cpp:132\` ended \`//\` lines with a backslash — gcc treats trailing \`\\\` in line comments as line continuation and warns. Rephrased so no \`//\` line ends in a bare backslash.

## Local verification
\`\`\`
Linux gcc release warning count: 0 (was 108)

test_memory_controller:    12/12 cases,  51/51 assertions
c_stationary_matmul_test:  14/14 cases,  24/24 assertions
flow_graph_executor_test:  21/21 cases, 106/106 assertions
\`\`\`

## #23 status after this lands
| Phase | What | Status |
|---|---|---|
| 1a | \`-Wstringop-overflow\` suppression | ✅ merged (#29) |
| 1b | \`-Wunused-*\` + \`-Wcomment\` sweep | this PR |
| 2 | All MSVC C4244/C4267 narrowings | ✅ merged (#25-28) |
| 3 | Lock in with \`-Werror\` / \`/WX\` in CI | follow-up |

After this merges, **all three platforms produce zero warnings** and Phase 3 is a small CI YAML change.

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)