### PR TITLE
refactor(l1)!: introduce L1Layer aggregate, replace flat L1 Config (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING — L1 memory layer restructuring (#34).** Introduced the `L1Layer`
+  aggregate (owns the `L1Buffer` stream buffers) and removed the flat L1 fields
+  from `KPUSimulator::Config`. Migration:
+  - `config.l1_buffer_count`        → `config.l1_layer.num_buffers`
+  - `config.l1_buffer_capacity_kb`  → `config.l1_layer.capacity_kb`
+  - For non-uniform layers, populate `config.l1_layer.buffer_groups`
+    (`group → element-config → multiplicity`) instead of the scalar fields.
+  - `config.l1_buffer_base` is unchanged. No backward-compatibility shims. Python
+    keeps the `l1_buffer_count` / `l1_buffer_capacity_kb` attribute names (they
+    proxy into `l1_layer`); the C ABI struct `KPUSimulatorConfig` is unchanged.
+  - `L1Layer` (like `L2Layer`/`L3Layer`) is a monitoring/ownership structure, not
+    a ResourceManager/dataflow API.
+
 - **BREAKING — L2 memory layer restructuring (#33).** Introduced the `L2Layer`
   aggregate (owns the `L2Bank` elements) and removed the flat L2 fields from
   `KPUSimulator::Config`. Migration:

--- a/docs/plans/memory-layer-restructuring.md
+++ b/docs/plans/memory-layer-restructuring.md
@@ -19,10 +19,22 @@ Concretely:
 - **Keep** the element types `L3Tile`, `L2Bank`, `L1Buffer` exactly as they are —
   they are real, addressable, configurable entities that matter to the machine's
   operation. This is **not** a rename of the elements.
-- **Do not** create an `L1Layer` memory aggregate. The L1 stream buffers are too
-  tightly coupled to the compute fabric; attach `L1Buffer`s to the **compute
-  fabric** and make the **Streamer** the entity that translates L2 bank shape
-  into L1 buffer shape.
+- Introduce an **`L1Layer`** aggregate that owns the `L1Buffer` stream buffers,
+  symmetric with `L2Layer` and `L3Layer`. *(Updated 2026-06-28 — supersedes an
+  earlier draft that folded `L1Buffer` into the `ComputeFabric`; see
+  "On `L1Layer`" below.)*
+
+### Principle: Layers are monitoring/ownership structures, not a dataflow API
+
+`L3Layer` / `L2Layer` / `L1Layer` are **conceptual resource owners** that reflect
+the physical distribution of storage across the SoC. They exist to let us
+**interrogate L3/L2/L1 resources for monitoring and debug** (occupancy, capacity,
+per-element state). They **must NOT** be part of any **ResourceManager API** or be
+used for **domain-flow / dataflow functionality** — precisely because these
+components are physically distributed. The actual data movement, reuse, and
+credit flow through the hierarchy is driven by the **distributed CSP engines**
+(DMA, BlockMover, Streamer) executing a global schedule. *The Layers observe; the
+CSPs drive.*
 
 ## The Defect Being Corrected
 
@@ -92,20 +104,29 @@ mechanics from scratch.
 | L3→L2 mover | `BlockMover` *(retained, ownership moves)* | pushes a tile from its `L3Tile` down into the `L2Layer` | **owned by `L3Layer`**, one attached per `L3Tile` (was a flat `std::vector<BlockMover>` on the simulator, `kpu_simulator.hpp:150`) |
 | L2 layer (whole) | **`L2Layer`** *(new)* | collection of `L2Bank`, layer ports, (interconnect TBD) | aggregate; may be **non-uniform** |
 | L2 element | `L2Bank` *(retained)* | own capacity, ports | addressable element |
-| L1 stream buffers | `L1Buffer` *(retained)* | own capacity, double-buffering | **owned by `ComputeFabric`**, not a memory layer |
+| L1 layer (whole) | **`L1Layer`** *(new)* | collection of `L1Buffer` stream buffers | aggregate; owner for monitoring/debug; may be **non-uniform** |
+| L1 element | `L1Buffer` *(retained)* | own capacity, double-buffering | addressable stream buffer feeding the compute fabric |
 | L2→L1 shape translation | `Streamer` *(existing role, made explicit)* | translates L2 bank shape → L1 buffer shape | the entity that bridges memory layer and compute |
 
-### Why no `L1Layer`
+### On `L1Layer` (decision updated 2026-06-28)
 
-L1 buffers are derived from and lifecycle-bound to the compute tiles
-(`4×(rows+cols)` per tile). Modeling an `L1Layer` peer to `L3Layer`/`L2Layer`
-would create a second owner for buffers that conceptually belong to compute. So:
+An earlier draft argued there should be **no** `L1Layer`: L1 buffers are derived
+from and lifecycle-bound to the compute tiles (`4×(rows+cols)` per tile), so they
+"belong" to the `ComputeFabric`. **That reasoning is rejected:**
 
-- `L1Buffer`s become members of `ComputeFabric` (or a compute-owned sub-struct).
-- The `Streamer` is the explicit bridge: it reads the L2 bank shape and feeds the
-  appropriately shaped L1 buffers for the compute fabric it serves.
-- Issue #34 changes from "introduce L1Layer" to "relocate L1Buffer ownership to
-  the compute fabric and formalize the Streamer's L2→L1 shape translation."
+- It does not distinguish L1 from L2. The size/shape of the `L2Layer`'s `L2Bank`
+  structures is **also** a function of the fabric size and kernel schedule — the
+  same properties that size the L1 buffers. If derivation-from-fabric justified
+  folding L1 into compute, it would equally justify folding L2 into compute,
+  which we do not do.
+- Under the monitoring/ownership framing above, an L1 owner is exactly what we
+  want for efficient inspection of the L1 resources. Symmetry of the hierarchy
+  (L3/L2/L1 each have an owner) is the right model.
+
+So **`L1Layer` is introduced** as a peer of `L2Layer`/`L3Layer`, owning the
+`L1Buffer` stream buffers. It is an *ownership/monitoring* structure only (see the
+principle above) — it is **not** wired into any ResourceManager or dataflow path,
+and the `Streamer` remains the CSP that actually drives L2→L1 movement.
 
 ## Key Requirement: Non-Uniform Layers (heterogeneous compute fabrics)
 
@@ -220,4 +241,4 @@ and must be updated in lockstep.
 | #35 | Tracking: rename L*→L*Layer | **Design epic**: introduce aggregate layers; this plan |
 | #32 | Rename `L3Tile`→`L3Layer` | **Introduce `L3Layer`** aggregate owning retained `L3Tile`s + interconnect + ports; non-uniform tile groups |
 | #33 | Rename `L2Bank`→`L2Layer` | **Introduce `L2Layer`** aggregate owning retained `L2Bank`s + ports; non-uniform bank/port groups |
-| #34 | Rename `L1Buffer`→`L1Layer` | **Relocate `L1Buffer` to `ComputeFabric`**; formalize `Streamer` as L2→L1 shape translator; **no** `L1Layer` |
+| #34 | Rename `L1Buffer`→`L1Layer` | **Introduce `L1Layer`** aggregate owning retained `L1Buffer`s (monitoring/ownership only, not a dataflow API); `Streamer` remains the L2→L1 CSP driver |

--- a/examples/basic/data_movement_pipeline.cpp
+++ b/examples/basic/data_movement_pipeline.cpp
@@ -10,8 +10,8 @@ int main() {
     config.memory_bank_count = 1;
     config.l3_layer.num_tiles = 1;
     config.l2_layer.num_banks = 1;
-    config.l1_buffer_count = 1;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 1;
+    config.l1_layer.capacity_kb = 64;
     config.compute_tile_count = 1;
     config.l3_layer.block_mover_count = 1;
     config.streamer_count = 2;

--- a/examples/basic/hello_kpu.cpp
+++ b/examples/basic/hello_kpu.cpp
@@ -17,8 +17,8 @@ int main() {
     config.memory_bank_count = 2;
     config.memory_bank_capacity_mb = 1024;
     config.memory_bandwidth_gbps = 100;
-    config.l1_buffer_count = 2;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 2;
+    config.l1_layer.capacity_kb = 64;
     config.compute_tile_count = 2;
     config.dma_engine_count = 2;
     config.processor_array_rows = 16;
@@ -27,7 +27,7 @@ int main() {
 
     std::cout << "Creating KPU with configuration:\n";
     std::cout << "  Memory banks: " << config.memory_bank_count << "\n";
-    std::cout << "  L1 buffers: " << config.l1_buffer_count << "\n";
+    std::cout << "  L1 buffers: " << config.l1_layer.num_buffers << "\n";
     std::cout << "  Compute tiles: " << config.compute_tile_count << "\n\n";
 
     // Create simulator

--- a/examples/basic/host_to_l3_matmul.cpp
+++ b/examples/basic/host_to_l3_matmul.cpp
@@ -156,8 +156,8 @@ This example demonstrates the full data flow for matrix multiplication:
     config.l3_layer.capacity_kb = 128;
     config.l2_layer.num_banks = 4;
     config.l2_layer.capacity_kb = 64;
-    config.l1_buffer_count = 64;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 64;
+    config.l1_layer.capacity_kb = 64;
     config.compute_tile_count = 1;
     config.processor_array_rows = 8;
     config.processor_array_cols = 8;
@@ -177,8 +177,8 @@ This example demonstrates the full data flow for matrix multiplication:
               << config.l3_layer.capacity_kb << " KB\n";
     std::cout << "  L2 Banks:        " << config.l2_layer.num_banks << " × "
               << config.l2_layer.capacity_kb << " KB\n";
-    std::cout << "  L1 Buffers:      " << config.l1_buffer_count << " × "
-              << config.l1_buffer_capacity_kb << " KB\n";
+    std::cout << "  L1 Buffers:      " << config.l1_layer.num_buffers << " × "
+              << config.l1_layer.capacity_kb << " KB\n";
     std::cout << "  Systolic Array:  " << config.processor_array_rows << "×"
               << config.processor_array_cols << "\n";
 

--- a/examples/basic/matrix_multiply.cpp
+++ b/examples/basic/matrix_multiply.cpp
@@ -46,8 +46,8 @@ int main() {
     config.memory_bank_count       = 1;
     config.memory_bank_capacity_mb = 1024;
     config.memory_bandwidth_gbps   = 100;
-    config.l1_buffer_count         = 1;
-    config.l1_buffer_capacity_kb   = 64;
+    config.l1_layer.num_buffers         = 1;
+    config.l1_layer.capacity_kb   = 64;
     config.compute_tile_count      = 1;
     config.dma_engine_count        = 1;
 

--- a/examples/basic/memory_management.cpp
+++ b/examples/basic/memory_management.cpp
@@ -36,8 +36,8 @@ int main() {
     config.memory_bank_count = 4;
     config.memory_bank_capacity_mb = 512;
     config.memory_bandwidth_gbps = 100;
-    config.l1_buffer_count = 4;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 4;
+    config.l1_layer.capacity_kb = 64;
     config.compute_tile_count = 2;
     config.dma_engine_count = 4;
     config.l3_layer.num_tiles = 4;

--- a/examples/basic/resource_api_demo.cpp
+++ b/examples/basic/resource_api_demo.cpp
@@ -91,8 +91,8 @@ int main() {
     config.l2_layer.num_banks = 16;
     config.l2_layer.capacity_kb = 128;
 
-    config.l1_buffer_count = 32;
-    config.l1_buffer_capacity_kb = 16;
+    config.l1_layer.num_buffers = 32;
+    config.l1_layer.capacity_kb = 16;
 
     // Configure compute and data movement
     config.compute_tile_count = 8;

--- a/examples/blas/big_matmul.cpp
+++ b/examples/blas/big_matmul.cpp
@@ -100,8 +100,8 @@ KPUSimulator::Config create_config() {
     config.l3_layer.capacity_kb = 512;
     config.l2_layer.num_banks = 64;
     config.l2_layer.capacity_kb = 32;
-    config.l1_buffer_count = 3072;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 3072;
+    config.l1_layer.capacity_kb = 64;
     config.compute_tile_count = 16;
     config.processor_array_rows = 24;
     config.processor_array_cols = 24;

--- a/examples/mlp/mnist_classifier.cpp
+++ b/examples/mlp/mnist_classifier.cpp
@@ -237,8 +237,8 @@ int main() {
     config.l3_layer.capacity_kb = 256;
     config.l2_layer.num_banks = 16;
     config.l2_layer.capacity_kb = 64;
-    config.l1_buffer_count = 8;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 8;
+    config.l1_layer.capacity_kb = 64;
     config.processor_array_rows = 16;
     config.processor_array_cols = 16;
     config.use_systolic_array_mode = true;

--- a/examples/mlp/sine_approximation.cpp
+++ b/examples/mlp/sine_approximation.cpp
@@ -188,8 +188,8 @@ int main() {
     config.l3_layer.capacity_kb = 128;
     config.l2_layer.num_banks = 8;
     config.l2_layer.capacity_kb = 64;
-    config.l1_buffer_count = 4;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 4;
+    config.l1_layer.capacity_kb = 64;
     config.processor_array_rows = 16;
     config.processor_array_cols = 16;
     config.use_systolic_array_mode = true;

--- a/examples/mlp/xor_classifier.cpp
+++ b/examples/mlp/xor_classifier.cpp
@@ -140,8 +140,8 @@ int main() {
     config.l3_layer.capacity_kb = 128;
     config.l2_layer.num_banks = 8;
     config.l2_layer.capacity_kb = 64;
-    config.l1_buffer_count = 4;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 4;
+    config.l1_layer.capacity_kb = 64;
     config.processor_array_rows = 16;
     config.processor_array_cols = 16;
     config.use_systolic_array_mode = true;

--- a/examples/runtime/runtime_demo.cpp
+++ b/examples/runtime/runtime_demo.cpp
@@ -123,8 +123,8 @@ int main() {
     sim_config.l3_layer.capacity_kb = 512;
     sim_config.l2_layer.num_banks = 16;
     sim_config.l2_layer.capacity_kb = 64;
-    sim_config.l1_buffer_count = 4;
-    sim_config.l1_buffer_capacity_kb = 64;
+    sim_config.l1_layer.num_buffers = 4;
+    sim_config.l1_layer.capacity_kb = 64;
     sim_config.dma_engine_count = 4;
     sim_config.l3_layer.block_mover_count = 8;
     sim_config.streamer_count = 16;

--- a/include/sw/kpu/kpu_simulator.hpp
+++ b/include/sw/kpu/kpu_simulator.hpp
@@ -41,6 +41,7 @@
 #include <sw/kpu/models/temporal/memory/l2_bank.hpp>
 #include <sw/kpu/models/temporal/memory/l2_layer.hpp>
 #include <sw/kpu/models/temporal/memory/l1_buffer.hpp>
+#include <sw/kpu/models/temporal/memory/l1_layer.hpp>
 #include <sw/kpu/models/temporal/datamovement/block_mover.hpp>
 #include <sw/kpu/models/temporal/datamovement/streamer.hpp>
 #include <sw/kpu/models/temporal/compute/compute_fabric.hpp>
@@ -148,7 +149,7 @@ private:
     std::vector<ExternalMemory> memory_banks;  // KPU local memory banks
     L3Layer l3_layer;  // SoC-wide L3 aggregate: owns L3Tiles, BlockMovers, interconnect
     L2Layer l2_layer;  // SoC-wide L2 aggregate: owns L2Banks
-    std::vector<L1Buffer> l1_buffers;  // L1 streaming buffers (compute fabric)
+    L1Layer l1_layer;  // SoC-wide L1 aggregate: owns L1 stream buffers (monitoring/ownership)
     std::vector<PageBuffer> page_buffers;  // Page buffers (memory controller)
     std::vector<DMAEngine> dma_engines;
     std::vector<ComputeFabric> compute_tiles;
@@ -288,7 +289,7 @@ public:
     size_t get_memory_bank_count() const { return memory_banks.size(); }
     size_t get_l3_tile_count() const { return l3_layer.tile_count(); }
     size_t get_l2_bank_count() const { return l2_layer.bank_count(); }
-    size_t get_l1_buffer_count() const { return l1_buffers.size(); }
+    size_t get_l1_buffer_count() const { return l1_layer.buffer_count(); }
     size_t get_page_buffer_count() const { return page_buffers.size(); }
     size_t get_compute_tile_count() const { return compute_tiles.size(); }
     size_t get_dma_engine_count() const { return dma_engines.size(); }

--- a/include/sw/kpu/kpu_simulator.hpp
+++ b/include/sw/kpu/kpu_simulator.hpp
@@ -79,12 +79,14 @@ public:
         // l2_layer.capacity_kb for a uniform layer, or l2_layer.bank_groups
         // for a non-uniform one.
         L2LayerConfig l2_layer;
-        // L1 streaming buffers: DERIVED from processor array configuration
-        // For rectangular arrays: 4 × (rows + cols) per compute tile
-        // For hexagonal arrays: 12 × side_length per compute tile
-        // See processor_array_topology.hpp for derivation formulas
-        Size l1_buffer_count;           // Auto-computed if 0; set only for testing
-        Size l1_buffer_capacity_kb;
+        // L1 layer: aggregate config (stream buffers feeding the compute fabric).
+        // Use l1_layer.num_buffers / l1_layer.capacity_kb for a uniform layer, or
+        // l1_layer.buffer_groups for a non-uniform one.
+        // The buffer count is typically DERIVED from the processor array
+        // configuration (4 × (rows + cols) per compute tile for rectangular
+        // arrays; see processor_array_topology.hpp) — set l1_layer.num_buffers
+        // accordingly (0 = none / set by the caller).
+        L1LayerConfig l1_layer;
 
         // Data movement engines
         // Note: BlockMovers are configured via l3_layer.block_mover_count
@@ -118,7 +120,6 @@ public:
               memory_bandwidth_gbps(0),
               memory_controller_count(0),
               page_buffer_count(0), page_buffer_capacity_kb(0),
-              l1_buffer_count(0), l1_buffer_capacity_kb(0),
               dma_engine_count(0), streamer_count(0),
               compute_tile_count(0),
               processor_array_rows(0), processor_array_cols(0),

--- a/include/sw/kpu/models/temporal/memory/l1_layer.hpp
+++ b/include/sw/kpu/models/temporal/memory/l1_layer.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+// Windows/MSVC compatibility
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4251) // DLL interface warnings
+    #ifdef BUILDING_KPU_SIMULATOR
+        #define KPU_API __declspec(dllexport)
+    #else
+        #define KPU_API __declspec(dllimport)
+    #endif
+#else
+    #define KPU_API
+#endif
+
+#include <sw/concepts.hpp>
+#include <sw/kpu/models/temporal/memory/l1_buffer.hpp>
+
+namespace sw::kpu {
+
+// ============================================================================
+// L1 Layer configuration
+//
+// The L1 layer is the whole SoC-wide L1 stream-buffer resource that feeds the
+// compute fabric: a (possibly non-uniform) collection of L1Buffer elements.
+//
+// IMPORTANT: L1Layer (like L2Layer / L3Layer) is a *conceptual resource owner*
+// for monitoring/debug — it reflects the physical distribution of storage and
+// lets us interrogate the L1 resources (count, capacity, per-element state). It
+// is NOT a ResourceManager / dataflow API: the actual data movement and credit
+// flow through the hierarchy is driven by the distributed CSP engines (DMA,
+// BlockMover, Streamer). The Layer observes; the Streamer drives L2->L1.
+//
+// Non-uniformity (heterogeneous compute fabrics) is expressed with the
+// `group -> element-config -> multiplicity` shape.
+// ============================================================================
+
+/// Per-element (L1Buffer) micro-architecture spec at the temporal-model level.
+struct L1BufferSpec {
+    /// Capacity per buffer in KB.
+    Size capacity_kb = 32;
+};
+
+/// A named group of identical L1Buffers: element-config bound to a multiplicity.
+struct L1BufferGroup {
+    std::string name;          ///< Symbolic group name (e.g. "default").
+    L1BufferSpec buffer;       ///< Element configuration shared by the group.
+    size_t multiplicity = 1;   ///< Number of identical buffers in the group.
+};
+
+/// Configuration for an L1Layer aggregate.
+///
+/// Two ways to describe the buffers:
+///  - **Canonical (non-uniform):** populate `buffer_groups` with named
+///    `group -> element-config -> multiplicity` entries.
+///  - **Uniform convenience:** leave `buffer_groups` empty and set the scalar
+///    `num_buffers` / `capacity_kb` fields; the layer is then built as
+///    `num_buffers` identical buffers of `capacity_kb`.
+/// When `buffer_groups` is non-empty it takes precedence over the scalar fields.
+///
+/// Note: the L1 buffer count is typically *derived* from the processor-array
+/// topology (see processor_array_topology.hpp). That derivation is a caller
+/// responsibility — set `num_buffers` (or `buffer_groups`) accordingly.
+struct L1LayerConfig {
+    /// Buffer groups: group -> element-config -> multiplicity (non-uniform layers).
+    std::vector<L1BufferGroup> buffer_groups;
+
+    /// Uniform convenience: number of identical buffers (used iff `buffer_groups` empty).
+    size_t num_buffers = 0;
+    /// Uniform convenience: per-buffer capacity in KB (used iff `buffer_groups` empty).
+    Size capacity_kb = 32;
+
+    /// Total number of buffers: sum of group multiplicities, or the uniform count.
+    size_t total_buffers() const {
+        if (!buffer_groups.empty()) {
+            size_t n = 0;
+            for (const auto& g : buffer_groups) {
+                n += g.multiplicity;
+            }
+            return n;
+        }
+        return num_buffers;
+    }
+
+    /// Convenience factory for a uniform layer.
+    static L1LayerConfig uniform(size_t num_buffers, Size capacity_kb) {
+        L1LayerConfig cfg;
+        cfg.num_buffers = num_buffers;
+        cfg.capacity_kb = capacity_kb;
+        return cfg;
+    }
+};
+
+// ============================================================================
+// L1 Layer aggregate
+// ============================================================================
+
+/// The whole SoC-wide L1 stream-buffer resource. Owns the L1Buffer elements.
+/// Ownership / monitoring structure only — not a dataflow API (see header note).
+class KPU_API L1Layer {
+public:
+    explicit L1Layer(const L1LayerConfig& config = {});
+
+    // --- L1Buffer elements ---------------------------------------------------
+    size_t buffer_count() const { return buffers_.size(); }
+    L1Buffer& buffer(size_t index);
+    const L1Buffer& buffer(size_t index) const;
+
+    /// Direct access to the buffer collection, for components whose APIs take a
+    /// `std::vector<L1Buffer>&` (e.g. the Streamer and ComputeFabric).
+    std::vector<L1Buffer>& buffers() { return buffers_; }
+    const std::vector<L1Buffer>& buffers() const { return buffers_; }
+
+    // --- Monitoring / inspection (not a dataflow API) ------------------------
+    /// Aggregate capacity of the layer in bytes.
+    Size total_capacity_bytes() const;
+
+    // --- Lifecycle -----------------------------------------------------------
+    void reset();
+
+    const L1LayerConfig& config() const { return config_; }
+
+private:
+    L1LayerConfig config_;
+    std::vector<L1Buffer> buffers_;
+};
+
+} // namespace sw::kpu
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif

--- a/models/kpu/test_debug_dataflow.cpp
+++ b/models/kpu/test_debug_dataflow.cpp
@@ -10,8 +10,8 @@ int main() {
     config.memory_bank_count = 1;
     config.l3_layer.num_tiles = 1;
     config.l2_layer.num_banks = 1;
-    config.l1_buffer_count = 1;
-    config.l1_buffer_capacity_kb = 64;
+    config.l1_layer.num_buffers = 1;
+    config.l1_layer.capacity_kb = 64;
     config.compute_tile_count = 1;
     config.l3_layer.block_mover_count = 1;
     config.streamer_count = 2;

--- a/src/system/simulator/CMakeLists.txt
+++ b/src/system/simulator/CMakeLists.txt
@@ -6,6 +6,7 @@ set(KPU_SIMULATOR_SOURCES
     kpu_simulator.cpp
     l3_layer.cpp
     l2_layer.cpp
+    l1_layer.cpp
     resource_manager.cpp
     kernel.cpp
     kernel_serializer.cpp

--- a/src/system/simulator/kpu_simulator.cpp
+++ b/src/system/simulator/kpu_simulator.cpp
@@ -33,8 +33,7 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
 
     // Initialize the L1 layer aggregate - owns the L1 stream buffers that feed
     // the compute fabric.
-    l1_layer = L1Layer(L1LayerConfig::uniform(config.l1_buffer_count,
-                                              config.l1_buffer_capacity_kb));
+    l1_layer = L1Layer(config.l1_layer);
 
     // Initialize page buffers - memory controller page buffers
     page_buffers.reserve(config.page_buffer_count);
@@ -137,12 +136,13 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
         current_addr += capacity;
     }
 
-    // L1 streaming buffers (compute fabric)
+    // L1 streaming buffers (capacities come from the constructed L1 layer;
+    // supports non-uniform buffers)
     if (config.l1_buffer_base != 0) {
         current_addr = config.l1_buffer_base;
     }
-    for (size_t i = 0; i < config.l1_buffer_count; ++i) {
-        Size capacity = config.l1_buffer_capacity_kb * 1024;
+    for (size_t i = 0; i < l1_layer.buffer_count(); ++i) {
+        Size capacity = l1_layer.buffer(i).get_capacity();
         address_decoder.add_region(current_addr, capacity, sw::memory::MemoryType::L1, i,
                                   "L1 Buffer " + std::to_string(i));
         current_addr += capacity;
@@ -784,8 +784,8 @@ KPUSimulator::Config generate_multi_bank_config(size_t num_banks, size_t num_til
     config.memory_bank_count = num_banks;
     config.memory_bank_capacity_mb = 512; // Smaller banks for multi-bank setup
     config.memory_bandwidth_gbps = 16; // Higher bandwidth per bank
-    config.l1_buffer_count = num_tiles; // One L1 buffer per tile
-    config.l1_buffer_capacity_kb = 256;
+    config.l1_layer.num_buffers = num_tiles; // One L1 buffer per tile
+    config.l1_layer.capacity_kb = 256;
     config.compute_tile_count = num_tiles;
     config.dma_engine_count = num_banks + num_tiles; // Plenty of DMA engines
     return config;

--- a/src/system/simulator/kpu_simulator.cpp
+++ b/src/system/simulator/kpu_simulator.cpp
@@ -31,11 +31,10 @@ KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
     // Initialize the L2 layer aggregate - owns the L2Banks.
     l2_layer = L2Layer(config.l2_layer);
 
-    // Initialize L1 streaming buffers - part of compute fabric
-    l1_buffers.reserve(config.l1_buffer_count);
-    for (size_t i = 0; i < config.l1_buffer_count; ++i) {
-        l1_buffers.emplace_back(i, config.l1_buffer_capacity_kb);
-    }
+    // Initialize the L1 layer aggregate - owns the L1 stream buffers that feed
+    // the compute fabric.
+    l1_layer = L1Layer(L1LayerConfig::uniform(config.l1_buffer_count,
+                                              config.l1_buffer_capacity_kb));
 
     // Initialize page buffers - memory controller page buffers
     page_buffers.reserve(config.page_buffer_count);
@@ -225,12 +224,12 @@ void KPUSimulator::write_l2_bank(size_t bank_id, Address addr, const void* data,
 
 void KPUSimulator::read_l1_buffer(size_t buffer_id, Address addr, void* data, Size size) {
     validate_l1_buffer_id(buffer_id);
-    l1_buffers[buffer_id].read(addr, data, size);
+    l1_layer.buffers()[buffer_id].read(addr, data, size);
 }
 
 void KPUSimulator::write_l1_buffer(size_t buffer_id, Address addr, const void* data, Size size) {
     validate_l1_buffer_id(buffer_id);
-    l1_buffers[buffer_id].write(addr, data, size);
+    l1_layer.buffers()[buffer_id].write(addr, data, size);
 }
 
 // ===========================================
@@ -433,7 +432,7 @@ void KPUSimulator::reset() {
     for (auto& l2_bank : l2_layer.banks()) {
         l2_bank.reset();
     }
-    for (auto& l1_buffer : l1_buffers) {
+    for (auto& l1_buffer : l1_layer.buffers()) {
         l1_buffer.reset();
     }
     for (auto& pad : page_buffers) {
@@ -481,10 +480,10 @@ void KPUSimulator::step() {
         block_mover.process_transfers(l3_layer.tiles(), l2_layer.banks());
     }
     for (auto& streamer : streamers) {
-        streamer.update(current_cycle, l2_layer.banks(), l1_buffers);
+        streamer.update(current_cycle, l2_layer.banks(), l1_layer.buffers());
     }
     for (auto& tile : compute_tiles) {
-        tile.update(current_cycle, l1_buffers);
+        tile.update(current_cycle, l1_layer.buffers());
     }
 }
 
@@ -545,7 +544,7 @@ Size KPUSimulator::get_l2_bank_capacity(size_t bank_id) const {
 
 Size KPUSimulator::get_l1_buffer_capacity(size_t buffer_id) const {
     validate_l1_buffer_id(buffer_id);
-    return l1_buffers[buffer_id].get_capacity();
+    return l1_layer.buffers()[buffer_id].get_capacity();
 }
 
 Size KPUSimulator::get_page_buffer_capacity(size_t pad_id) const {
@@ -567,7 +566,7 @@ void KPUSimulator::print_stats() const {
     std::cout << "Memory banks: " << memory_banks.size() << std::endl;
     std::cout << "L3 tiles: " << l3_layer.tiles().size() << std::endl;
     std::cout << "L2 banks: " << l2_layer.banks().size() << std::endl;
-    std::cout << "L1 buffers: " << l1_buffers.size() << std::endl;
+    std::cout << "L1 buffers: " << l1_layer.buffers().size() << std::endl;
     std::cout << "Page buffers: " << page_buffers.size() << std::endl;
     std::cout << "Compute tiles: " << compute_tiles.size() << std::endl;
     std::cout << "DMA engines: " << dma_engines.size() << std::endl;
@@ -610,9 +609,9 @@ void KPUSimulator::print_component_status() const {
     }
 
     std::cout << "L1 Buffers (Compute Fabric):" << std::endl;
-    for (size_t i = 0; i < l1_buffers.size(); ++i) {
-        std::cout << "  L1Buffer[" << i << "]: " << l1_buffers[i].get_capacity() / 1024
-                  << " KB, Ready: " << (l1_buffers[i].is_ready() ? "Yes" : "No") << std::endl;
+    for (size_t i = 0; i < l1_layer.buffers().size(); ++i) {
+        std::cout << "  L1Buffer[" << i << "]: " << l1_layer.buffers()[i].get_capacity() / 1024
+                  << " KB, Ready: " << (l1_layer.buffers()[i].is_ready() ? "Yes" : "No") << std::endl;
     }
 
     std::cout << "Block Movers:" << std::endl;
@@ -654,7 +653,7 @@ bool KPUSimulator::is_l2_bank_ready(size_t bank_id) const {
 
 bool KPUSimulator::is_l1_buffer_ready(size_t buffer_id) const {
     validate_l1_buffer_id(buffer_id);
-    return l1_buffers[buffer_id].is_ready();
+    return l1_layer.buffers()[buffer_id].is_ready();
 }
 
 bool KPUSimulator::is_page_buffer_ready(size_t pad_id) const {
@@ -706,7 +705,7 @@ void KPUSimulator::validate_l2_bank_id(size_t bank_id) const {
 }
 
 void KPUSimulator::validate_l1_buffer_id(size_t buffer_id) const {
-    if (buffer_id >= l1_buffers.size()) {
+    if (buffer_id >= l1_layer.buffers().size()) {
         throw std::out_of_range("Invalid L1 buffer ID: " + std::to_string(buffer_id));
     }
 }
@@ -949,7 +948,7 @@ Address KPUSimulator::get_l1_buffer_base(size_t buffer_id) const {
     }
     // Then add offsets for L1 buffers before this one
     for (size_t i = 0; i < buffer_id; ++i) {
-        base += l1_buffers[i].get_capacity();
+        base += l1_layer.buffers()[i].get_capacity();
     }
     return base;
 }
@@ -970,7 +969,7 @@ Address KPUSimulator::get_page_buffer_base(size_t pad_id) const {
     for (const auto& bank : l2_layer.banks()) {
         base += bank.get_capacity();
     }
-    for (const auto& buffer : l1_buffers) {
+    for (const auto& buffer : l1_layer.buffers()) {
         base += buffer.get_capacity();
     }
     // Then add offsets for page buffers before this one

--- a/src/system/simulator/l1_layer.cpp
+++ b/src/system/simulator/l1_layer.cpp
@@ -1,0 +1,61 @@
+#include <sw/kpu/models/temporal/memory/l1_layer.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace sw::kpu {
+
+L1Layer::L1Layer(const L1LayerConfig& config)
+    : config_(config) {
+    // Materialize the L1Buffer elements, assigning a global flat buffer_id so the
+    // layer presents a single index space. Prefer the canonical buffer_groups;
+    // otherwise fall back to the uniform (num_buffers x capacity_kb) convenience.
+    const size_t total = config_.total_buffers();
+    buffers_.reserve(total);
+    size_t global_id = 0;
+    if (!config_.buffer_groups.empty()) {
+        for (const auto& group : config_.buffer_groups) {
+            for (size_t k = 0; k < group.multiplicity; ++k) {
+                buffers_.emplace_back(global_id, group.buffer.capacity_kb);
+                ++global_id;
+            }
+        }
+    } else {
+        for (size_t k = 0; k < config_.num_buffers; ++k) {
+            buffers_.emplace_back(global_id, config_.capacity_kb);
+            ++global_id;
+        }
+    }
+}
+
+L1Buffer& L1Layer::buffer(size_t index) {
+    if (index >= buffers_.size()) {
+        throw std::out_of_range("L1Layer::buffer: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(buffers_.size()) + " buffers)");
+    }
+    return buffers_[index];
+}
+
+const L1Buffer& L1Layer::buffer(size_t index) const {
+    if (index >= buffers_.size()) {
+        throw std::out_of_range("L1Layer::buffer: index " + std::to_string(index) +
+                                " out of range (" + std::to_string(buffers_.size()) + " buffers)");
+    }
+    return buffers_[index];
+}
+
+Size L1Layer::total_capacity_bytes() const {
+    Size total = 0;
+    for (const auto& buffer : buffers_) {
+        total += buffer.get_capacity();
+    }
+    return total;
+}
+
+void L1Layer::reset() {
+    for (auto& buffer : buffers_) {
+        buffer.reset();
+    }
+}
+
+} // namespace sw::kpu

--- a/src/system/toplevel.cpp
+++ b/src/system/toplevel.cpp
@@ -152,9 +152,9 @@ sw::kpu::KPUSimulator* SystemSimulator::create_kpu_from_config(const KPUConfig& 
     }
 
     // L1 buffer configuration (compute fabric)
-    sim_config.l1_buffer_count = kpu_config.memory.l1_buffers.size();
+    sim_config.l1_layer.num_buffers = kpu_config.memory.l1_buffers.size();
     if (!kpu_config.memory.l1_buffers.empty()) {
-        sim_config.l1_buffer_capacity_kb = kpu_config.memory.l1_buffers[0].capacity_kb;
+        sim_config.l1_layer.capacity_kb = kpu_config.memory.l1_buffers[0].capacity_kb;
     }
 
     // Page buffer configuration (memory controller scratchpads)

--- a/src/tools/bindings/python/kpu_bindings.cpp
+++ b/src/tools/bindings/python/kpu_bindings.cpp
@@ -89,8 +89,14 @@ PYBIND11_MODULE(stillwater_kpu, m) {
         .def_property("l2_bank_capacity_kb",
             [](const sw::kpu::KPUSimulator::Config& c) { return c.l2_layer.capacity_kb; },
             [](sw::kpu::KPUSimulator::Config& c, sw::kpu::Size v) { c.l2_layer.capacity_kb = v; })
-        .def_readwrite("l1_buffer_count", &sw::kpu::KPUSimulator::Config::l1_buffer_count)
-        .def_readwrite("l1_buffer_capacity_kb", &sw::kpu::KPUSimulator::Config::l1_buffer_capacity_kb)
+        // L1 buffers now live in the L1Layer aggregate config; these properties
+        // proxy into config.l1_layer for a uniform layer.
+        .def_property("l1_buffer_count",
+            [](const sw::kpu::KPUSimulator::Config& c) { return c.l1_layer.num_buffers; },
+            [](sw::kpu::KPUSimulator::Config& c, size_t v) { c.l1_layer.num_buffers = v; })
+        .def_property("l1_buffer_capacity_kb",
+            [](const sw::kpu::KPUSimulator::Config& c) { return c.l1_layer.capacity_kb; },
+            [](sw::kpu::KPUSimulator::Config& c, sw::kpu::Size v) { c.l1_layer.capacity_kb = v; })
         // Compute resources
         .def_readwrite("compute_tile_count", &sw::kpu::KPUSimulator::Config::compute_tile_count)
         // Data movement engines

--- a/tests/block_mover/test_block_mover_basic.cpp
+++ b/tests/block_mover/test_block_mover_basic.cpp
@@ -21,8 +21,8 @@ public:
         config.memory_bank_count = 2;
         config.memory_bank_capacity_mb = 64;
         config.memory_bandwidth_gbps = 8;
-        config.l1_buffer_count = 2;
-        config.l1_buffer_capacity_kb = 256;
+        config.l1_layer.num_buffers = 2;
+        config.l1_layer.capacity_kb = 256;
         config.compute_tile_count = 1;
         config.dma_engine_count = 4;
         config.l3_layer.num_tiles = 4;

--- a/tests/common/test_configs.hpp
+++ b/tests/common/test_configs.hpp
@@ -49,8 +49,8 @@ inline KPUSimulator::Config minimal_config() {
     c.l3_layer.capacity_kb      = 64;
     c.l2_layer.num_banks        = 1;
     c.l2_layer.capacity_kb      = 32;
-    c.l1_buffer_count           = 1;
-    c.l1_buffer_capacity_kb     = 32;
+    c.l1_layer.num_buffers      = 1;
+    c.l1_layer.capacity_kb      = 32;
     c.compute_tile_count        = 1;
     c.dma_engine_count          = 1;
     return c;
@@ -68,8 +68,8 @@ inline KPUSimulator::Config small_config() {
     c.l3_layer.capacity_kb      = 256;
     c.l2_layer.num_banks        = 4;
     c.l2_layer.capacity_kb      = 128;
-    c.l1_buffer_count           = 2;
-    c.l1_buffer_capacity_kb     = 64;
+    c.l1_layer.num_buffers      = 2;
+    c.l1_layer.capacity_kb      = 64;
     c.compute_tile_count        = 2;
     c.dma_engine_count          = 4;
     return c;
@@ -89,8 +89,8 @@ inline KPUSimulator::Config medium_config() {
     c.l3_layer.capacity_kb      = 1024;
     c.l2_layer.num_banks        = 4;
     c.l2_layer.capacity_kb      = 512;
-    c.l1_buffer_count           = 4;
-    c.l1_buffer_capacity_kb     = 256;
+    c.l1_layer.num_buffers      = 4;
+    c.l1_layer.capacity_kb      = 256;
     c.compute_tile_count        = 4;
     c.dma_engine_count          = 8;
     return c;

--- a/tests/compute/test_systolic_array.cpp
+++ b/tests/compute/test_systolic_array.cpp
@@ -21,8 +21,8 @@ public:
         config.memory_bank_count = 2;
         config.memory_bank_capacity_mb = 64;
         config.memory_bandwidth_gbps = 8;
-        config.l1_buffer_count = 4;
-        config.l1_buffer_capacity_kb = 256;
+        config.l1_layer.num_buffers = 4;
+        config.l1_layer.capacity_kb = 256;
         config.compute_tile_count = 1;
         config.dma_engine_count = 2;
         config.l3_layer.num_tiles = 4;

--- a/tests/driver/test_all_resources.cpp
+++ b/tests/driver/test_all_resources.cpp
@@ -37,8 +37,8 @@ public:
         config.l2_layer.num_banks = 8;
         config.l2_layer.capacity_kb = 64;
 
-        config.l1_buffer_count = 16;
-        config.l1_buffer_capacity_kb = 8;
+        config.l1_layer.num_buffers = 16;
+        config.l1_layer.capacity_kb = 8;
 
         config.page_buffer_count = 4;
         config.page_buffer_capacity_kb = 16;

--- a/tests/driver/test_resource_api.cpp
+++ b/tests/driver/test_resource_api.cpp
@@ -97,7 +97,7 @@ TEST_CASE("ResourceManager resource discovery", "[resource_api]") {
     config.memory_bank_capacity_mb = 128;  // 128 MB per bank
     config.l3_layer.num_tiles = 4;
     config.l2_layer.num_banks = 8;
-    config.l1_buffer_count = 4;
+    config.l1_layer.num_buffers = 4;
     config.page_buffer_count = 2;
     config.compute_tile_count = 2;
     config.dma_engine_count = 4;

--- a/tests/runtime/test_executor.cpp
+++ b/tests/runtime/test_executor.cpp
@@ -35,8 +35,8 @@ protected:
         config.l2_layer.capacity_kb = 64;
         config.page_buffer_count = 2;
         config.page_buffer_capacity_kb = 64;
-        config.l1_buffer_count = 4;
-        config.l1_buffer_capacity_kb = 64;
+        config.l1_layer.num_buffers = 4;
+        config.l1_layer.capacity_kb = 64;
         config.dma_engine_count = 2;
         config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;

--- a/tests/runtime/test_graph.cpp
+++ b/tests/runtime/test_graph.cpp
@@ -34,8 +34,8 @@ protected:
         config.l2_layer.capacity_kb = 64;
         config.page_buffer_count = 2;
         config.page_buffer_capacity_kb = 64;
-        config.l1_buffer_count = 4;
-        config.l1_buffer_capacity_kb = 64;
+        config.l1_layer.num_buffers = 4;
+        config.l1_layer.capacity_kb = 64;
         config.dma_engine_count = 2;
         config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;

--- a/tests/runtime/test_runtime.cpp
+++ b/tests/runtime/test_runtime.cpp
@@ -35,8 +35,8 @@ protected:
         config.l2_layer.capacity_kb = 64;
         config.page_buffer_count = 2;
         config.page_buffer_capacity_kb = 64;
-        config.l1_buffer_count = 4;
-        config.l1_buffer_capacity_kb = 64;
+        config.l1_layer.num_buffers = 4;
+        config.l1_layer.capacity_kb = 64;
         config.dma_engine_count = 2;
         config.l3_layer.block_mover_count = 4;
         config.streamer_count = 8;

--- a/tests/streamer/test_streamer_basic.cpp
+++ b/tests/streamer/test_streamer_basic.cpp
@@ -21,8 +21,8 @@ public:
         config.memory_bank_count = 2;
         config.memory_bank_capacity_mb = 64;
         config.memory_bandwidth_gbps = 8;
-        config.l1_buffer_count = 4;
-        config.l1_buffer_capacity_kb = 256;
+        config.l1_layer.num_buffers = 4;
+        config.l1_layer.capacity_kb = 256;
         config.compute_tile_count = 1;
         config.dma_engine_count = 4;
         config.l3_layer.num_tiles = 4;
@@ -320,7 +320,7 @@ TEST_CASE_METHOD(StreamerTestFixture, "Streamer Error Handling", "[streamer][err
     }
 
     SECTION("Validates L1 buffer ID bounds") {
-        const size_t invalid_l1_id = config.l1_buffer_count + 1;
+        const size_t invalid_l1_id = config.l1_layer.num_buffers + 1;
 
         REQUIRE_THROWS_AS(
             sim->start_row_stream(0, 0, invalid_l1_id, 0, 0, 4, 4, 4, 2),

--- a/tools/runner/kpu_runner.cpp
+++ b/tools/runner/kpu_runner.cpp
@@ -81,8 +81,8 @@ KPUSimulator::Config convert_config(const SimulatorConfig& sim_config) {
     config.l2_layer.capacity_kb = 64;  // Default
 
     // L1 buffers - derived from compute fabric
-    config.l1_buffer_count = 0;  // Auto-compute
-    config.l1_buffer_capacity_kb = 32;
+    config.l1_layer.num_buffers = 0;  // Auto-compute
+    config.l1_layer.capacity_kb = 32;
 
     // Data movement
     config.dma_engine_count = sim_config.num_dma_engines;

--- a/tools/runtime/kpu-loader/schedule_binder.cpp
+++ b/tools/runtime/kpu-loader/schedule_binder.cpp
@@ -76,7 +76,7 @@ BoundSchedule ScheduleBinder::bind(const dfx::Program& program) {
             current_l2_bank = (current_l2_bank + 1) % config_.l2_layer.num_banks;
 
             bound.l1_buffer_id = current_l1_buffer;
-            current_l1_buffer = (current_l1_buffer + 1) % config_.l1_buffer_count;
+            current_l1_buffer = (current_l1_buffer + 1) % config_.l1_layer.num_buffers;
 
             // Calculate addresses
             bound.source_addr = calculate_address(data_move->source, src_level);


### PR DESCRIPTION
## Summary

Resolves #34 — introduce the **`L1Layer`** aggregate over the retained
`L1Buffer` stream buffers, completing the memory-layer restructuring epic (#35)
with all three layers (L3/L2/L1) now owned by symmetric aggregates.

### Decision reversed (with rationale)

The earlier plan said *no* `L1Layer` (fold `L1Buffer` into `ComputeFabric`). That
is **superseded**:

- The "L1 is derived from the fabric" argument does **not** distinguish L1 from
  L2 — the `L2Bank` shape is also a function of fabric size and kernel schedule.
- The Layers are **conceptual resource owners for monitoring/debug, not a
  ResourceManager/dataflow API** (the distributed DMA/BlockMover/Streamer CSPs
  drive the actual dataflow + credit flow). Under that framing, L1 should have
  its own owner for symmetry and efficient monitoring.

The issue body, the design plan (`docs/plans/memory-layer-restructuring.md`),
and this PR all reflect the updated decision.

## Commits

- **`56679ee` (1A+1B, foundation):** new `L1Layer` / `L1LayerConfig` (owns the
  `L1Buffer`s; `group → element-config → multiplicity` config with scalar
  uniform convenience; `total_capacity_bytes()` monitoring accessor).
  `KPUSimulator` holds one `L1Layer`; internal sites delegate via
  `l1_layer.buffers()`. Behavior-preserving. Plan doc updated.
- **`a059a4f` (1C, hard break):** remove flat `l1_buffer_count` /
  `l1_buffer_capacity_kb` from `Config`; route through `l1_layer`.

## Migration

| Old | New |
|-----|-----|
| `config.l1_buffer_count` | `config.l1_layer.num_buffers` |
| `config.l1_buffer_capacity_kb` | `config.l1_layer.capacity_kb` |

- L1 address-map regions built from the constructed layer. `l1_buffer_base`
  retained. Derived-from-topology count remains a caller responsibility.
- Python keeps the old attribute names via `def_property` proxies; C ABI struct
  unchanged.

## Care taken

Per-file owning-struct audit before migrating (these field names are shared by
`MemoryModelConfig`); migrated only the 24 `KPUSimulator::Config` files. Build
green on first try after fixing `generate_multi_bank_config`.

## Validation

- Build green on **linux-gcc**; **95/95** ctest pass. CHANGELOG updated.

Closes #34 · epic #35 (final piece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * L1 buffer settings now use a nested L1 layer configuration instead of flat top-level fields.
  * Existing examples, tests, tools, and Python accessors were updated to match the new configuration shape.

* **New Features**
  * Added support for an explicit L1 layer with configurable buffer groups, including non-uniform layouts.

* **Bug Fixes**
  * L1 buffer allocation, validation, and status reporting now follow the updated L1 layer structure consistently across the simulator and related tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->