### PR TITLE
feat(l3): introduce L3Layer aggregate (#32, Phase 1A/1B)

### DIFF
--- a/include/sw/kpu/kpu_simulator.hpp
+++ b/include/sw/kpu/kpu_simulator.hpp
@@ -37,6 +37,7 @@
 #include <sw/kpu/models/temporal/memory/controllers/controller_base.hpp>
 #include <sw/kpu/models/temporal/datamovement/dma_engine.hpp>
 #include <sw/kpu/models/temporal/memory/l3_tile.hpp>
+#include <sw/kpu/models/temporal/memory/l3_layer.hpp>
 #include <sw/kpu/models/temporal/memory/l2_bank.hpp>
 #include <sw/kpu/models/temporal/memory/l1_buffer.hpp>
 #include <sw/kpu/models/temporal/datamovement/block_mover.hpp>
@@ -141,13 +142,12 @@ private:
     // Component vectors - value semantics, addressable
     std::vector<ExternalMemory> host_memory_regions;  // Host system memory (NUMA regions)
     std::vector<ExternalMemory> memory_banks;  // KPU local memory banks
-    std::vector<L3Tile> l3_tiles;
+    L3Layer l3_layer;  // SoC-wide L3 aggregate: owns L3Tiles, BlockMovers, interconnect
     std::vector<L2Bank> l2_banks;
     std::vector<L1Buffer> l1_buffers;  // L1 streaming buffers (compute fabric)
     std::vector<PageBuffer> page_buffers;  // Page buffers (memory controller)
     std::vector<DMAEngine> dma_engines;
     std::vector<ComputeFabric> compute_tiles;
-    std::vector<BlockMover> block_movers;
     std::vector<Streamer> streamers;
 
     // Address decoder for unified address space
@@ -282,13 +282,13 @@ public:
     // Configuration queries
     size_t get_host_memory_region_count() const { return host_memory_regions.size(); }
     size_t get_memory_bank_count() const { return memory_banks.size(); }
-    size_t get_l3_tile_count() const { return l3_tiles.size(); }
+    size_t get_l3_tile_count() const { return l3_layer.tile_count(); }
     size_t get_l2_bank_count() const { return l2_banks.size(); }
     size_t get_l1_buffer_count() const { return l1_buffers.size(); }
     size_t get_page_buffer_count() const { return page_buffers.size(); }
     size_t get_compute_tile_count() const { return compute_tiles.size(); }
     size_t get_dma_engine_count() const { return dma_engines.size(); }
-    size_t get_block_mover_count() const { return block_movers.size(); }
+    size_t get_block_mover_count() const { return l3_layer.block_mover_count(); }
     size_t get_streamer_count() const { return streamers.size(); }
 
     Size get_host_memory_region_capacity(size_t region_id) const;

--- a/include/sw/kpu/models/temporal/memory/l3_layer.hpp
+++ b/include/sw/kpu/models/temporal/memory/l3_layer.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <cstdint>
+
+// Windows/MSVC compatibility
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4251) // DLL interface warnings
+    #ifdef BUILDING_KPU_SIMULATOR
+        #define KPU_API __declspec(dllexport)
+    #else
+        #define KPU_API __declspec(dllimport)
+    #endif
+#else
+    #define KPU_API
+#endif
+
+#include <sw/concepts.hpp>
+#include <sw/kpu/models/temporal/memory/l3_tile.hpp>
+#include <sw/kpu/models/temporal/datamovement/block_mover.hpp>
+#include <sw/kpu/models/temporal/datamovement/l3_interconnect.hpp>
+
+namespace sw::kpu {
+
+// Forward declaration: L2Bank is only referenced by reference (process_block_movers).
+class L2Bank;
+
+// ============================================================================
+// L3 Layer configuration
+//
+// The L3 layer is the whole SoC-wide L3 resource: a (possibly non-uniform)
+// collection of L3Tile elements, the per-tile BlockMovers that push tiles down
+// into the L2 layer, and the L3 interconnect/NoC. Element micro-architecture
+// (capacity, banks, ports) belongs to the element; the *layer* describes how
+// many elements there are, their grouping, and the layer-level resources.
+//
+// Non-uniformity (heterogeneous compute fabrics) is expressed with the
+// `group -> element-config -> multiplicity` shape: each named group binds one
+// element spec to a count of identical tiles, and a layer holds many groups.
+// ============================================================================
+
+/// Per-element (L3Tile) micro-architecture spec at the temporal-model level.
+struct L3TileSpec {
+    /// Capacity per tile in KB.
+    Size capacity_kb = 128;
+};
+
+/// A named group of identical L3Tiles: element-config bound to a multiplicity.
+struct L3TileGroup {
+    std::string name;          ///< Symbolic group name (e.g. "default", "hbw").
+    L3TileSpec tile;           ///< Element configuration shared by the group.
+    size_t multiplicity = 1;   ///< Number of identical tiles in the group.
+};
+
+/// Configuration for an L3Layer aggregate.
+struct L3LayerConfig {
+    /// Tile groups: group -> element-config -> multiplicity (supports non-uniform layers).
+    std::vector<L3TileGroup> tile_groups;
+
+    /// Number of BlockMovers the layer owns (round-robin associated to tiles).
+    /// Target micro-architecture is one BlockMover per L3Tile.
+    size_t block_mover_count = 0;
+
+    /// Construct and own an L3Interconnect instance (ownership seam; routing
+    /// integration is a separate concern from ownership).
+    bool enable_interconnect = false;
+
+    /// BlockMover timing parameters.
+    double block_mover_clock_ghz = 1.0;
+    double block_mover_bandwidth_gb_s = 100.0;
+
+    /// Total number of tiles across all groups.
+    size_t total_tiles() const {
+        size_t n = 0;
+        for (const auto& g : tile_groups) {
+            n += g.multiplicity;
+        }
+        return n;
+    }
+
+    /// Convenience constructor for a uniform layer: `num_tiles` identical tiles
+    /// of `capacity_kb`, with `block_mover_count` movers. Used to bridge the
+    /// legacy flat configuration until per-group config is wired through.
+    static L3LayerConfig uniform(size_t num_tiles, Size capacity_kb,
+                                 size_t block_mover_count = 0) {
+        L3LayerConfig cfg;
+        if (num_tiles > 0) {
+            cfg.tile_groups.push_back(L3TileGroup{"default", L3TileSpec{capacity_kb}, num_tiles});
+        }
+        cfg.block_mover_count = block_mover_count;
+        return cfg;
+    }
+};
+
+// ============================================================================
+// L3 Layer aggregate
+// ============================================================================
+
+/// The whole SoC-wide L3 resource. Owns the L3Tile elements, the BlockMovers
+/// attached to them, and the (optional) L3 interconnect.
+class KPU_API L3Layer {
+public:
+    explicit L3Layer(const L3LayerConfig& config = {});
+    ~L3Layer();
+
+    // Non-copyable (owns a unique_ptr); movable.
+    L3Layer(const L3Layer&) = delete;
+    L3Layer& operator=(const L3Layer&) = delete;
+    L3Layer(L3Layer&&) noexcept;
+    L3Layer& operator=(L3Layer&&) noexcept;
+
+    // --- L3Tile elements -----------------------------------------------------
+    size_t tile_count() const { return tiles_.size(); }
+    L3Tile& tile(size_t index);
+    const L3Tile& tile(size_t index) const;
+
+    /// Direct access to the tile collection, for components whose APIs take a
+    /// `std::vector<L3Tile>&` (e.g. the DMA engine and BlockMover).
+    std::vector<L3Tile>& tiles() { return tiles_; }
+    const std::vector<L3Tile>& tiles() const { return tiles_; }
+
+    // --- BlockMovers (owned by the layer) ------------------------------------
+    size_t block_mover_count() const { return block_movers_.size(); }
+    BlockMover& block_mover(size_t index);
+    const BlockMover& block_mover(size_t index) const;
+    std::vector<BlockMover>& block_movers() { return block_movers_; }
+
+    /// Drive all owned BlockMovers one step, pushing tiles down into the L2 layer.
+    void process_block_movers(std::vector<L2Bank>& l2_banks);
+    /// Set the simulation cycle on all owned BlockMovers.
+    void set_block_mover_cycle(Cycle cycle);
+    /// True if any owned BlockMover still has work in flight.
+    bool any_block_mover_busy() const;
+
+    // --- Interconnect (ownership seam; may be absent) ------------------------
+    bool has_interconnect() const { return interconnect_ != nullptr; }
+    L3Interconnect& interconnect();
+    const L3Interconnect& interconnect() const;
+
+    // --- Lifecycle -----------------------------------------------------------
+    void reset();
+
+    const L3LayerConfig& config() const { return config_; }
+
+private:
+    L3LayerConfig config_;
+    std::vector<L3Tile> tiles_;
+    std::vector<BlockMover> block_movers_;
+    std::unique_ptr<L3Interconnect> interconnect_;
+};
+
+} // namespace sw::kpu
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif

--- a/include/sw/kpu/models/temporal/memory/l3_layer.hpp
+++ b/include/sw/kpu/models/temporal/memory/l3_layer.hpp
@@ -127,6 +127,7 @@ public:
     BlockMover& block_mover(size_t index);
     const BlockMover& block_mover(size_t index) const;
     std::vector<BlockMover>& block_movers() { return block_movers_; }
+    const std::vector<BlockMover>& block_movers() const { return block_movers_; }
 
     /// Drive all owned BlockMovers one step, pushing tiles down into the L2 layer.
     void process_block_movers(std::vector<L2Bank>& l2_banks);

--- a/src/system/simulator/CMakeLists.txt
+++ b/src/system/simulator/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(KPU_SIMULATOR_SOURCES
     kpu_simulator.cpp
+    l3_layer.cpp
     resource_manager.cpp
     kernel.cpp
     kernel_serializer.cpp

--- a/src/system/simulator/kpu_simulator.cpp
+++ b/src/system/simulator/kpu_simulator.cpp
@@ -24,11 +24,11 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
         memory_banks.emplace_back(config.memory_bank_capacity_mb, config.memory_bandwidth_gbps);
     }
 
-    // Initialize L3 tiles - software-managed on-chip buffers
-    l3_tiles.reserve(config.l3_tile_count);
-    for (size_t i = 0; i < config.l3_tile_count; ++i) {
-        l3_tiles.emplace_back(i, config.l3_tile_capacity_kb);
-    }
+    // Initialize the L3 layer aggregate - owns the L3Tiles, the per-tile
+    // BlockMovers, and (optionally) the L3 interconnect.
+    l3_layer = L3Layer(L3LayerConfig::uniform(config.l3_tile_count,
+                                              config.l3_tile_capacity_kb,
+                                              config.block_mover_count));
 
     // Initialize L2 banks - software-managed on-chip buffers
     l2_banks.reserve(config.l2_bank_count);
@@ -66,12 +66,8 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
         dma_engines.emplace_back(i);
     }
 
-    // Initialize BlockMovers - L3↔L2 data movement with transformations
-    block_movers.reserve(config.block_mover_count);
-    for (size_t i = 0; i < config.block_mover_count; ++i) {
-        size_t associated_l3_tile = i % config.l3_tile_count;
-        block_movers.emplace_back(i, associated_l3_tile);
-    }
+    // BlockMovers (L3↔L2 data movement with transformations) are owned by the
+    // L3 layer; they were constructed above as part of the L3Layer aggregate.
 
     // Initialize Streamers - L2↔L1 streaming for compute fabric
     streamers.reserve(config.streamer_count);
@@ -212,12 +208,12 @@ void KPUSimulator::write_page_buffer(size_t pad_id, Address addr, const void* da
 // L3 and L2 memory operations
 void KPUSimulator::read_l3_tile(size_t tile_id, Address addr, void* data, Size size) {
     validate_l3_tile_id(tile_id);
-    l3_tiles[tile_id].read(addr, data, size);
+    l3_layer.tiles()[tile_id].read(addr, data, size);
 }
 
 void KPUSimulator::write_l3_tile(size_t tile_id, Address addr, const void* data, Size size) {
     validate_l3_tile_id(tile_id);
-    l3_tiles[tile_id].write(addr, data, size);
+    l3_layer.tiles()[tile_id].write(addr, data, size);
 }
 
 void KPUSimulator::read_l2_bank(size_t bank_id, Address addr, void* data, Size size) {
@@ -333,7 +329,7 @@ void KPUSimulator::start_block_transfer(size_t block_mover_id, size_t src_l3_til
     validate_l3_tile_id(src_l3_tile_id);
     validate_l2_bank_id(dst_l2_bank_id);
 
-    block_movers[block_mover_id].enqueue_block_transfer(
+    l3_layer.block_movers()[block_mover_id].enqueue_block_transfer(
         src_l3_tile_id, src_offset, dst_l2_bank_id, dst_offset,
         block_height, block_width, element_size, transform, std::move(callback)
     );
@@ -341,7 +337,7 @@ void KPUSimulator::start_block_transfer(size_t block_mover_id, size_t src_l3_til
 
 bool KPUSimulator::is_block_mover_busy(size_t block_mover_id) {
     validate_block_mover_id(block_mover_id);
-    return block_movers[block_mover_id].is_busy();
+    return l3_layer.block_movers()[block_mover_id].is_busy();
 }
 
 // Streamer operations
@@ -434,7 +430,7 @@ void KPUSimulator::reset() {
     for (auto& bank : memory_banks) {
         bank.reset();
     }
-    for (auto& l3_tile : l3_tiles) {
+    for (auto& l3_tile : l3_layer.tiles()) {
         l3_tile.reset();
     }
     for (auto& l2_bank : l2_banks) {
@@ -452,7 +448,7 @@ void KPUSimulator::reset() {
     for (auto& tile : compute_tiles) {
         tile.reset();
     }
-    for (auto& block_mover : block_movers) {
+    for (auto& block_mover : l3_layer.block_movers()) {
         block_mover.reset();
     }
     for (auto& streamer : streamers) {
@@ -469,7 +465,7 @@ void KPUSimulator::step() {
     for (auto& dma : dma_engines) {
         dma.set_current_cycle(current_cycle);
     }
-    for (auto& block_mover : block_movers) {
+    for (auto& block_mover : l3_layer.block_movers()) {
         block_mover.set_cycle(current_cycle);
     }
     for (auto& streamer : streamers) {
@@ -482,10 +478,10 @@ void KPUSimulator::step() {
     // Then process/update all components
     // DMA engines move data between host/KPU memory and L3 tiles
     for (auto& dma : dma_engines) {
-        dma.process_transfers(host_memory_regions, memory_banks, l3_tiles);
+        dma.process_transfers(host_memory_regions, memory_banks, l3_layer.tiles());
     }
-    for (auto& block_mover : block_movers) {
-        block_mover.process_transfers(l3_tiles, l2_banks);
+    for (auto& block_mover : l3_layer.block_movers()) {
+        block_mover.process_transfers(l3_layer.tiles(), l2_banks);
     }
     for (auto& streamer : streamers) {
         streamer.update(current_cycle, l2_banks, l1_buffers);
@@ -505,7 +501,7 @@ void KPUSimulator::run_until_idle() {
                 break;
             }
         }
-        for (const auto& block_mover : block_movers) {
+        for (const auto& block_mover : l3_layer.block_movers()) {
             if (block_mover.is_busy()) {
                 any_busy = true;
                 break;
@@ -542,7 +538,7 @@ Size KPUSimulator::get_memory_bank_capacity(size_t bank_id) const {
 
 Size KPUSimulator::get_l3_tile_capacity(size_t tile_id) const {
     validate_l3_tile_id(tile_id);
-    return l3_tiles[tile_id].get_capacity();
+    return l3_layer.tiles()[tile_id].get_capacity();
 }
 
 Size KPUSimulator::get_l2_bank_capacity(size_t bank_id) const {
@@ -572,13 +568,13 @@ void KPUSimulator::print_stats() const {
     std::cout << "Simulation cycles: " << current_cycle << std::endl;
     std::cout << "Wall-clock time: " << get_elapsed_time_ms() << " ms" << std::endl;
     std::cout << "Memory banks: " << memory_banks.size() << std::endl;
-    std::cout << "L3 tiles: " << l3_tiles.size() << std::endl;
+    std::cout << "L3 tiles: " << l3_layer.tiles().size() << std::endl;
     std::cout << "L2 banks: " << l2_banks.size() << std::endl;
     std::cout << "L1 buffers: " << l1_buffers.size() << std::endl;
     std::cout << "Page buffers: " << page_buffers.size() << std::endl;
     std::cout << "Compute tiles: " << compute_tiles.size() << std::endl;
     std::cout << "DMA engines: " << dma_engines.size() << std::endl;
-    std::cout << "Block movers: " << block_movers.size() << std::endl;
+    std::cout << "Block movers: " << l3_layer.block_movers().size() << std::endl;
 }
 
 void KPUSimulator::print_component_status() const {
@@ -605,9 +601,9 @@ void KPUSimulator::print_component_status() const {
     }
 
     std::cout << "L3 Tiles:" << std::endl;
-    for (size_t i = 0; i < l3_tiles.size(); ++i) {
-        std::cout << "  L3Tile[" << i << "]: " << l3_tiles[i].get_capacity() / 1024
-                  << " KB, Ready: " << (l3_tiles[i].is_ready() ? "Yes" : "No") << std::endl;
+    for (size_t i = 0; i < l3_layer.tiles().size(); ++i) {
+        std::cout << "  L3Tile[" << i << "]: " << l3_layer.tiles()[i].get_capacity() / 1024
+                  << " KB, Ready: " << (l3_layer.tiles()[i].is_ready() ? "Yes" : "No") << std::endl;
     }
 
     std::cout << "L2 Banks:" << std::endl;
@@ -623,8 +619,8 @@ void KPUSimulator::print_component_status() const {
     }
 
     std::cout << "Block Movers:" << std::endl;
-    for (size_t i = 0; i < block_movers.size(); ++i) {
-        const auto& mover = block_movers[i];
+    for (size_t i = 0; i < l3_layer.block_movers().size(); ++i) {
+        const auto& mover = l3_layer.block_movers()[i];
         std::cout << "  BlockMover[" << i << "]: ";
         std::cout << "Busy: " << (mover.is_busy() ? "Yes" : "No");
         std::cout << ", Queue: " << mover.get_queue_size() << " transfers";
@@ -651,7 +647,7 @@ bool KPUSimulator::is_memory_bank_ready(size_t bank_id) const {
 
 bool KPUSimulator::is_l3_tile_ready(size_t tile_id) const {
     validate_l3_tile_id(tile_id);
-    return l3_tiles[tile_id].is_ready();
+    return l3_layer.tiles()[tile_id].is_ready();
 }
 
 bool KPUSimulator::is_l2_bank_ready(size_t bank_id) const {
@@ -701,7 +697,7 @@ void KPUSimulator::validate_tile_id(size_t tile_id) const {
 }
 
 void KPUSimulator::validate_l3_tile_id(size_t tile_id) const {
-    if (tile_id >= l3_tiles.size()) {
+    if (tile_id >= l3_layer.tiles().size()) {
         throw std::out_of_range("Invalid L3 tile ID: " + std::to_string(tile_id));
     }
 }
@@ -719,7 +715,7 @@ void KPUSimulator::validate_l1_buffer_id(size_t buffer_id) const {
 }
 
 void KPUSimulator::validate_block_mover_id(size_t mover_id) const {
-    if (mover_id >= block_movers.size()) {
+    if (mover_id >= l3_layer.block_movers().size()) {
         throw std::out_of_range("Invalid block mover ID: " + std::to_string(mover_id));
     }
 }
@@ -836,7 +832,7 @@ void KPUSimulator::enable_dma_tracing(size_t dma_id) {
 
 void KPUSimulator::enable_block_mover_tracing(size_t mover_id) {
     validate_block_mover_id(mover_id);
-    block_movers[mover_id].enable_tracing();
+    l3_layer.block_movers()[mover_id].enable_tracing();
 }
 
 void KPUSimulator::enable_streamer_tracing(size_t streamer_id) {
@@ -856,7 +852,7 @@ void KPUSimulator::disable_dma_tracing(size_t dma_id) {
 
 void KPUSimulator::disable_block_mover_tracing(size_t mover_id) {
     validate_block_mover_id(mover_id);
-    block_movers[mover_id].disable_tracing();
+    l3_layer.block_movers()[mover_id].disable_tracing();
 }
 
 void KPUSimulator::disable_streamer_tracing(size_t streamer_id) {
@@ -913,7 +909,7 @@ Address KPUSimulator::get_l3_tile_base(size_t tile_id) const {
     }
     // Then add offsets for L3 tiles before this one
     for (size_t i = 0; i < tile_id; ++i) {
-        base += l3_tiles[i].get_capacity();
+        base += l3_layer.tiles()[i].get_capacity();
     }
     return base;
 }
@@ -928,7 +924,7 @@ Address KPUSimulator::get_l2_bank_base(size_t bank_id) const {
     for (const auto& bank : memory_banks) {
         base += bank.get_capacity();
     }
-    for (const auto& tile : l3_tiles) {
+    for (const auto& tile : l3_layer.tiles()) {
         base += tile.get_capacity();
     }
     // Then add offsets for L2 banks before this one
@@ -948,7 +944,7 @@ Address KPUSimulator::get_l1_buffer_base(size_t buffer_id) const {
     for (const auto& bank : memory_banks) {
         base += bank.get_capacity();
     }
-    for (const auto& tile : l3_tiles) {
+    for (const auto& tile : l3_layer.tiles()) {
         base += tile.get_capacity();
     }
     for (const auto& bank : l2_banks) {
@@ -971,7 +967,7 @@ Address KPUSimulator::get_page_buffer_base(size_t pad_id) const {
     for (const auto& bank : memory_banks) {
         base += bank.get_capacity();
     }
-    for (const auto& tile : l3_tiles) {
+    for (const auto& tile : l3_layer.tiles()) {
         base += tile.get_capacity();
     }
     for (const auto& bank : l2_banks) {

--- a/src/system/simulator/l3_layer.cpp
+++ b/src/system/simulator/l3_layer.cpp
@@ -1,0 +1,119 @@
+#include <sw/kpu/models/temporal/memory/l3_layer.hpp>
+#include <sw/kpu/models/temporal/memory/l2_bank.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace sw::kpu {
+
+L3Layer::L3Layer(const L3LayerConfig& config)
+    : config_(config) {
+    // Materialize the L3Tile elements from the tile groups, assigning a global
+    // flat tile_id across all groups so the layer presents a single index space.
+    const size_t total = config_.total_tiles();
+    tiles_.reserve(total);
+    size_t global_id = 0;
+    for (const auto& group : config_.tile_groups) {
+        for (size_t k = 0; k < group.multiplicity; ++k) {
+            tiles_.emplace_back(global_id, group.tile.capacity_kb);
+            ++global_id;
+        }
+    }
+
+    // Materialize the BlockMovers the layer owns. They are round-robin
+    // associated to tiles (target micro-architecture: one mover per tile).
+    block_movers_.reserve(config_.block_mover_count);
+    for (size_t i = 0; i < config_.block_mover_count; ++i) {
+        const size_t associated_tile = total > 0 ? (i % total) : 0;
+        block_movers_.emplace_back(i, associated_tile,
+                                   config_.block_mover_clock_ghz,
+                                   config_.block_mover_bandwidth_gb_s);
+    }
+
+    // Construct the interconnect only when requested (ownership seam).
+    if (config_.enable_interconnect && total > 0) {
+        interconnect_ = std::make_unique<L3Interconnect>();
+    }
+}
+
+L3Layer::~L3Layer() = default;
+L3Layer::L3Layer(L3Layer&&) noexcept = default;
+L3Layer& L3Layer::operator=(L3Layer&&) noexcept = default;
+
+L3Tile& L3Layer::tile(size_t index) {
+    if (index >= tiles_.size()) {
+        throw std::out_of_range("L3Layer::tile: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(tiles_.size()) + " tiles)");
+    }
+    return tiles_[index];
+}
+
+const L3Tile& L3Layer::tile(size_t index) const {
+    if (index >= tiles_.size()) {
+        throw std::out_of_range("L3Layer::tile: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(tiles_.size()) + " tiles)");
+    }
+    return tiles_[index];
+}
+
+BlockMover& L3Layer::block_mover(size_t index) {
+    if (index >= block_movers_.size()) {
+        throw std::out_of_range("L3Layer::block_mover: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(block_movers_.size()) + " movers)");
+    }
+    return block_movers_[index];
+}
+
+const BlockMover& L3Layer::block_mover(size_t index) const {
+    if (index >= block_movers_.size()) {
+        throw std::out_of_range("L3Layer::block_mover: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(block_movers_.size()) + " movers)");
+    }
+    return block_movers_[index];
+}
+
+void L3Layer::process_block_movers(std::vector<L2Bank>& l2_banks) {
+    for (auto& mover : block_movers_) {
+        mover.process_transfers(tiles_, l2_banks);
+    }
+}
+
+void L3Layer::set_block_mover_cycle(Cycle cycle) {
+    for (auto& mover : block_movers_) {
+        mover.set_cycle(cycle);
+    }
+}
+
+bool L3Layer::any_block_mover_busy() const {
+    for (const auto& mover : block_movers_) {
+        if (mover.is_busy()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+L3Interconnect& L3Layer::interconnect() {
+    if (!interconnect_) {
+        throw std::logic_error("L3Layer::interconnect: layer has no interconnect");
+    }
+    return *interconnect_;
+}
+
+const L3Interconnect& L3Layer::interconnect() const {
+    if (!interconnect_) {
+        throw std::logic_error("L3Layer::interconnect: layer has no interconnect");
+    }
+    return *interconnect_;
+}
+
+void L3Layer::reset() {
+    for (auto& tile : tiles_) {
+        tile.reset();
+    }
+    for (auto& mover : block_movers_) {
+        mover.reset();
+    }
+}
+
+} // namespace sw::kpu


### PR DESCRIPTION
## Summary

Implements the foundation of #32: introduce the **`L3Layer`** aggregate and wire
it into `KPUSimulator` — **without breaking the public API yet**. Per the
approved design plan (`docs/plans/memory-layer-restructuring.md`), this is
Phases 1A + 1B; the breaking config/API rewrite is Phase 1C (still to come).

## What's here

- **1A — new aggregate** (`l3_layer.hpp` / `l3_layer.cpp`, compiled in the
  `kpu_simulator` library to sit above datamovement/memory and avoid a circular
  dependency):
  - `L3Layer` owns the retained `L3Tile` elements, the per-tile `BlockMover`s,
    and an optional `L3Interconnect` (ownership seam).
  - `L3LayerConfig` uses the **`group → element-config → multiplicity`** shape
    for non-uniform layers; `uniform()` bridges the legacy flat config.
- **1B — internal integration**: `KPUSimulator` now holds one `L3Layer` instead
  of bare `std::vector<L3Tile>` + `std::vector<BlockMover>` members. All internal
  call sites delegate through `l3_layer.tiles()` / `l3_layer.block_movers()`.
  The external API (Config fields, public accessors) is **unchanged**, so this
  step is behavior-preserving.

## Not in this PR (Phase 1C — the hard break)

- Replace flat `KPUSimulator::Config` fields (`l3_tile_count`,
  `l3_tile_capacity_kb`, `block_mover_count`, …) with `L3LayerConfig`.
- Migrate ~45 config call sites + ~32 `L3Tile`/`BlockMover` users, the public C
  API, Python bindings, and the JSON config parser.
- No backward-compat shims (per plan).

## Validation

- Build green on **linux-gcc**.
- **95/95** ctest tests pass.
- CI will additionally cover Windows/MSVC + Clang and sanitizers.

Part of #32 · epic #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)