### PR TITLE
refactor(l3)!: replace flat L3 Config fields with L3LayerConfig (#32, Phase 1C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — L3 memory layer restructuring (#32).** Introduced the `L3Layer`
+  aggregate (owns the `L3Tile` elements, the per-tile `BlockMover`s, and an
+  optional `L3Interconnect`) and removed the flat L3 fields from
+  `KPUSimulator::Config`. Migration:
+  - `config.l3_tile_count`        → `config.l3_layer.num_tiles`
+  - `config.l3_tile_capacity_kb`  → `config.l3_layer.capacity_kb`
+  - `config.block_mover_count`    → `config.l3_layer.block_mover_count`
+  - For non-uniform layers, populate `config.l3_layer.tile_groups`
+    (`group → element-config → multiplicity`) instead of the scalar fields.
+  - `config.l3_tile_base` is unchanged. No backward-compatibility shims are
+    provided. Python keeps the `l3_tile_count` / `l3_tile_capacity_kb` /
+    `block_mover_count` attribute names (they proxy into `l3_layer`); the C ABI
+    struct `KPUSimulatorConfig` is unchanged.
+
 ### Added
 
 - **CSP Schedule Generators (Phase 4)** — Complete schedule generation infrastructure

--- a/CLAUDE.sw21.md
+++ b/CLAUDE.sw21.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+The Stillwater Knowledge Processing Unit (KPU) Simulator is a C++20 functional simulator for a specialized hardware accelerator targeting knowledge processing and AI workloads. Key characteristics:
+
+- **Data-driven execution model** (not traditional stored-program architecture)
+- **Software-managed memory hierarchy** with DMA engines, BlockMovers, and Streamers
+- **Systolic array** for matrix operations (tau111_s001 configuration: 8×8 PEs)
+- **Integration with domain_flow** computational graphs
+
+## Build Commands
+
+```bash
+# Build (release)
+cmake --preset=release
+cmake --build --preset=release
+
+# Build (debug with sanitizers)
+cmake --preset=debug
+cmake --build --preset=debug
+
+# Run all tests (excluding external domain_flow tests)
+ctest --test-dir build -E "^(dsp_|nla_|dfa_|dnn_|ctl_|cnn_)" --output-on-failure
+
+# Run single test
+ctest --test-dir build -R "test_name" -V
+
+# Run tests by category label
+ctest --test-dir build -L compiler -V    # compiler tests
+ctest --test-dir build -L memory -V      # memory tests
+ctest --test-dir build -L integration -V # integration tests
+
+# Build with local domain_flow
+cmake --preset=release -DKPU_DOMAIN_FLOW_LOCAL_PATH=~/dev/domain_flow
+```
+
+## Architecture
+
+### Memory Hierarchy (Nested)
+```
+Host DDR → (PCIe) → External Memory (GDDR6/HBM)
+  → DMA Engines (50GB/s) → L3 Tiles (128KB × 4)
+  → BlockMovers (100GB/s) → L2 Banks (64KB × 8)
+  → Streamers (200GB/s) → L1 Buffers (32KB × 4)
+  → PE Registers → Systolic Array
+```
+
+### Key Subsystems
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/system/` | Top-level orchestration, configuration loading |
+| `src/components/datamovement/` | DMA, BlockMover, Streamer engines |
+| `src/components/compute/` | SystolicArray, ComputeFabric |
+| `src/components/memory/` | L1/L2/L3 caches, address decoder |
+| `src/compiler/` | Graph loading, tile optimization, schedule generation |
+| `src/isa/` | Tile layouts, memory interleaving policies |
+
+### Core Abstractions
+
+- **GraphLoader** (`include/sw/compiler/graph_loader.hpp`): Loads domain_flow `.dfg` or JSON graphs
+- **TileOptimizer** (`include/sw/compiler/tile_optimizer.hpp`): Determines optimal tile sizes for memory hierarchy
+- **ScheduleGenerator** (`include/sw/compiler/schedule_generator.hpp`): Converts graphs to execution schedules
+- **TileLayout** (`include/sw/isa/tile_layout.hpp`): Memory channel interleaving policies (MATRIX_PARTITIONED, ROUND_ROBIN, ITERATION_AWARE, HARDWARE_INTERLEAVED)
+
+### Namespaces
+
+- `sw::kpu::*` - KPU simulator components
+- `sw::sim::*` - System-level simulation
+- `sw::kpu::compiler::*` - Compiler infrastructure
+
+## Testing
+
+Test helper macro in `tests/CMakeLists.txt`: `kpu_add_component_test(NAME category/test_name SOURCES file.cpp LABELS label1 label2)`
+
+Test categories: system, driver, memory, trace, dma, block_mover, streamer, compute, storage, compiler, isa, integration
+
+## Configuration
+
+JSON-based configuration in `configs/`. Key CMake options:
+- `KPU_BUILD_TESTS`, `KPU_BUILD_EXAMPLES`, `KPU_BUILD_PYTHON_BINDINGS` (all ON by default)
+- `KPU_DOMAIN_FLOW_LOCAL_PATH` - Path to local domain_flow for development
+
+## Python Bindings
+
+```bash
+pip install -e .
+export PYTHONPATH=$PWD/build:$PYTHONPATH
+python tests/test_python.py
+```
+
+Module name: `kpu_bindings` (import as `import kpu_bindings`)

--- a/examples/basic/data_movement_pipeline.cpp
+++ b/examples/basic/data_movement_pipeline.cpp
@@ -8,12 +8,12 @@ int main() {
     // Create minimal config
     KPUSimulator::Config config;
     config.memory_bank_count = 1;
-    config.l3_tile_count = 1;
+    config.l3_layer.num_tiles = 1;
     config.l2_bank_count = 1;
     config.l1_buffer_count = 1;
     config.l1_buffer_capacity_kb = 64;
     config.compute_tile_count = 1;
-    config.block_mover_count = 1;
+    config.l3_layer.block_mover_count = 1;
     config.streamer_count = 2;
     config.processor_array_rows = 16;
     config.processor_array_cols = 16;

--- a/examples/basic/host_to_l3_matmul.cpp
+++ b/examples/basic/host_to_l3_matmul.cpp
@@ -152,8 +152,8 @@ This example demonstrates the full data flow for matrix multiplication:
     config.memory_controller_count = 1;
     config.page_buffer_count = 2;
     config.page_buffer_capacity_kb = 32;
-    config.l3_tile_count = 1;
-    config.l3_tile_capacity_kb = 128;
+    config.l3_layer.num_tiles = 1;
+    config.l3_layer.capacity_kb = 128;
     config.l2_bank_count = 4;
     config.l2_bank_capacity_kb = 64;
     config.l1_buffer_count = 64;
@@ -164,7 +164,7 @@ This example demonstrates the full data flow for matrix multiplication:
     config.processor_array_topology = ProcessorArrayTopology::RECTANGULAR;
     config.use_systolic_array_mode = true;
     config.dma_engine_count = 2;
-    config.block_mover_count = 2;
+    config.l3_layer.block_mover_count = 2;
     config.streamer_count = 4;
 
     // Print configuration
@@ -173,8 +173,8 @@ This example demonstrates the full data flow for matrix multiplication:
               << config.host_memory_region_capacity_mb << " MB\n";
     std::cout << "  External Memory: " << config.memory_bank_count << " banks × "
               << config.memory_bank_capacity_mb << " MB\n";
-    std::cout << "  L3 Tiles:        " << config.l3_tile_count << " × "
-              << config.l3_tile_capacity_kb << " KB\n";
+    std::cout << "  L3 Tiles:        " << config.l3_layer.num_tiles << " × "
+              << config.l3_layer.capacity_kb << " KB\n";
     std::cout << "  L2 Banks:        " << config.l2_bank_count << " × "
               << config.l2_bank_capacity_kb << " KB\n";
     std::cout << "  L1 Buffers:      " << config.l1_buffer_count << " × "

--- a/examples/basic/memory_management.cpp
+++ b/examples/basic/memory_management.cpp
@@ -40,11 +40,11 @@ int main() {
     config.l1_buffer_capacity_kb = 64;
     config.compute_tile_count = 2;
     config.dma_engine_count = 4;
-    config.l3_tile_count = 4;
-    config.l3_tile_capacity_kb = 256;
+    config.l3_layer.num_tiles = 4;
+    config.l3_layer.capacity_kb = 256;
     config.l2_bank_count = 8;
     config.l2_bank_capacity_kb = 64;
-    config.block_mover_count = 4;
+    config.l3_layer.block_mover_count = 4;
     config.streamer_count = 8;
 
     sw::kpu::KPUSimulator kpu(config);

--- a/examples/basic/resource_api_demo.cpp
+++ b/examples/basic/resource_api_demo.cpp
@@ -85,8 +85,8 @@ int main() {
     config.memory_bank_count = 4;
     config.memory_bank_capacity_mb = 16;
 
-    config.l3_tile_count = 8;
-    config.l3_tile_capacity_kb = 512;
+    config.l3_layer.num_tiles = 8;
+    config.l3_layer.capacity_kb = 512;
 
     config.l2_bank_count = 16;
     config.l2_bank_capacity_kb = 128;
@@ -97,7 +97,7 @@ int main() {
     // Configure compute and data movement
     config.compute_tile_count = 8;
     config.dma_engine_count = 4;
-    config.block_mover_count = 8;
+    config.l3_layer.block_mover_count = 8;
     config.streamer_count = 16;
 
     KPUSimulator simulator(config);

--- a/examples/blas/big_matmul.cpp
+++ b/examples/blas/big_matmul.cpp
@@ -96,8 +96,8 @@ KPUSimulator::Config create_config() {
     config.memory_controller_count = 2;
     config.page_buffer_count = 8;
     config.page_buffer_capacity_kb = 32;
-    config.l3_tile_count = 16;
-    config.l3_tile_capacity_kb = 512;
+    config.l3_layer.num_tiles = 16;
+    config.l3_layer.capacity_kb = 512;
     config.l2_bank_count = 64;
     config.l2_bank_capacity_kb = 32;
     config.l1_buffer_count = 3072;
@@ -108,7 +108,7 @@ KPUSimulator::Config create_config() {
     config.processor_array_topology = ProcessorArrayTopology::RECTANGULAR;
     config.use_systolic_array_mode = true;
     config.dma_engine_count = 4;
-    config.block_mover_count = 16;
+    config.l3_layer.block_mover_count = 16;
     config.streamer_count = 64;
     return config;
 }

--- a/examples/mlp/mnist_classifier.cpp
+++ b/examples/mlp/mnist_classifier.cpp
@@ -233,8 +233,8 @@ int main() {
     KPUSimulator::Config config;
     config.memory_bank_count = 4;
     config.memory_bank_capacity_mb = 128;
-    config.l3_tile_count = 8;
-    config.l3_tile_capacity_kb = 256;
+    config.l3_layer.num_tiles = 8;
+    config.l3_layer.capacity_kb = 256;
     config.l2_bank_count = 16;
     config.l2_bank_capacity_kb = 64;
     config.l1_buffer_count = 8;

--- a/examples/mlp/sine_approximation.cpp
+++ b/examples/mlp/sine_approximation.cpp
@@ -184,8 +184,8 @@ int main() {
     KPUSimulator::Config config;
     config.memory_bank_count = 2;
     config.memory_bank_capacity_mb = 64;
-    config.l3_tile_count = 4;
-    config.l3_tile_capacity_kb = 128;
+    config.l3_layer.num_tiles = 4;
+    config.l3_layer.capacity_kb = 128;
     config.l2_bank_count = 8;
     config.l2_bank_capacity_kb = 64;
     config.l1_buffer_count = 4;

--- a/examples/mlp/xor_classifier.cpp
+++ b/examples/mlp/xor_classifier.cpp
@@ -136,8 +136,8 @@ int main() {
     KPUSimulator::Config config;
     config.memory_bank_count = 2;
     config.memory_bank_capacity_mb = 64;
-    config.l3_tile_count = 4;
-    config.l3_tile_capacity_kb = 128;
+    config.l3_layer.num_tiles = 4;
+    config.l3_layer.capacity_kb = 128;
     config.l2_bank_count = 8;
     config.l2_bank_capacity_kb = 64;
     config.l1_buffer_count = 4;

--- a/examples/runtime/runtime_demo.cpp
+++ b/examples/runtime/runtime_demo.cpp
@@ -119,14 +119,14 @@ int main() {
     KPUSimulator::Config sim_config;
     sim_config.memory_bank_count = 4;
     sim_config.memory_bank_capacity_mb = 256;
-    sim_config.l3_tile_count = 8;
-    sim_config.l3_tile_capacity_kb = 512;
+    sim_config.l3_layer.num_tiles = 8;
+    sim_config.l3_layer.capacity_kb = 512;
     sim_config.l2_bank_count = 16;
     sim_config.l2_bank_capacity_kb = 64;
     sim_config.l1_buffer_count = 4;
     sim_config.l1_buffer_capacity_kb = 64;
     sim_config.dma_engine_count = 4;
-    sim_config.block_mover_count = 8;
+    sim_config.l3_layer.block_mover_count = 8;
     sim_config.streamer_count = 16;
     sim_config.processor_array_rows = 16;
     sim_config.processor_array_cols = 16;
@@ -142,7 +142,7 @@ int main() {
     KPURuntime runtime(&simulator, rt_config);
 
     std::cout << "  Simulator: " << sim_config.memory_bank_count << " memory banks, "
-              << sim_config.l3_tile_count << " L3 tiles\n";
+              << sim_config.l3_layer.num_tiles << " L3 tiles\n";
     std::cout << "  Runtime:   Clock = " << rt_config.clock_ghz << " GHz\n";
     std::cout << "  Memory:    Total = " << format_bytes(runtime.get_total_memory())
               << ", Free = " << format_bytes(runtime.get_free_memory()) << "\n";

--- a/include/sw/kpu/kpu_simulator.hpp
+++ b/include/sw/kpu/kpu_simulator.hpp
@@ -69,8 +69,10 @@ public:
         Size page_buffer_capacity_kb;
 
         // On-chip memory hierarchy
-        Size l3_tile_count;
-        Size l3_tile_capacity_kb;
+        // L3 layer: aggregate config (tiles, block movers, interconnect).
+        // Use l3_layer.num_tiles / l3_layer.capacity_kb for a uniform layer, or
+        // l3_layer.tile_groups for a non-uniform one.
+        L3LayerConfig l3_layer;
         Size l2_bank_count;
         Size l2_bank_capacity_kb;
         // L1 streaming buffers: DERIVED from processor array configuration
@@ -81,8 +83,9 @@ public:
         Size l1_buffer_capacity_kb;
 
         // Data movement engines
+        // Note: BlockMovers are configured via l3_layer.block_mover_count
+        // (they are owned by the L3 layer).
         Size dma_engine_count;
-        Size block_mover_count;
         Size streamer_count;
 
         // Compute resources
@@ -111,10 +114,9 @@ public:
               memory_bandwidth_gbps(0),
               memory_controller_count(0),
               page_buffer_count(0), page_buffer_capacity_kb(0),
-              l3_tile_count(0), l3_tile_capacity_kb(0),
               l2_bank_count(0), l2_bank_capacity_kb(0),
               l1_buffer_count(0), l1_buffer_capacity_kb(0),
-              dma_engine_count(0), block_mover_count(0), streamer_count(0),
+              dma_engine_count(0), streamer_count(0),
               compute_tile_count(0),
               processor_array_rows(0), processor_array_cols(0),
               processor_array_topology(ProcessorArrayTopology::RECTANGULAR),

--- a/include/sw/kpu/models/temporal/memory/l3_layer.hpp
+++ b/include/sw/kpu/models/temporal/memory/l3_layer.hpp
@@ -56,9 +56,23 @@ struct L3TileGroup {
 };
 
 /// Configuration for an L3Layer aggregate.
+///
+/// Two ways to describe the tiles:
+///  - **Canonical (non-uniform):** populate `tile_groups` with named
+///    `group -> element-config -> multiplicity` entries.
+///  - **Uniform convenience:** leave `tile_groups` empty and set the scalar
+///    `num_tiles` / `capacity_kb` fields; the layer is then built as `num_tiles`
+///    identical tiles of `capacity_kb`. This is the path used while system
+///    configs remain uniform.
+/// When `tile_groups` is non-empty it takes precedence over the scalar fields.
 struct L3LayerConfig {
     /// Tile groups: group -> element-config -> multiplicity (supports non-uniform layers).
     std::vector<L3TileGroup> tile_groups;
+
+    /// Uniform convenience: number of identical tiles (used iff `tile_groups` empty).
+    size_t num_tiles = 0;
+    /// Uniform convenience: per-tile capacity in KB (used iff `tile_groups` empty).
+    Size capacity_kb = 128;
 
     /// Number of BlockMovers the layer owns (round-robin associated to tiles).
     /// Target micro-architecture is one BlockMover per L3Tile.
@@ -72,24 +86,24 @@ struct L3LayerConfig {
     double block_mover_clock_ghz = 1.0;
     double block_mover_bandwidth_gb_s = 100.0;
 
-    /// Total number of tiles across all groups.
+    /// Total number of tiles: sum of group multiplicities, or the uniform count.
     size_t total_tiles() const {
-        size_t n = 0;
-        for (const auto& g : tile_groups) {
-            n += g.multiplicity;
+        if (!tile_groups.empty()) {
+            size_t n = 0;
+            for (const auto& g : tile_groups) {
+                n += g.multiplicity;
+            }
+            return n;
         }
-        return n;
+        return num_tiles;
     }
 
-    /// Convenience constructor for a uniform layer: `num_tiles` identical tiles
-    /// of `capacity_kb`, with `block_mover_count` movers. Used to bridge the
-    /// legacy flat configuration until per-group config is wired through.
+    /// Convenience factory for a uniform layer.
     static L3LayerConfig uniform(size_t num_tiles, Size capacity_kb,
                                  size_t block_mover_count = 0) {
         L3LayerConfig cfg;
-        if (num_tiles > 0) {
-            cfg.tile_groups.push_back(L3TileGroup{"default", L3TileSpec{capacity_kb}, num_tiles});
-        }
+        cfg.num_tiles = num_tiles;
+        cfg.capacity_kb = capacity_kb;
         cfg.block_mover_count = block_mover_count;
         return cfg;
     }

--- a/models/kpu/test_debug_dataflow.cpp
+++ b/models/kpu/test_debug_dataflow.cpp
@@ -8,12 +8,12 @@ int main() {
     // Create minimal config
     KPUSimulator::Config config;
     config.memory_bank_count = 1;
-    config.l3_tile_count = 1;
+    config.l3_layer.num_tiles = 1;
     config.l2_bank_count = 1;
     config.l1_buffer_count = 1;
     config.l1_buffer_capacity_kb = 64;
     config.compute_tile_count = 1;
-    config.block_mover_count = 1;
+    config.l3_layer.block_mover_count = 1;
     config.streamer_count = 2;
     config.processor_array_rows = 16;
     config.processor_array_cols = 16;

--- a/src/system/simulator/kpu_simulator.cpp
+++ b/src/system/simulator/kpu_simulator.cpp
@@ -26,9 +26,7 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
 
     // Initialize the L3 layer aggregate - owns the L3Tiles, the per-tile
     // BlockMovers, and (optionally) the L3 interconnect.
-    l3_layer = L3Layer(L3LayerConfig::uniform(config.l3_tile_count,
-                                              config.l3_tile_capacity_kb,
-                                              config.block_mover_count));
+    l3_layer = L3Layer(config.l3_layer);
 
     // Initialize L2 banks - software-managed on-chip buffers
     l2_banks.reserve(config.l2_bank_count);
@@ -119,12 +117,13 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
         current_addr += capacity;
     }
 
-    // L3 tiles
+    // L3 tiles (capacities come from the constructed L3 layer; supports
+    // non-uniform tiles)
     if (config.l3_tile_base != 0) {
         current_addr = config.l3_tile_base;
     }
-    for (size_t i = 0; i < config.l3_tile_count; ++i) {
-        Size capacity = config.l3_tile_capacity_kb * 1024;
+    for (size_t i = 0; i < l3_layer.tile_count(); ++i) {
+        Size capacity = l3_layer.tile(i).get_capacity();
         address_decoder.add_region(current_addr, capacity, sw::memory::MemoryType::L3_TILE, i,
                                   "L3 Tile " + std::to_string(i));
         current_addr += capacity;

--- a/src/system/simulator/l3_layer.cpp
+++ b/src/system/simulator/l3_layer.cpp
@@ -8,14 +8,22 @@ namespace sw::kpu {
 
 L3Layer::L3Layer(const L3LayerConfig& config)
     : config_(config) {
-    // Materialize the L3Tile elements from the tile groups, assigning a global
-    // flat tile_id across all groups so the layer presents a single index space.
+    // Materialize the L3Tile elements, assigning a global flat tile_id so the
+    // layer presents a single index space. Prefer the canonical tile_groups;
+    // otherwise fall back to the uniform (num_tiles x capacity_kb) convenience.
     const size_t total = config_.total_tiles();
     tiles_.reserve(total);
     size_t global_id = 0;
-    for (const auto& group : config_.tile_groups) {
-        for (size_t k = 0; k < group.multiplicity; ++k) {
-            tiles_.emplace_back(global_id, group.tile.capacity_kb);
+    if (!config_.tile_groups.empty()) {
+        for (const auto& group : config_.tile_groups) {
+            for (size_t k = 0; k < group.multiplicity; ++k) {
+                tiles_.emplace_back(global_id, group.tile.capacity_kb);
+                ++global_id;
+            }
+        }
+    } else {
+        for (size_t k = 0; k < config_.num_tiles; ++k) {
+            tiles_.emplace_back(global_id, config_.capacity_kb);
             ++global_id;
         }
     }

--- a/src/system/toplevel.cpp
+++ b/src/system/toplevel.cpp
@@ -164,9 +164,9 @@ sw::kpu::KPUSimulator* SystemSimulator::create_kpu_from_config(const KPUConfig& 
     }
 
     // L3 and L2 configuration
-    sim_config.l3_tile_count = kpu_config.memory.l3_tiles.size();
+    sim_config.l3_layer.num_tiles = kpu_config.memory.l3_tiles.size();
     if (!kpu_config.memory.l3_tiles.empty()) {
-        sim_config.l3_tile_capacity_kb = kpu_config.memory.l3_tiles[0].capacity_kb;
+        sim_config.l3_layer.capacity_kb = kpu_config.memory.l3_tiles[0].capacity_kb;
     }
 
     sim_config.l2_bank_count = kpu_config.memory.l2_banks.size();
@@ -185,7 +185,7 @@ sw::kpu::KPUSimulator* SystemSimulator::create_kpu_from_config(const KPUConfig& 
 
     // Data movement configuration
     sim_config.dma_engine_count = kpu_config.data_movement.dma_engines.size();
-    sim_config.block_mover_count = kpu_config.data_movement.block_movers.size();
+    sim_config.l3_layer.block_mover_count = kpu_config.data_movement.block_movers.size();
     sim_config.streamer_count = kpu_config.data_movement.streamers.size();
 
     return new sw::kpu::KPUSimulator(sim_config);

--- a/src/tools/bindings/c/kpu_c_api.cpp
+++ b/src/tools/bindings/c/kpu_c_api.cpp
@@ -42,8 +42,8 @@ KPUHandle kpu_create(uint64_t main_memory_size, uint64_t scratchpad_size) {
             (main_memory_size / (1024 * 1024)) : 1024;  // Default 1GB
         config.memory_bandwidth_gbps = 100;
 
-        config.l3_tile_count = 1;
-        config.l3_tile_capacity_kb = (scratchpad_size > 0) ?
+        config.l3_layer.num_tiles = 1;
+        config.l3_layer.capacity_kb = (scratchpad_size > 0) ?
             (scratchpad_size / 1024) : 1024;  // Default 1MB
 
         config.compute_tile_count = 1;

--- a/src/tools/bindings/python/kpu_bindings.cpp
+++ b/src/tools/bindings/python/kpu_bindings.cpp
@@ -73,8 +73,14 @@ PYBIND11_MODULE(stillwater_kpu, m) {
         .def_readwrite("memory_bank_capacity_mb", &sw::kpu::KPUSimulator::Config::memory_bank_capacity_mb)
         .def_readwrite("memory_bandwidth_gbps", &sw::kpu::KPUSimulator::Config::memory_bandwidth_gbps)
         // On-chip memory hierarchy
-        .def_readwrite("l3_tile_count", &sw::kpu::KPUSimulator::Config::l3_tile_count)
-        .def_readwrite("l3_tile_capacity_kb", &sw::kpu::KPUSimulator::Config::l3_tile_capacity_kb)
+        // L3 tiles/block movers now live in the L3Layer aggregate config; these
+        // properties proxy into config.l3_layer for a uniform layer.
+        .def_property("l3_tile_count",
+            [](const sw::kpu::KPUSimulator::Config& c) { return c.l3_layer.num_tiles; },
+            [](sw::kpu::KPUSimulator::Config& c, size_t v) { c.l3_layer.num_tiles = v; })
+        .def_property("l3_tile_capacity_kb",
+            [](const sw::kpu::KPUSimulator::Config& c) { return c.l3_layer.capacity_kb; },
+            [](sw::kpu::KPUSimulator::Config& c, sw::kpu::Size v) { c.l3_layer.capacity_kb = v; })
         .def_readwrite("l2_bank_count", &sw::kpu::KPUSimulator::Config::l2_bank_count)
         .def_readwrite("l2_bank_capacity_kb", &sw::kpu::KPUSimulator::Config::l2_bank_capacity_kb)
         .def_readwrite("l1_buffer_count", &sw::kpu::KPUSimulator::Config::l1_buffer_count)
@@ -83,7 +89,10 @@ PYBIND11_MODULE(stillwater_kpu, m) {
         .def_readwrite("compute_tile_count", &sw::kpu::KPUSimulator::Config::compute_tile_count)
         // Data movement engines
         .def_readwrite("dma_engine_count", &sw::kpu::KPUSimulator::Config::dma_engine_count)
-        .def_readwrite("block_mover_count", &sw::kpu::KPUSimulator::Config::block_mover_count)
+        // BlockMovers are owned by the L3 layer; proxy into config.l3_layer.
+        .def_property("block_mover_count",
+            [](const sw::kpu::KPUSimulator::Config& c) { return c.l3_layer.block_mover_count; },
+            [](sw::kpu::KPUSimulator::Config& c, size_t v) { c.l3_layer.block_mover_count = v; })
         .def_readwrite("streamer_count", &sw::kpu::KPUSimulator::Config::streamer_count)
         // Processor array configuration
         .def_readwrite("processor_array_rows", &sw::kpu::KPUSimulator::Config::processor_array_rows)

--- a/tests/block_mover/test_block_mover_basic.cpp
+++ b/tests/block_mover/test_block_mover_basic.cpp
@@ -25,11 +25,11 @@ public:
         config.l1_buffer_capacity_kb = 256;
         config.compute_tile_count = 1;
         config.dma_engine_count = 4;
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 128;
+        config.l3_layer.num_tiles = 4;
+        config.l3_layer.capacity_kb = 128;
         config.l2_bank_count = 8;
         config.l2_bank_capacity_kb = 64;
-        config.block_mover_count = 4;
+        config.l3_layer.block_mover_count = 4;
 
         sim = std::make_unique<KPUSimulator>(config);
     }

--- a/tests/common/test_configs.hpp
+++ b/tests/common/test_configs.hpp
@@ -45,8 +45,8 @@ inline KPUSimulator::Config minimal_config() {
     c.memory_bank_count         = 1;
     c.memory_bank_capacity_mb   = 1;
     c.memory_bandwidth_gbps     = 8;
-    c.l3_tile_count             = 1;
-    c.l3_tile_capacity_kb       = 64;
+    c.l3_layer.num_tiles        = 1;
+    c.l3_layer.capacity_kb      = 64;
     c.l2_bank_count             = 1;
     c.l2_bank_capacity_kb       = 32;
     c.l1_buffer_count           = 1;
@@ -64,8 +64,8 @@ inline KPUSimulator::Config small_config() {
     c.memory_bank_count         = 2;
     c.memory_bank_capacity_mb   = 4;
     c.memory_bandwidth_gbps     = 8;
-    c.l3_tile_count             = 4;
-    c.l3_tile_capacity_kb       = 256;
+    c.l3_layer.num_tiles        = 4;
+    c.l3_layer.capacity_kb      = 256;
     c.l2_bank_count             = 4;
     c.l2_bank_capacity_kb       = 128;
     c.l1_buffer_count           = 2;
@@ -85,8 +85,8 @@ inline KPUSimulator::Config medium_config() {
     c.memory_bank_count         = 2;
     c.memory_bank_capacity_mb   = 16;
     c.memory_bandwidth_gbps     = 16;
-    c.l3_tile_count             = 4;
-    c.l3_tile_capacity_kb       = 1024;
+    c.l3_layer.num_tiles        = 4;
+    c.l3_layer.capacity_kb      = 1024;
     c.l2_bank_count             = 4;
     c.l2_bank_capacity_kb       = 512;
     c.l1_buffer_count           = 4;

--- a/tests/compute/test_systolic_array.cpp
+++ b/tests/compute/test_systolic_array.cpp
@@ -25,11 +25,11 @@ public:
         config.l1_buffer_capacity_kb = 256;
         config.compute_tile_count = 1;
         config.dma_engine_count = 2;
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 128;
+        config.l3_layer.num_tiles = 4;
+        config.l3_layer.capacity_kb = 128;
         config.l2_bank_count = 8;
         config.l2_bank_capacity_kb = 64;
-        config.block_mover_count = 4;
+        config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
 
         // Systolic array configuration

--- a/tests/dma/test_dma_basic.cpp
+++ b/tests/dma/test_dma_basic.cpp
@@ -108,7 +108,7 @@ TEST_CASE_METHOD(DMATestFixture, "DMA Basic Transfer - L3 Tile to External", "[d
 
 TEST_CASE_METHOD(DMATestFixture, "DMA Large Transfer", "[dma][large]") {
     // Test with L3 tile capacity
-    const size_t transfer_size = config.l3_tile_capacity_kb * 1024 / 2; // Half tile capacity
+    const size_t transfer_size = config.l3_layer.capacity_kb * 1024 / 2; // Half tile capacity
     const Address src_addr = 0x0;
     const Address dst_addr = 0x0;
 
@@ -141,7 +141,7 @@ TEST_CASE_METHOD(DMATestFixture, "DMA Concurrent Transfers", "[dma][concurrent]"
 
     // Setup transfers to different L3 tiles using different DMA engines
     std::vector<std::vector<uint8_t>> test_data_sets;
-    for (size_t i = 0; i < config.l3_tile_count && i < config.dma_engine_count; ++i) {
+    for (size_t i = 0; i < config.l3_layer.num_tiles && i < config.dma_engine_count; ++i) {
         auto data = generate_test_pattern(transfer_size, static_cast<uint8_t>(i * 0x10));
         test_data_sets.push_back(data);
 

--- a/tests/dma/test_dma_debug.cpp
+++ b/tests/dma/test_dma_debug.cpp
@@ -11,8 +11,8 @@ TEST_CASE("DMA Debug - Component Status", "[dma][debug]") {
     KPUSimulator::Config config;
     config.memory_bank_count = 2;
     config.memory_bank_capacity_mb = 4;
-    config.l3_tile_count = 2;
-    config.l3_tile_capacity_kb = 256;
+    config.l3_layer.num_tiles = 2;
+    config.l3_layer.capacity_kb = 256;
     config.dma_engine_count = 2;
 
     KPUSimulator sim(config);
@@ -33,8 +33,8 @@ TEST_CASE("DMA Debug - Transfer Verification", "[dma][debug]") {
     KPUSimulator::Config config;
     config.memory_bank_count = 1;
     config.memory_bank_capacity_mb = 4;
-    config.l3_tile_count = 1;
-    config.l3_tile_capacity_kb = 256;
+    config.l3_layer.num_tiles = 1;
+    config.l3_layer.capacity_kb = 256;
     config.dma_engine_count = 1;
 
     KPUSimulator sim(config);

--- a/tests/dma/test_dma_performance.cpp
+++ b/tests/dma/test_dma_performance.cpp
@@ -23,7 +23,7 @@ public:
         // than the default. Max transfer here is 8 KB - small_config()'s
         // memory sizing is fine.
         config.memory_bandwidth_gbps = 100;
-        config.l3_tile_capacity_kb   = 512;
+        config.l3_layer.capacity_kb   = 512;
         sim = std::make_unique<KPUSimulator>(config);
     }
 };
@@ -65,7 +65,7 @@ TEST_CASE_METHOD(DMAPerformanceFixture, "DMA Performance - Single Transfer Throu
 
 TEST_CASE_METHOD(DMAPerformanceFixture, "DMA Performance - Concurrent Transfers", "[dma][performance]") {
     const size_t transfer_size = 4096;
-    const size_t num_transfers = std::min(config.l3_tile_count, config.dma_engine_count);
+    const size_t num_transfers = std::min(config.l3_layer.num_tiles, config.dma_engine_count);
 
     // Setup data for each transfer
     std::vector<std::vector<uint8_t>> data_sets;

--- a/tests/dma/test_dma_tensor_movement.cpp
+++ b/tests/dma/test_dma_tensor_movement.cpp
@@ -22,7 +22,7 @@ public:
         // covers it; bandwidth and tile capacity are tuned higher
         // for the kind of timings this file exercises.
         config.memory_bandwidth_gbps = 100;
-        config.l3_tile_capacity_kb   = 512;
+        config.l3_layer.capacity_kb   = 512;
         sim = std::make_unique<KPUSimulator>(config);
     }
 
@@ -94,7 +94,7 @@ TEST_CASE_METHOD(TensorMovementFixture, "Tensor Movement - Multiple Tiles", "[dm
     const size_t tile_rows = 16;
     const size_t tile_cols = 16;
     const size_t tile_size = tile_rows * tile_cols * sizeof(float);
-    const size_t num_tiles = std::min(config.l3_tile_count, config.dma_engine_count);
+    const size_t num_tiles = std::min(config.l3_layer.num_tiles, config.dma_engine_count);
 
     // Create different tensors for each tile
     std::vector<std::vector<float>> tiles;
@@ -134,7 +134,7 @@ TEST_CASE_METHOD(TensorMovementFixture, "Tensor Movement - Large Tensor", "[dma]
     const size_t cols = 128;
     const size_t size = rows * cols * sizeof(float);
 
-    REQUIRE(size <= config.l3_tile_capacity_kb * 1024);
+    REQUIRE(size <= config.l3_layer.capacity_kb * 1024);
 
     auto tensor = create_tensor(rows, cols);
     sim->write_memory_bank(0, 0, tensor.data(), size);

--- a/tests/driver/test_all_resources.cpp
+++ b/tests/driver/test_all_resources.cpp
@@ -31,8 +31,8 @@ public:
         config.memory_bank_count = 2;
         config.memory_bank_capacity_mb = 8;
 
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 256;
+        config.l3_layer.num_tiles = 4;
+        config.l3_layer.capacity_kb = 256;
 
         config.l2_bank_count = 8;
         config.l2_bank_capacity_kb = 64;
@@ -45,7 +45,7 @@ public:
 
         config.compute_tile_count = 4;
         config.dma_engine_count = 2;
-        config.block_mover_count = 4;
+        config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
 
         simulator = std::make_unique<KPUSimulator>(config);

--- a/tests/driver/test_resource_api.cpp
+++ b/tests/driver/test_resource_api.cpp
@@ -95,13 +95,13 @@ TEST_CASE("ResourceManager resource discovery", "[resource_api]") {
     config.host_memory_region_count = 1;
     config.memory_bank_count = 2;
     config.memory_bank_capacity_mb = 128;  // 128 MB per bank
-    config.l3_tile_count = 4;
+    config.l3_layer.num_tiles = 4;
     config.l2_bank_count = 8;
     config.l1_buffer_count = 4;
     config.page_buffer_count = 2;
     config.compute_tile_count = 2;
     config.dma_engine_count = 4;
-    config.block_mover_count = 4;
+    config.l3_layer.block_mover_count = 4;
     config.streamer_count = 8;
 
     KPUSimulator simulator(config);

--- a/tests/runtime/test_executor.cpp
+++ b/tests/runtime/test_executor.cpp
@@ -29,8 +29,8 @@ protected:
         // 4 MB is plenty for runtime executor tests; the previous 64 MB
         // contributed to OOM under parallel Windows runs (see #22).
         config.memory_bank_capacity_mb = 4;
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 128;
+        config.l3_layer.num_tiles = 4;
+        config.l3_layer.capacity_kb = 128;
         config.l2_bank_count = 8;
         config.l2_bank_capacity_kb = 64;
         config.page_buffer_count = 2;
@@ -38,7 +38,7 @@ protected:
         config.l1_buffer_count = 4;
         config.l1_buffer_capacity_kb = 64;
         config.dma_engine_count = 2;
-        config.block_mover_count = 4;
+        config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
         config.processor_array_rows = 16;
         config.processor_array_cols = 16;

--- a/tests/runtime/test_graph.cpp
+++ b/tests/runtime/test_graph.cpp
@@ -28,8 +28,8 @@ protected:
         // 4 MB is plenty for runtime graph tests; the previous 64 MB
         // contributed to OOM under parallel Windows runs (see #22).
         config.memory_bank_capacity_mb = 4;
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 128;
+        config.l3_layer.num_tiles = 4;
+        config.l3_layer.capacity_kb = 128;
         config.l2_bank_count = 8;
         config.l2_bank_capacity_kb = 64;
         config.page_buffer_count = 2;
@@ -37,7 +37,7 @@ protected:
         config.l1_buffer_count = 4;
         config.l1_buffer_capacity_kb = 64;
         config.dma_engine_count = 2;
-        config.block_mover_count = 4;
+        config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
         config.processor_array_rows = 16;
         config.processor_array_cols = 16;

--- a/tests/runtime/test_runtime.cpp
+++ b/tests/runtime/test_runtime.cpp
@@ -29,8 +29,8 @@ protected:
         // 4 MB is plenty for runtime tests; the previous 64 MB
         // contributed to OOM under parallel Windows runs (see #22).
         config.memory_bank_capacity_mb = 4;
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 128;
+        config.l3_layer.num_tiles = 4;
+        config.l3_layer.capacity_kb = 128;
         config.l2_bank_count = 8;
         config.l2_bank_capacity_kb = 64;
         config.page_buffer_count = 2;
@@ -38,7 +38,7 @@ protected:
         config.l1_buffer_count = 4;
         config.l1_buffer_capacity_kb = 64;
         config.dma_engine_count = 2;
-        config.block_mover_count = 4;
+        config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
         config.processor_array_rows = 16;
         config.processor_array_cols = 16;

--- a/tests/streamer/test_streamer_basic.cpp
+++ b/tests/streamer/test_streamer_basic.cpp
@@ -25,11 +25,11 @@ public:
         config.l1_buffer_capacity_kb = 256;
         config.compute_tile_count = 1;
         config.dma_engine_count = 4;
-        config.l3_tile_count = 4;
-        config.l3_tile_capacity_kb = 128;
+        config.l3_layer.num_tiles = 4;
+        config.l3_layer.capacity_kb = 128;
         config.l2_bank_count = 8;
         config.l2_bank_capacity_kb = 64;
-        config.block_mover_count = 4;
+        config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
 
         sim = std::make_unique<KPUSimulator>(config);

--- a/tools/runner/kpu_runner.cpp
+++ b/tools/runner/kpu_runner.cpp
@@ -70,11 +70,11 @@ KPUSimulator::Config convert_config(const SimulatorConfig& sim_config) {
     config.page_buffer_capacity_kb = 32;
 
     // On-chip memory hierarchy
-    config.l3_tile_count = sim_config.num_l3_tiles;
+    config.l3_layer.num_tiles = sim_config.num_l3_tiles;
     if (sim_config.l3_tile) {
-        config.l3_tile_capacity_kb = sim_config.l3_tile->capacity_kb;
+        config.l3_layer.capacity_kb = sim_config.l3_tile->capacity_kb;
     } else {
-        config.l3_tile_capacity_kb = 256;  // Default
+        config.l3_layer.capacity_kb = 256;  // Default
     }
 
     config.l2_bank_count = sim_config.num_l2_banks;
@@ -87,9 +87,9 @@ KPUSimulator::Config convert_config(const SimulatorConfig& sim_config) {
     // Data movement
     config.dma_engine_count = sim_config.num_dma_engines;
     if (sim_config.dma_engine) {
-        config.block_mover_count = sim_config.dma_engine->num_channels;
+        config.l3_layer.block_mover_count = sim_config.dma_engine->num_channels;
     } else {
-        config.block_mover_count = sim_config.num_l3_tiles;
+        config.l3_layer.block_mover_count = sim_config.num_l3_tiles;
     }
     config.streamer_count = sim_config.num_l3_tiles * 4;
 

--- a/tools/runtime/kpu-loader/schedule_binder.cpp
+++ b/tools/runtime/kpu-loader/schedule_binder.cpp
@@ -55,7 +55,7 @@ BoundSchedule ScheduleBinder::bind(const dfx::Program& program) {
                      (src_level == dfx::MemoryLevel::L2 && dst_level == dfx::MemoryLevel::L3)) {
                 // Use BlockMover for L3↔L2 transfers
                 bound.block_mover_id = current_block_mover;
-                current_block_mover = (current_block_mover + 1) % config_.block_mover_count;
+                current_block_mover = (current_block_mover + 1) % config_.l3_layer.block_mover_count;
                 schedule.resources.block_movers_used =
                     std::max(schedule.resources.block_movers_used, current_block_mover + 1);
             }
@@ -70,7 +70,7 @@ BoundSchedule ScheduleBinder::bind(const dfx::Program& program) {
 
             // Allocate memory resources
             bound.l3_tile_id = current_l3_tile;
-            current_l3_tile = (current_l3_tile + 1) % config_.l3_tile_count;
+            current_l3_tile = (current_l3_tile + 1) % config_.l3_layer.num_tiles;
 
             bound.l2_bank_id = current_l2_bank;
             current_l2_bank = (current_l2_bank + 1) % config_.l2_bank_count;


### PR DESCRIPTION
## Summary

Completes #32 (Phase 1C — the hard break). Removes the flat L3 fields from
`KPUSimulator::Config` and routes them through the `L3Layer` aggregate config
introduced in #37. Per the approved plan (`docs/plans/memory-layer-restructuring.md`),
**no backward-compat shims**; system configs stay **uniform** this pass.

## Migration

| Old | New |
|-----|-----|
| `config.l3_tile_count` | `config.l3_layer.num_tiles` |
| `config.l3_tile_capacity_kb` | `config.l3_layer.capacity_kb` |
| `config.block_mover_count` | `config.l3_layer.block_mover_count` |

- `L3LayerConfig` gains ergonomic scalar uniform fields (`num_tiles`,
  `capacity_kb`) alongside the canonical `tile_groups`
  (`group → element-config → multiplicity`). Non-uniform layers populate
  `tile_groups`; this pass keeps configs uniform.
- The simulator builds L3 address-map regions from the constructed layer
  (per-tile capacity), so non-uniform tiles are already supported.
- `config.l3_tile_base` (memory-map base) retained.

## Scope of the change (~30 call sites)

- Examples, tests, `tools/`, `src/system/toplevel.cpp`, and the C API
  (`kpu_c_api.cpp`, which builds a C++ `Config`).
- **Python**: keeps the `l3_tile_count` / `l3_tile_capacity_kb` /
  `block_mover_count` attribute names via `def_property` proxies into
  `l3_layer` (binding-layer convenience; the C++ Config is hard-broken).
- **Untouched on purpose**: the C ABI struct `KPUSimulatorConfig`
  (`kpu_c_types.h`) — separate public ABI; and the unrelated `MemoryModelConfig`
  / `HardwareConfig` / `L3SchedulerConfig` structs that coincidentally share
  field names.

## Validation

- Build green on **linux-gcc**; **95/95** ctest pass.
- CHANGELOG updated with the breaking-change migration.
- CI will additionally cover Windows/MSVC + Clang.

## Note

`src/system/simulator/kpu_simulator_old.cpp` is a dead file (not in any CMake
target) and still references the old fields; left untouched (out of scope).

Closes #32 · epic #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)