### PR TITLE
refactor(l2)!: introduce L2Layer aggregate, replace flat L2 Config (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING — L2 memory layer restructuring (#33).** Introduced the `L2Layer`
+  aggregate (owns the `L2Bank` elements) and removed the flat L2 fields from
+  `KPUSimulator::Config`. Migration:
+  - `config.l2_bank_count`        → `config.l2_layer.num_banks`
+  - `config.l2_bank_capacity_kb`  → `config.l2_layer.capacity_kb`
+  - For non-uniform layers, populate `config.l2_layer.bank_groups`
+    (`group → element-config → multiplicity`) instead of the scalar fields.
+  - `config.l2_bank_base` is unchanged. No backward-compatibility shims. Python
+    keeps the `l2_bank_count` / `l2_bank_capacity_kb` attribute names (they proxy
+    into `l2_layer`); the C ABI struct `KPUSimulatorConfig` is unchanged.
+
 - **BREAKING — L3 memory layer restructuring (#32).** Introduced the `L3Layer`
   aggregate (owns the `L3Tile` elements, the per-tile `BlockMover`s, and an
   optional `L3Interconnect`) and removed the flat L3 fields from

--- a/examples/basic/data_movement_pipeline.cpp
+++ b/examples/basic/data_movement_pipeline.cpp
@@ -9,7 +9,7 @@ int main() {
     KPUSimulator::Config config;
     config.memory_bank_count = 1;
     config.l3_layer.num_tiles = 1;
-    config.l2_bank_count = 1;
+    config.l2_layer.num_banks = 1;
     config.l1_buffer_count = 1;
     config.l1_buffer_capacity_kb = 64;
     config.compute_tile_count = 1;

--- a/examples/basic/host_to_l3_matmul.cpp
+++ b/examples/basic/host_to_l3_matmul.cpp
@@ -154,8 +154,8 @@ This example demonstrates the full data flow for matrix multiplication:
     config.page_buffer_capacity_kb = 32;
     config.l3_layer.num_tiles = 1;
     config.l3_layer.capacity_kb = 128;
-    config.l2_bank_count = 4;
-    config.l2_bank_capacity_kb = 64;
+    config.l2_layer.num_banks = 4;
+    config.l2_layer.capacity_kb = 64;
     config.l1_buffer_count = 64;
     config.l1_buffer_capacity_kb = 64;
     config.compute_tile_count = 1;
@@ -175,8 +175,8 @@ This example demonstrates the full data flow for matrix multiplication:
               << config.memory_bank_capacity_mb << " MB\n";
     std::cout << "  L3 Tiles:        " << config.l3_layer.num_tiles << " × "
               << config.l3_layer.capacity_kb << " KB\n";
-    std::cout << "  L2 Banks:        " << config.l2_bank_count << " × "
-              << config.l2_bank_capacity_kb << " KB\n";
+    std::cout << "  L2 Banks:        " << config.l2_layer.num_banks << " × "
+              << config.l2_layer.capacity_kb << " KB\n";
     std::cout << "  L1 Buffers:      " << config.l1_buffer_count << " × "
               << config.l1_buffer_capacity_kb << " KB\n";
     std::cout << "  Systolic Array:  " << config.processor_array_rows << "×"

--- a/examples/basic/memory_management.cpp
+++ b/examples/basic/memory_management.cpp
@@ -42,8 +42,8 @@ int main() {
     config.dma_engine_count = 4;
     config.l3_layer.num_tiles = 4;
     config.l3_layer.capacity_kb = 256;
-    config.l2_bank_count = 8;
-    config.l2_bank_capacity_kb = 64;
+    config.l2_layer.num_banks = 8;
+    config.l2_layer.capacity_kb = 64;
     config.l3_layer.block_mover_count = 4;
     config.streamer_count = 8;
 

--- a/examples/basic/resource_api_demo.cpp
+++ b/examples/basic/resource_api_demo.cpp
@@ -88,8 +88,8 @@ int main() {
     config.l3_layer.num_tiles = 8;
     config.l3_layer.capacity_kb = 512;
 
-    config.l2_bank_count = 16;
-    config.l2_bank_capacity_kb = 128;
+    config.l2_layer.num_banks = 16;
+    config.l2_layer.capacity_kb = 128;
 
     config.l1_buffer_count = 32;
     config.l1_buffer_capacity_kb = 16;

--- a/examples/blas/big_matmul.cpp
+++ b/examples/blas/big_matmul.cpp
@@ -98,8 +98,8 @@ KPUSimulator::Config create_config() {
     config.page_buffer_capacity_kb = 32;
     config.l3_layer.num_tiles = 16;
     config.l3_layer.capacity_kb = 512;
-    config.l2_bank_count = 64;
-    config.l2_bank_capacity_kb = 32;
+    config.l2_layer.num_banks = 64;
+    config.l2_layer.capacity_kb = 32;
     config.l1_buffer_count = 3072;
     config.l1_buffer_capacity_kb = 64;
     config.compute_tile_count = 16;

--- a/examples/mlp/mnist_classifier.cpp
+++ b/examples/mlp/mnist_classifier.cpp
@@ -235,8 +235,8 @@ int main() {
     config.memory_bank_capacity_mb = 128;
     config.l3_layer.num_tiles = 8;
     config.l3_layer.capacity_kb = 256;
-    config.l2_bank_count = 16;
-    config.l2_bank_capacity_kb = 64;
+    config.l2_layer.num_banks = 16;
+    config.l2_layer.capacity_kb = 64;
     config.l1_buffer_count = 8;
     config.l1_buffer_capacity_kb = 64;
     config.processor_array_rows = 16;

--- a/examples/mlp/sine_approximation.cpp
+++ b/examples/mlp/sine_approximation.cpp
@@ -186,8 +186,8 @@ int main() {
     config.memory_bank_capacity_mb = 64;
     config.l3_layer.num_tiles = 4;
     config.l3_layer.capacity_kb = 128;
-    config.l2_bank_count = 8;
-    config.l2_bank_capacity_kb = 64;
+    config.l2_layer.num_banks = 8;
+    config.l2_layer.capacity_kb = 64;
     config.l1_buffer_count = 4;
     config.l1_buffer_capacity_kb = 64;
     config.processor_array_rows = 16;

--- a/examples/mlp/xor_classifier.cpp
+++ b/examples/mlp/xor_classifier.cpp
@@ -138,8 +138,8 @@ int main() {
     config.memory_bank_capacity_mb = 64;
     config.l3_layer.num_tiles = 4;
     config.l3_layer.capacity_kb = 128;
-    config.l2_bank_count = 8;
-    config.l2_bank_capacity_kb = 64;
+    config.l2_layer.num_banks = 8;
+    config.l2_layer.capacity_kb = 64;
     config.l1_buffer_count = 4;
     config.l1_buffer_capacity_kb = 64;
     config.processor_array_rows = 16;

--- a/examples/runtime/runtime_demo.cpp
+++ b/examples/runtime/runtime_demo.cpp
@@ -121,8 +121,8 @@ int main() {
     sim_config.memory_bank_capacity_mb = 256;
     sim_config.l3_layer.num_tiles = 8;
     sim_config.l3_layer.capacity_kb = 512;
-    sim_config.l2_bank_count = 16;
-    sim_config.l2_bank_capacity_kb = 64;
+    sim_config.l2_layer.num_banks = 16;
+    sim_config.l2_layer.capacity_kb = 64;
     sim_config.l1_buffer_count = 4;
     sim_config.l1_buffer_capacity_kb = 64;
     sim_config.dma_engine_count = 4;

--- a/include/sw/kpu/kpu_simulator.hpp
+++ b/include/sw/kpu/kpu_simulator.hpp
@@ -74,8 +74,10 @@ public:
         // Use l3_layer.num_tiles / l3_layer.capacity_kb for a uniform layer, or
         // l3_layer.tile_groups for a non-uniform one.
         L3LayerConfig l3_layer;
-        Size l2_bank_count;
-        Size l2_bank_capacity_kb;
+        // L2 layer: aggregate config (banks). Use l2_layer.num_banks /
+        // l2_layer.capacity_kb for a uniform layer, or l2_layer.bank_groups
+        // for a non-uniform one.
+        L2LayerConfig l2_layer;
         // L1 streaming buffers: DERIVED from processor array configuration
         // For rectangular arrays: 4 × (rows + cols) per compute tile
         // For hexagonal arrays: 12 × side_length per compute tile
@@ -115,7 +117,6 @@ public:
               memory_bandwidth_gbps(0),
               memory_controller_count(0),
               page_buffer_count(0), page_buffer_capacity_kb(0),
-              l2_bank_count(0), l2_bank_capacity_kb(0),
               l1_buffer_count(0), l1_buffer_capacity_kb(0),
               dma_engine_count(0), streamer_count(0),
               compute_tile_count(0),

--- a/include/sw/kpu/kpu_simulator.hpp
+++ b/include/sw/kpu/kpu_simulator.hpp
@@ -39,6 +39,7 @@
 #include <sw/kpu/models/temporal/memory/l3_tile.hpp>
 #include <sw/kpu/models/temporal/memory/l3_layer.hpp>
 #include <sw/kpu/models/temporal/memory/l2_bank.hpp>
+#include <sw/kpu/models/temporal/memory/l2_layer.hpp>
 #include <sw/kpu/models/temporal/memory/l1_buffer.hpp>
 #include <sw/kpu/models/temporal/datamovement/block_mover.hpp>
 #include <sw/kpu/models/temporal/datamovement/streamer.hpp>
@@ -145,7 +146,7 @@ private:
     std::vector<ExternalMemory> host_memory_regions;  // Host system memory (NUMA regions)
     std::vector<ExternalMemory> memory_banks;  // KPU local memory banks
     L3Layer l3_layer;  // SoC-wide L3 aggregate: owns L3Tiles, BlockMovers, interconnect
-    std::vector<L2Bank> l2_banks;
+    L2Layer l2_layer;  // SoC-wide L2 aggregate: owns L2Banks
     std::vector<L1Buffer> l1_buffers;  // L1 streaming buffers (compute fabric)
     std::vector<PageBuffer> page_buffers;  // Page buffers (memory controller)
     std::vector<DMAEngine> dma_engines;
@@ -285,7 +286,7 @@ public:
     size_t get_host_memory_region_count() const { return host_memory_regions.size(); }
     size_t get_memory_bank_count() const { return memory_banks.size(); }
     size_t get_l3_tile_count() const { return l3_layer.tile_count(); }
-    size_t get_l2_bank_count() const { return l2_banks.size(); }
+    size_t get_l2_bank_count() const { return l2_layer.bank_count(); }
     size_t get_l1_buffer_count() const { return l1_buffers.size(); }
     size_t get_page_buffer_count() const { return page_buffers.size(); }
     size_t get_compute_tile_count() const { return compute_tiles.size(); }

--- a/include/sw/kpu/models/temporal/memory/l2_layer.hpp
+++ b/include/sw/kpu/models/temporal/memory/l2_layer.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+// Windows/MSVC compatibility
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4251) // DLL interface warnings
+    #ifdef BUILDING_KPU_SIMULATOR
+        #define KPU_API __declspec(dllexport)
+    #else
+        #define KPU_API __declspec(dllimport)
+    #endif
+#else
+    #define KPU_API
+#endif
+
+#include <sw/concepts.hpp>
+#include <sw/kpu/models/temporal/memory/l2_bank.hpp>
+
+namespace sw::kpu {
+
+// ============================================================================
+// L2 Layer configuration
+//
+// The L2 layer is the whole SoC-wide L2 resource that sits between the L3 layer
+// and the stream buffers feeding the compute fabric: a (possibly non-uniform)
+// collection of L2Bank elements plus the layer's access ports. Element
+// micro-architecture (capacity, ports) belongs to the element; the *layer*
+// describes how many elements there are and their grouping.
+//
+// Non-uniformity (heterogeneous compute fabrics) is expressed with the
+// `group -> element-config -> multiplicity` shape: each named group binds one
+// element spec to a count of identical banks, and a layer holds many groups.
+//
+// (An L2 interconnect/topology is intentionally out of scope for now; see the
+//  memory-layer restructuring plan.)
+// ============================================================================
+
+/// Per-element (L2Bank) micro-architecture spec at the temporal-model level.
+struct L2BankSpec {
+    /// Capacity per bank in KB.
+    Size capacity_kb = 64;
+};
+
+/// A named group of identical L2Banks: element-config bound to a multiplicity.
+struct L2BankGroup {
+    std::string name;          ///< Symbolic group name (e.g. "default").
+    L2BankSpec bank;           ///< Element configuration shared by the group.
+    size_t multiplicity = 1;   ///< Number of identical banks in the group.
+};
+
+/// Configuration for an L2Layer aggregate.
+///
+/// Two ways to describe the banks:
+///  - **Canonical (non-uniform):** populate `bank_groups` with named
+///    `group -> element-config -> multiplicity` entries.
+///  - **Uniform convenience:** leave `bank_groups` empty and set the scalar
+///    `num_banks` / `capacity_kb` fields; the layer is then built as `num_banks`
+///    identical banks of `capacity_kb`.
+/// When `bank_groups` is non-empty it takes precedence over the scalar fields.
+struct L2LayerConfig {
+    /// Bank groups: group -> element-config -> multiplicity (supports non-uniform layers).
+    std::vector<L2BankGroup> bank_groups;
+
+    /// Uniform convenience: number of identical banks (used iff `bank_groups` empty).
+    size_t num_banks = 0;
+    /// Uniform convenience: per-bank capacity in KB (used iff `bank_groups` empty).
+    Size capacity_kb = 64;
+
+    /// Total number of banks: sum of group multiplicities, or the uniform count.
+    size_t total_banks() const {
+        if (!bank_groups.empty()) {
+            size_t n = 0;
+            for (const auto& g : bank_groups) {
+                n += g.multiplicity;
+            }
+            return n;
+        }
+        return num_banks;
+    }
+
+    /// Convenience factory for a uniform layer.
+    static L2LayerConfig uniform(size_t num_banks, Size capacity_kb) {
+        L2LayerConfig cfg;
+        cfg.num_banks = num_banks;
+        cfg.capacity_kb = capacity_kb;
+        return cfg;
+    }
+};
+
+// ============================================================================
+// L2 Layer aggregate
+// ============================================================================
+
+/// The whole SoC-wide L2 resource. Owns the L2Bank elements.
+class KPU_API L2Layer {
+public:
+    explicit L2Layer(const L2LayerConfig& config = {});
+
+    // --- L2Bank elements -----------------------------------------------------
+    size_t bank_count() const { return banks_.size(); }
+    L2Bank& bank(size_t index);
+    const L2Bank& bank(size_t index) const;
+
+    /// Direct access to the bank collection, for components whose APIs take a
+    /// `std::vector<L2Bank>&` (e.g. the BlockMover and Streamer).
+    std::vector<L2Bank>& banks() { return banks_; }
+    const std::vector<L2Bank>& banks() const { return banks_; }
+
+    // --- Lifecycle -----------------------------------------------------------
+    void reset();
+
+    const L2LayerConfig& config() const { return config_; }
+
+private:
+    L2LayerConfig config_;
+    std::vector<L2Bank> banks_;
+};
+
+} // namespace sw::kpu
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif

--- a/models/kpu/test_debug_dataflow.cpp
+++ b/models/kpu/test_debug_dataflow.cpp
@@ -9,7 +9,7 @@ int main() {
     KPUSimulator::Config config;
     config.memory_bank_count = 1;
     config.l3_layer.num_tiles = 1;
-    config.l2_bank_count = 1;
+    config.l2_layer.num_banks = 1;
     config.l1_buffer_count = 1;
     config.l1_buffer_capacity_kb = 64;
     config.compute_tile_count = 1;

--- a/src/system/simulator/CMakeLists.txt
+++ b/src/system/simulator/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(KPU_SIMULATOR_SOURCES
     kpu_simulator.cpp
     l3_layer.cpp
+    l2_layer.cpp
     resource_manager.cpp
     kernel.cpp
     kernel_serializer.cpp

--- a/src/system/simulator/kpu_simulator.cpp
+++ b/src/system/simulator/kpu_simulator.cpp
@@ -28,11 +28,9 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
     // BlockMovers, and (optionally) the L3 interconnect.
     l3_layer = L3Layer(config.l3_layer);
 
-    // Initialize L2 banks - software-managed on-chip buffers
-    l2_banks.reserve(config.l2_bank_count);
-    for (size_t i = 0; i < config.l2_bank_count; ++i) {
-        l2_banks.emplace_back(i, config.l2_bank_capacity_kb);
-    }
+    // Initialize the L2 layer aggregate - owns the L2Banks.
+    l2_layer = L2Layer(L2LayerConfig::uniform(config.l2_bank_count,
+                                              config.l2_bank_capacity_kb));
 
     // Initialize L1 streaming buffers - part of compute fabric
     l1_buffers.reserve(config.l1_buffer_count);
@@ -217,12 +215,12 @@ void KPUSimulator::write_l3_tile(size_t tile_id, Address addr, const void* data,
 
 void KPUSimulator::read_l2_bank(size_t bank_id, Address addr, void* data, Size size) {
     validate_l2_bank_id(bank_id);
-    l2_banks[bank_id].read(addr, data, size);
+    l2_layer.banks()[bank_id].read(addr, data, size);
 }
 
 void KPUSimulator::write_l2_bank(size_t bank_id, Address addr, const void* data, Size size) {
     validate_l2_bank_id(bank_id);
-    l2_banks[bank_id].write(addr, data, size);
+    l2_layer.banks()[bank_id].write(addr, data, size);
 }
 
 void KPUSimulator::read_l1_buffer(size_t buffer_id, Address addr, void* data, Size size) {
@@ -432,7 +430,7 @@ void KPUSimulator::reset() {
     for (auto& l3_tile : l3_layer.tiles()) {
         l3_tile.reset();
     }
-    for (auto& l2_bank : l2_banks) {
+    for (auto& l2_bank : l2_layer.banks()) {
         l2_bank.reset();
     }
     for (auto& l1_buffer : l1_buffers) {
@@ -480,10 +478,10 @@ void KPUSimulator::step() {
         dma.process_transfers(host_memory_regions, memory_banks, l3_layer.tiles());
     }
     for (auto& block_mover : l3_layer.block_movers()) {
-        block_mover.process_transfers(l3_layer.tiles(), l2_banks);
+        block_mover.process_transfers(l3_layer.tiles(), l2_layer.banks());
     }
     for (auto& streamer : streamers) {
-        streamer.update(current_cycle, l2_banks, l1_buffers);
+        streamer.update(current_cycle, l2_layer.banks(), l1_buffers);
     }
     for (auto& tile : compute_tiles) {
         tile.update(current_cycle, l1_buffers);
@@ -542,7 +540,7 @@ Size KPUSimulator::get_l3_tile_capacity(size_t tile_id) const {
 
 Size KPUSimulator::get_l2_bank_capacity(size_t bank_id) const {
     validate_l2_bank_id(bank_id);
-    return l2_banks[bank_id].get_capacity();
+    return l2_layer.banks()[bank_id].get_capacity();
 }
 
 Size KPUSimulator::get_l1_buffer_capacity(size_t buffer_id) const {
@@ -568,7 +566,7 @@ void KPUSimulator::print_stats() const {
     std::cout << "Wall-clock time: " << get_elapsed_time_ms() << " ms" << std::endl;
     std::cout << "Memory banks: " << memory_banks.size() << std::endl;
     std::cout << "L3 tiles: " << l3_layer.tiles().size() << std::endl;
-    std::cout << "L2 banks: " << l2_banks.size() << std::endl;
+    std::cout << "L2 banks: " << l2_layer.banks().size() << std::endl;
     std::cout << "L1 buffers: " << l1_buffers.size() << std::endl;
     std::cout << "Page buffers: " << page_buffers.size() << std::endl;
     std::cout << "Compute tiles: " << compute_tiles.size() << std::endl;
@@ -606,9 +604,9 @@ void KPUSimulator::print_component_status() const {
     }
 
     std::cout << "L2 Banks:" << std::endl;
-    for (size_t i = 0; i < l2_banks.size(); ++i) {
-        std::cout << "  L2Bank[" << i << "]: " << l2_banks[i].get_capacity() / 1024
-                  << " KB, Ready: " << (l2_banks[i].is_ready() ? "Yes" : "No") << std::endl;
+    for (size_t i = 0; i < l2_layer.banks().size(); ++i) {
+        std::cout << "  L2Bank[" << i << "]: " << l2_layer.banks()[i].get_capacity() / 1024
+                  << " KB, Ready: " << (l2_layer.banks()[i].is_ready() ? "Yes" : "No") << std::endl;
     }
 
     std::cout << "L1 Buffers (Compute Fabric):" << std::endl;
@@ -651,7 +649,7 @@ bool KPUSimulator::is_l3_tile_ready(size_t tile_id) const {
 
 bool KPUSimulator::is_l2_bank_ready(size_t bank_id) const {
     validate_l2_bank_id(bank_id);
-    return l2_banks[bank_id].is_ready();
+    return l2_layer.banks()[bank_id].is_ready();
 }
 
 bool KPUSimulator::is_l1_buffer_ready(size_t buffer_id) const {
@@ -702,7 +700,7 @@ void KPUSimulator::validate_l3_tile_id(size_t tile_id) const {
 }
 
 void KPUSimulator::validate_l2_bank_id(size_t bank_id) const {
-    if (bank_id >= l2_banks.size()) {
+    if (bank_id >= l2_layer.banks().size()) {
         throw std::out_of_range("Invalid L2 bank ID: " + std::to_string(bank_id));
     }
 }
@@ -928,7 +926,7 @@ Address KPUSimulator::get_l2_bank_base(size_t bank_id) const {
     }
     // Then add offsets for L2 banks before this one
     for (size_t i = 0; i < bank_id; ++i) {
-        base += l2_banks[i].get_capacity();
+        base += l2_layer.banks()[i].get_capacity();
     }
     return base;
 }
@@ -946,7 +944,7 @@ Address KPUSimulator::get_l1_buffer_base(size_t buffer_id) const {
     for (const auto& tile : l3_layer.tiles()) {
         base += tile.get_capacity();
     }
-    for (const auto& bank : l2_banks) {
+    for (const auto& bank : l2_layer.banks()) {
         base += bank.get_capacity();
     }
     // Then add offsets for L1 buffers before this one
@@ -969,7 +967,7 @@ Address KPUSimulator::get_page_buffer_base(size_t pad_id) const {
     for (const auto& tile : l3_layer.tiles()) {
         base += tile.get_capacity();
     }
-    for (const auto& bank : l2_banks) {
+    for (const auto& bank : l2_layer.banks()) {
         base += bank.get_capacity();
     }
     for (const auto& buffer : l1_buffers) {

--- a/src/system/simulator/kpu_simulator.cpp
+++ b/src/system/simulator/kpu_simulator.cpp
@@ -29,8 +29,7 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
     l3_layer = L3Layer(config.l3_layer);
 
     // Initialize the L2 layer aggregate - owns the L2Banks.
-    l2_layer = L2Layer(L2LayerConfig::uniform(config.l2_bank_count,
-                                              config.l2_bank_capacity_kb));
+    l2_layer = L2Layer(config.l2_layer);
 
     // Initialize L1 streaming buffers - part of compute fabric
     l1_buffers.reserve(config.l1_buffer_count);
@@ -127,12 +126,13 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
         current_addr += capacity;
     }
 
-    // L2 banks
+    // L2 banks (capacities come from the constructed L2 layer; supports
+    // non-uniform banks)
     if (config.l2_bank_base != 0) {
         current_addr = config.l2_bank_base;
     }
-    for (size_t i = 0; i < config.l2_bank_count; ++i) {
-        Size capacity = config.l2_bank_capacity_kb * 1024;
+    for (size_t i = 0; i < l2_layer.bank_count(); ++i) {
+        Size capacity = l2_layer.bank(i).get_capacity();
         address_decoder.add_region(current_addr, capacity, sw::memory::MemoryType::L2_BANK, i,
                                   "L2 Bank " + std::to_string(i));
         current_addr += capacity;

--- a/src/system/simulator/l2_layer.cpp
+++ b/src/system/simulator/l2_layer.cpp
@@ -1,0 +1,53 @@
+#include <sw/kpu/models/temporal/memory/l2_layer.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace sw::kpu {
+
+L2Layer::L2Layer(const L2LayerConfig& config)
+    : config_(config) {
+    // Materialize the L2Bank elements, assigning a global flat bank_id so the
+    // layer presents a single index space. Prefer the canonical bank_groups;
+    // otherwise fall back to the uniform (num_banks x capacity_kb) convenience.
+    const size_t total = config_.total_banks();
+    banks_.reserve(total);
+    size_t global_id = 0;
+    if (!config_.bank_groups.empty()) {
+        for (const auto& group : config_.bank_groups) {
+            for (size_t k = 0; k < group.multiplicity; ++k) {
+                banks_.emplace_back(global_id, group.bank.capacity_kb);
+                ++global_id;
+            }
+        }
+    } else {
+        for (size_t k = 0; k < config_.num_banks; ++k) {
+            banks_.emplace_back(global_id, config_.capacity_kb);
+            ++global_id;
+        }
+    }
+}
+
+L2Bank& L2Layer::bank(size_t index) {
+    if (index >= banks_.size()) {
+        throw std::out_of_range("L2Layer::bank: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(banks_.size()) + " banks)");
+    }
+    return banks_[index];
+}
+
+const L2Bank& L2Layer::bank(size_t index) const {
+    if (index >= banks_.size()) {
+        throw std::out_of_range("L2Layer::bank: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(banks_.size()) + " banks)");
+    }
+    return banks_[index];
+}
+
+void L2Layer::reset() {
+    for (auto& bank : banks_) {
+        bank.reset();
+    }
+}
+
+} // namespace sw::kpu

--- a/src/system/toplevel.cpp
+++ b/src/system/toplevel.cpp
@@ -169,9 +169,9 @@ sw::kpu::KPUSimulator* SystemSimulator::create_kpu_from_config(const KPUConfig& 
         sim_config.l3_layer.capacity_kb = kpu_config.memory.l3_tiles[0].capacity_kb;
     }
 
-    sim_config.l2_bank_count = kpu_config.memory.l2_banks.size();
+    sim_config.l2_layer.num_banks = kpu_config.memory.l2_banks.size();
     if (!kpu_config.memory.l2_banks.empty()) {
-        sim_config.l2_bank_capacity_kb = kpu_config.memory.l2_banks[0].capacity_kb;
+        sim_config.l2_layer.capacity_kb = kpu_config.memory.l2_banks[0].capacity_kb;
     }
 
     // Compute configuration

--- a/src/tools/bindings/python/kpu_bindings.cpp
+++ b/src/tools/bindings/python/kpu_bindings.cpp
@@ -81,8 +81,14 @@ PYBIND11_MODULE(stillwater_kpu, m) {
         .def_property("l3_tile_capacity_kb",
             [](const sw::kpu::KPUSimulator::Config& c) { return c.l3_layer.capacity_kb; },
             [](sw::kpu::KPUSimulator::Config& c, sw::kpu::Size v) { c.l3_layer.capacity_kb = v; })
-        .def_readwrite("l2_bank_count", &sw::kpu::KPUSimulator::Config::l2_bank_count)
-        .def_readwrite("l2_bank_capacity_kb", &sw::kpu::KPUSimulator::Config::l2_bank_capacity_kb)
+        // L2 banks now live in the L2Layer aggregate config; these properties
+        // proxy into config.l2_layer for a uniform layer.
+        .def_property("l2_bank_count",
+            [](const sw::kpu::KPUSimulator::Config& c) { return c.l2_layer.num_banks; },
+            [](sw::kpu::KPUSimulator::Config& c, size_t v) { c.l2_layer.num_banks = v; })
+        .def_property("l2_bank_capacity_kb",
+            [](const sw::kpu::KPUSimulator::Config& c) { return c.l2_layer.capacity_kb; },
+            [](sw::kpu::KPUSimulator::Config& c, sw::kpu::Size v) { c.l2_layer.capacity_kb = v; })
         .def_readwrite("l1_buffer_count", &sw::kpu::KPUSimulator::Config::l1_buffer_count)
         .def_readwrite("l1_buffer_capacity_kb", &sw::kpu::KPUSimulator::Config::l1_buffer_capacity_kb)
         // Compute resources

--- a/tests/block_mover/test_block_mover_basic.cpp
+++ b/tests/block_mover/test_block_mover_basic.cpp
@@ -27,8 +27,8 @@ public:
         config.dma_engine_count = 4;
         config.l3_layer.num_tiles = 4;
         config.l3_layer.capacity_kb = 128;
-        config.l2_bank_count = 8;
-        config.l2_bank_capacity_kb = 64;
+        config.l2_layer.num_banks = 8;
+        config.l2_layer.capacity_kb = 64;
         config.l3_layer.block_mover_count = 4;
 
         sim = std::make_unique<KPUSimulator>(config);

--- a/tests/common/test_configs.hpp
+++ b/tests/common/test_configs.hpp
@@ -47,8 +47,8 @@ inline KPUSimulator::Config minimal_config() {
     c.memory_bandwidth_gbps     = 8;
     c.l3_layer.num_tiles        = 1;
     c.l3_layer.capacity_kb      = 64;
-    c.l2_bank_count             = 1;
-    c.l2_bank_capacity_kb       = 32;
+    c.l2_layer.num_banks        = 1;
+    c.l2_layer.capacity_kb      = 32;
     c.l1_buffer_count           = 1;
     c.l1_buffer_capacity_kb     = 32;
     c.compute_tile_count        = 1;
@@ -66,8 +66,8 @@ inline KPUSimulator::Config small_config() {
     c.memory_bandwidth_gbps     = 8;
     c.l3_layer.num_tiles        = 4;
     c.l3_layer.capacity_kb      = 256;
-    c.l2_bank_count             = 4;
-    c.l2_bank_capacity_kb       = 128;
+    c.l2_layer.num_banks        = 4;
+    c.l2_layer.capacity_kb      = 128;
     c.l1_buffer_count           = 2;
     c.l1_buffer_capacity_kb     = 64;
     c.compute_tile_count        = 2;
@@ -87,8 +87,8 @@ inline KPUSimulator::Config medium_config() {
     c.memory_bandwidth_gbps     = 16;
     c.l3_layer.num_tiles        = 4;
     c.l3_layer.capacity_kb      = 1024;
-    c.l2_bank_count             = 4;
-    c.l2_bank_capacity_kb       = 512;
+    c.l2_layer.num_banks        = 4;
+    c.l2_layer.capacity_kb      = 512;
     c.l1_buffer_count           = 4;
     c.l1_buffer_capacity_kb     = 256;
     c.compute_tile_count        = 4;

--- a/tests/compute/test_systolic_array.cpp
+++ b/tests/compute/test_systolic_array.cpp
@@ -27,8 +27,8 @@ public:
         config.dma_engine_count = 2;
         config.l3_layer.num_tiles = 4;
         config.l3_layer.capacity_kb = 128;
-        config.l2_bank_count = 8;
-        config.l2_bank_capacity_kb = 64;
+        config.l2_layer.num_banks = 8;
+        config.l2_layer.capacity_kb = 64;
         config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
 

--- a/tests/driver/test_all_resources.cpp
+++ b/tests/driver/test_all_resources.cpp
@@ -34,8 +34,8 @@ public:
         config.l3_layer.num_tiles = 4;
         config.l3_layer.capacity_kb = 256;
 
-        config.l2_bank_count = 8;
-        config.l2_bank_capacity_kb = 64;
+        config.l2_layer.num_banks = 8;
+        config.l2_layer.capacity_kb = 64;
 
         config.l1_buffer_count = 16;
         config.l1_buffer_capacity_kb = 8;

--- a/tests/driver/test_resource_api.cpp
+++ b/tests/driver/test_resource_api.cpp
@@ -96,7 +96,7 @@ TEST_CASE("ResourceManager resource discovery", "[resource_api]") {
     config.memory_bank_count = 2;
     config.memory_bank_capacity_mb = 128;  // 128 MB per bank
     config.l3_layer.num_tiles = 4;
-    config.l2_bank_count = 8;
+    config.l2_layer.num_banks = 8;
     config.l1_buffer_count = 4;
     config.page_buffer_count = 2;
     config.compute_tile_count = 2;

--- a/tests/runtime/test_executor.cpp
+++ b/tests/runtime/test_executor.cpp
@@ -31,8 +31,8 @@ protected:
         config.memory_bank_capacity_mb = 4;
         config.l3_layer.num_tiles = 4;
         config.l3_layer.capacity_kb = 128;
-        config.l2_bank_count = 8;
-        config.l2_bank_capacity_kb = 64;
+        config.l2_layer.num_banks = 8;
+        config.l2_layer.capacity_kb = 64;
         config.page_buffer_count = 2;
         config.page_buffer_capacity_kb = 64;
         config.l1_buffer_count = 4;

--- a/tests/runtime/test_graph.cpp
+++ b/tests/runtime/test_graph.cpp
@@ -30,8 +30,8 @@ protected:
         config.memory_bank_capacity_mb = 4;
         config.l3_layer.num_tiles = 4;
         config.l3_layer.capacity_kb = 128;
-        config.l2_bank_count = 8;
-        config.l2_bank_capacity_kb = 64;
+        config.l2_layer.num_banks = 8;
+        config.l2_layer.capacity_kb = 64;
         config.page_buffer_count = 2;
         config.page_buffer_capacity_kb = 64;
         config.l1_buffer_count = 4;

--- a/tests/runtime/test_runtime.cpp
+++ b/tests/runtime/test_runtime.cpp
@@ -31,8 +31,8 @@ protected:
         config.memory_bank_capacity_mb = 4;
         config.l3_layer.num_tiles = 4;
         config.l3_layer.capacity_kb = 128;
-        config.l2_bank_count = 8;
-        config.l2_bank_capacity_kb = 64;
+        config.l2_layer.num_banks = 8;
+        config.l2_layer.capacity_kb = 64;
         config.page_buffer_count = 2;
         config.page_buffer_capacity_kb = 64;
         config.l1_buffer_count = 4;

--- a/tests/streamer/test_streamer_basic.cpp
+++ b/tests/streamer/test_streamer_basic.cpp
@@ -27,8 +27,8 @@ public:
         config.dma_engine_count = 4;
         config.l3_layer.num_tiles = 4;
         config.l3_layer.capacity_kb = 128;
-        config.l2_bank_count = 8;
-        config.l2_bank_capacity_kb = 64;
+        config.l2_layer.num_banks = 8;
+        config.l2_layer.capacity_kb = 64;
         config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;
 
@@ -311,7 +311,7 @@ TEST_CASE_METHOD(StreamerTestFixture, "Streamer Error Handling", "[streamer][err
     }
 
     SECTION("Validates L2 bank ID bounds") {
-        const size_t invalid_l2_bank_id = config.l2_bank_count + 1;
+        const size_t invalid_l2_bank_id = config.l2_layer.num_banks + 1;
 
         REQUIRE_THROWS_AS(
             sim->start_row_stream(0, invalid_l2_bank_id, 0, 0, 0, 4, 4, 4, 2),

--- a/tools/runner/kpu_runner.cpp
+++ b/tools/runner/kpu_runner.cpp
@@ -77,8 +77,8 @@ KPUSimulator::Config convert_config(const SimulatorConfig& sim_config) {
         config.l3_layer.capacity_kb = 256;  // Default
     }
 
-    config.l2_bank_count = sim_config.num_l2_banks;
-    config.l2_bank_capacity_kb = 64;  // Default
+    config.l2_layer.num_banks = sim_config.num_l2_banks;
+    config.l2_layer.capacity_kb = 64;  // Default
 
     // L1 buffers - derived from compute fabric
     config.l1_buffer_count = 0;  // Auto-compute

--- a/tools/runtime/kpu-loader/schedule_binder.cpp
+++ b/tools/runtime/kpu-loader/schedule_binder.cpp
@@ -73,7 +73,7 @@ BoundSchedule ScheduleBinder::bind(const dfx::Program& program) {
             current_l3_tile = (current_l3_tile + 1) % config_.l3_layer.num_tiles;
 
             bound.l2_bank_id = current_l2_bank;
-            current_l2_bank = (current_l2_bank + 1) % config_.l2_bank_count;
+            current_l2_bank = (current_l2_bank + 1) % config_.l2_layer.num_banks;
 
             bound.l1_buffer_id = current_l1_buffer;
             current_l1_buffer = (current_l1_buffer + 1) % config_.l1_buffer_count;


### PR DESCRIPTION
## Summary

Resolves #33 — introduce the **`L2Layer`** aggregate over the retained `L2Bank`
elements, mirroring the L3Layer work (#32). Per the approved plan
(`docs/plans/memory-layer-restructuring.md`): no backward-compat shims; configs
kept **uniform** this pass.

## Commits

- **`10f6adf` (1A+1B, foundation):** new `L2Layer` / `L2LayerConfig` (owns the
  `L2Bank`s; `group → element-config → multiplicity` config with scalar uniform
  convenience). `KPUSimulator` holds one `L2Layer` instead of a bare
  `std::vector<L2Bank>`; internal sites delegate via `l2_layer.banks()`. External
  API unchanged → behavior-preserving.
- **`abdbc0f` (1C, hard break):** remove flat `l2_bank_count` /
  `l2_bank_capacity_kb` from `KPUSimulator::Config`; route through `l2_layer`.

## Migration

| Old | New |
|-----|-----|
| `config.l2_bank_count` | `config.l2_layer.num_banks` |
| `config.l2_bank_capacity_kb` | `config.l2_layer.capacity_kb` |

- L2 address-map regions now built from the constructed layer (per-bank
  capacity → non-uniform ready). `config.l2_bank_base` retained.
- Python keeps the old attribute names via `def_property` proxies into
  `l2_layer`; the C ABI struct `KPUSimulatorConfig` is unchanged.

## Care taken

These field names are shared by several unrelated structs
(`MemoryModelConfig`, `ConcurrentTimingExecutor`, `ScheduleValidator`). I did a
**per-file owning-struct audit** and migrated only the 22 files that use
`KPUSimulator::Config`, leaving the others intact (verified by a clean build).

## Validation

- Build green on **linux-gcc**; **95/95** ctest pass.
- CHANGELOG updated. CI will additionally cover Windows/MSVC + Clang.

Closes #33 · epic #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)