### PR TITLE
feat(46): fused-MLP SURE + domain-flow derivation (B3)

### DIFF
--- a/docs/design/fused-mlp-sure.md
+++ b/docs/design/fused-mlp-sure.md
@@ -145,13 +145,28 @@ Construction sketch (one fused node, one domain):
 4. `applyLinearSchedule(τ)` with `τ=(0,0,1)` to generate wavefronts; sanity-check
    latency/speed-of-light.
 
-### Open verification item
+### Resolved: approach B3 (own the fused domain in kpu-sim)
 
-If domain_flow's `DomainOfComputation` / `RecurrenceVariable` API turns out to
-force everything through `elaborate(opType)` and cannot cleanly carry a custom
-boundary recurrence, the minimal fallback is a small **upstream** addition to
-`branes-ai/domain_flow` (a `FUSED_MATMUL_BIAS_ACT` elaboration). This would be
-raised as an explicit decision, not a silent fork.
+Verification of the domain_flow headers settled the open question: a
+`DomainFlowNode`'s domain is elaborated **purely from `opType`**
+(`domain_of_computation.hpp` `elaborate*` switch over `ADD/MATMUL/…`), and
+`RecurrenceVariable` is **decoupled** from the graph path (used only in
+`recurrence_var.hpp` / `dependency_graph.hpp`). There is **no API to attach a
+custom boundary recurrence to a graph node**, so a genuine single-domain fusion
+cannot be expressed through domain_flow's graph IR as-is.
+
+Decision (**B3**): build the fused domain *in kpu-sim* using domain_flow's
+**standalone** primitives — `ConstraintSet` → `IndexSpace` for the merged
+`(i,j,k)` domain, `RecurrenceVariable` + `AffineMap` for the recurrence system,
+`ScheduleVector` for the output-stationary schedule — leaving domain_flow
+unmodified (it is the polyhedral/affine math kernel). Reference implementation:
+`examples/dataflow/fused_mlp_sure_demo.cpp` (self-validating; registered as the
+`fused_mlp_sure_demo` CTest).
+
+The two upstream alternatives are filed against domain_flow so they are not lost:
+- **B1** — fused `MATMUL` epilogue via an output-face activation attribute
+  (bias via existing `Cin`): `branes-ai/domain_flow#1`.
+- **B2** — dedicated `FUSED_MATMUL_BIAS_ACT` operator: `branes-ai/domain_flow#2`.
 
 ## 6. Bridge into kpu-sim
 

--- a/docs/design/fused-mlp-sure.md
+++ b/docs/design/fused-mlp-sure.md
@@ -84,9 +84,11 @@ Y(i, j) = activation( C(i, j, K-1) + b(j) )
 ```
 
 `C` at the terminal face is consumed **in place** by the bias-add and
-activation. The dependence epilogue→accumulation is **intra-domain** (a boundary
-dependence within `D`), not an inter-domain edge. `b(j)` enters at the terminal
-face (broadcast over `i`, `k`). The only value that leaves `D` is `Y(i,j)`.
+activation. The epilogue **reads** the accumulation result `C(i,j,K-1)` — it does
+not feed the accumulation; that dependence (accumulation → epilogue) is
+**intra-domain** (a boundary dependence within `D`), not an inter-domain edge.
+`b(j)` enters at the terminal face (broadcast over `i`, `k`). The only value that
+leaves `D` is `Y(i,j)`.
 
 ### 3.2 Dependence summary
 
@@ -135,15 +137,26 @@ which we bypass by constructing the recurrence system explicitly):
 
 Construction sketch (one fused node, one domain):
 
-1. Build `ConstraintSet` for `0≤i<B, 0≤j<N, 0≤k<K`; `IndexSpace::enumerate()`.
-2. Create `RecurrenceVariable`s `X,W,C,b,Y`; attach dependences via `AffineMap`:
-   `X.dependsOn(X, shift(0,1,0))`, `W.dependsOn(W, shift(1,0,0))`,
-   `C.dependsOn(C, shift(0,0,1))`, plus the terminal-face epilogue for `Y`.
-3. Attach the recurrence system + index space to a `DomainFlowNode`'s
-   `DomainOfComputation`; tag the node (attribute `fused = matmul_bias_<act>`),
-   map `b` and `Y` confluences to the `k=K-1` face.
-4. `applyLinearSchedule(τ)` with `τ=(0,0,1)` to generate wavefronts; sanity-check
-   latency/speed-of-light.
+*Conceptual mapping. The realized B3 path (see "Resolved" below) builds the
+domain and schedule directly from the standalone primitives and does **not**
+construct a `DomainFlowNode`; steps 3–4 describe the graph-IR mapping that B3
+supersedes.*
+
+1. Build `ConstraintSet` for `0≤i<B, 0≤j<N, 0≤k<K`; construct an `IndexSpace`
+   from it (its constructor enumerates the integer points of `D`).
+2. Create `RecurrenceVariable`s `X,W,C` and attach their **uniform** dependences
+   via `AffineMap`: `X.dependsOn(X, shift(0,1,0))`,
+   `W.dependsOn(W, shift(1,0,0))`, `C.dependsOn(C, shift(0,0,1))`. The bias `b`
+   and output `Y` are **not** graph recurrence variables — they are the
+   terminal-face epilogue `Y(i,j) = act(C(i,j,K-1) + b(j))`, applied when a point
+   reaches `k=K-1`. (This is exactly what `fused_mlp_sure.cpp` does: only `X,W,C`
+   are `sw::dfa` recurrence variables.)
+3. *(graph-IR mapping, not taken by B3)* Attach the recurrence system + index
+   space to a `DomainFlowNode`'s `DomainOfComputation`; tag the node (attribute
+   `fused = matmul_bias_<act>`), map `b` and `Y` confluences to the `k=K-1` face.
+4. *(graph-IR mapping, not taken by B3)* `applyLinearSchedule(τ)` with `τ=(0,0,1)`
+   to generate wavefronts. In B3 the schedule is applied directly over the
+   enumerated index space (`ScheduleVector::dot`), as in the demo/library.
 
 ### Resolved: approach B3 (own the fused domain in kpu-sim)
 

--- a/docs/design/fused-mlp-sure.md
+++ b/docs/design/fused-mlp-sure.md
@@ -1,0 +1,179 @@
+# Fused batched-MLP layer: SURE and domain-flow derivation
+
+**Status:** Design (issue #46, epic #45)
+**Operator:** `Y = activation( X · W + b )` — fused matmul + bias + activation
+**Depends on:** `branes-ai/domain_flow` (`sw::dfa`, `KPU_HAS_DOMAIN_FLOW`)
+
+## 1. Operator
+
+A batched MLP layer over a batch of `B` samples:
+
+```
+X : [B, K]   (batch B, in-features K)
+W : [K, N]   (weights)
+b : [N]      (bias, broadcast over the batch)
+Y : [B, N]   Y[i,j] = activation( Σ_k X[i,k]·W[k,j] + b[j] )
+activation ∈ { ReLU, GELU, SiLU, Sigmoid, … }
+```
+
+We model this as a **single fused operator**, i.e. a single System of Uniform
+Recurrence Equations (SURE) over one iteration domain — *not* three operators
+(matmul, bias-add, activation) chained by inter-operator edges.
+
+## 2. Why "fused" must merge the domains (not annotate three of them)
+
+In a SURE an operator **is** a domain of computation: an index space plus a
+system of recurrence equations whose dependence vectors are uniform over that
+domain. Composing three separate operators yields **three domains joined by
+inter-domain edges**; each edge means the producer's result is a *tensor that
+leaves its domain and is communicated* to the consumer's domain.
+
+**Unfused** (three domains, two communicated intermediates):
+
+| Domain | Index space | Reads | Emits (leaves the domain) |
+|--------|-------------|-------|---------------------------|
+| `D₁` matmul | `(i,j,k)` | `X`, `W` | `A[i,j] = C(i,j,K-1)` |
+| `D₂` bias  | `(i,j)`   | `A`, `b` | `Z[i,j] = A[i,j] + b[j]` |
+| `D₃` act   | `(i,j)`   | `Z`      | `Y[i,j] = act(Z[i,j])` |
+
+Marking these three nodes "fused" with metadata changes **none** of the
+recurrence equations: the domains are still separate, the edges still imply
+communicating `A` and `Z`, and the local recurrence that should connect the
+accumulation result to the epilogue does not exist in the representation. Fusion
+genuinely *changes the recurrence equations*, so a flag cannot express it.
+
+**Fused** merges `D₂` and `D₃` onto `D₁`'s terminal face and rewrites the
+epilogue as **boundary recurrences inside the single domain**, so neither `A`
+nor `Z` is ever materialized or communicated.
+
+## 3. The fused SURE
+
+Single iteration domain:
+
+```
+D = { (i, j, k) ∈ ℤ³ : 0 ≤ i < B, 0 ≤ j < N, 0 ≤ k < K }
+```
+
+Bias/activation add **no iteration dimensions** — they are pointwise on the
+`(i,j)` output face — so the fused domain is exactly the matmul domain.
+
+### 3.1 Recurrence equations
+
+**Input propagation (uniform broadcast):**
+
+```
+X(i, j, k) = X(i, j-1, k)        seeded at j = 0 from input X[i,k]     dep (0,1,0)
+W(i, j, k) = W(i-1, j, k)        seeded at i = 0 from input W[k,j]     dep (1,0,0)
+```
+
+`X` is independent of `j` (reused across output columns); `W` is independent of
+`i` (reused across the batch). The seeds inject the external tensors at the
+`j=0` / `i=0` faces.
+
+**Accumulation (reduction along k):**
+
+```
+C(i, j, k) = C(i, j, k-1) + X(i, j, k) · W(i, j, k)
+C(i, j, -1) = 0                                                        dep (0,0,1)
+```
+
+**Epilogue on the terminal face k = K-1 (the fusion):**
+
+```
+Y(i, j) = activation( C(i, j, K-1) + b(j) )
+```
+
+`C` at the terminal face is consumed **in place** by the bias-add and
+activation. The dependence epilogue→accumulation is **intra-domain** (a boundary
+dependence within `D`), not an inter-domain edge. `b(j)` enters at the terminal
+face (broadcast over `i`, `k`). The only value that leaves `D` is `Y(i,j)`.
+
+### 3.2 Dependence summary
+
+| Variable | Recurrence | Dependence vector | Meaning |
+|----------|------------|-------------------|---------|
+| `X` | `X(i,j,k)=X(i,j-1,k)` | `(0,1,0)` | input reuse across columns |
+| `W` | `W(i,j,k)=W(i-1,j,k)` | `(1,0,0)` | weight reuse across batch |
+| `C` | `C(i,j,k)=C(i,j,k-1)+X·W` | `(0,0,1)` | accumulation |
+| `Y` | `Y(i,j)=act(C(i,j,K-1)+b(j))` | boundary (k=K-1) | fused epilogue, in place |
+
+This is the energy-optimal transformation: the bias and activation cost no extra
+data movement because they ride the accumulation's exit at the terminal face;
+the matmul's intermediate `A` and the bias output `Z` never exist as tensors.
+
+## 4. Schedule (space–time mapping)
+
+`domain_flow` does **not** synthesize schedules (`generateSchedule()` is a stub);
+we supply an explicit linear schedule τ. For the **output-stationary** dataflow
+the simulator already uses:
+
+- **Time** advances along the accumulation axis `k`: `τ = (0, 0, 1)` (or a skewed
+  variant for the systolic fill/drain), so `time(i,j,k) = τ · (i,j,k) = k`.
+- **Space** = the `(i,j)` output plane, mapped onto the systolic array; each PE
+  owns one output `Y(i,j)` and accumulates over `k` in time. This is precisely
+  why "output-stationary": the stationary operand is the accumulator `C(i,j,·)`.
+- The epilogue fires once per PE at `k = K-1` (the fused tail), reusing the SFU
+  for the activation.
+
+Automated schedule **synthesis** (deriving τ from the dependence cone) is out of
+scope for #46 and is filed separately — see §7.
+
+## 5. Mapping to `sw::dfa` (domain_flow) primitives
+
+Built with the standalone SURE primitives, so **no edit to domain_flow's
+operator enum is required** (the enum only drives shape-based auto-elaboration,
+which we bypass by constructing the recurrence system explicitly):
+
+| Concept | domain_flow type | Header |
+|---------|------------------|--------|
+| Iteration domain `D` | `ConstraintSet<int>` → `IndexSpace<int>` | `dfa/constraint_set.hpp`, `dfa/index_space.hpp` |
+| Domain of computation | `DomainOfComputation<int>` (node `.doc`) | `dfa/domain_of_computation.hpp` |
+| Recurrence variables `X,W,C,b,Y` | `RecurrenceVariable` | `dfa/recurrence_var.hpp` |
+| Dependence maps | `AffineMap<int>` (`f(x)=Ax+c`) | `dfa/affine_map.hpp` |
+| Schedule τ / wavefronts | `ScheduleVector<int>`, `Schedule<int>` | `dfa/schedule.hpp` |
+| Node / graph | `DomainFlowNode`, `DomainFlowGraph` | `dfa/domain_flow_node.hpp`, `dfa/domain_flow_graph.hpp` |
+
+Construction sketch (one fused node, one domain):
+
+1. Build `ConstraintSet` for `0≤i<B, 0≤j<N, 0≤k<K`; `IndexSpace::enumerate()`.
+2. Create `RecurrenceVariable`s `X,W,C,b,Y`; attach dependences via `AffineMap`:
+   `X.dependsOn(X, shift(0,1,0))`, `W.dependsOn(W, shift(1,0,0))`,
+   `C.dependsOn(C, shift(0,0,1))`, plus the terminal-face epilogue for `Y`.
+3. Attach the recurrence system + index space to a `DomainFlowNode`'s
+   `DomainOfComputation`; tag the node (attribute `fused = matmul_bias_<act>`),
+   map `b` and `Y` confluences to the `k=K-1` face.
+4. `applyLinearSchedule(τ)` with `τ=(0,0,1)` to generate wavefronts; sanity-check
+   latency/speed-of-light.
+
+### Open verification item
+
+If domain_flow's `DomainOfComputation` / `RecurrenceVariable` API turns out to
+force everything through `elaborate(opType)` and cannot cleanly carry a custom
+boundary recurrence, the minimal fallback is a small **upstream** addition to
+`branes-ai/domain_flow` (a `FUSED_MATMUL_BIAS_ACT` elaboration). This would be
+raised as an explicit decision, not a silent fork.
+
+## 6. Bridge into kpu-sim
+
+The derived fused domain feeds the simulator's existing IR:
+
+- `ComputationalGraph` (`include/sw/compiler/graph_loader.hpp`) — single fused op
+  node carrying shapes + activation kind.
+- `TileDataFlowGraph` (`include/sw/kpu/dataflow/tile_dataflow_graph.hpp`) — the
+  tiled lowering target consumed by #47.
+
+Validation for #46: build the fused-MLP `DomainFlowGraph`, derive the domain +
+index space, apply τ, and confirm the **single-tile** case reproduces the
+reference `Y = act(X·W + b)` (numerically, against `compute_harness`).
+
+## 7. Scope boundaries
+
+- **#46 (this):** the fused SURE + derived domain-flow program (domains,
+  dependence vectors, explicit output-stationary schedule) + bridge + single-tile
+  validation.
+- **#47:** lower the fused domain to a tiled `DMProgram` (matmul epilogue).
+- **#48:** multi-tile tiling/reuse configs (1…33 L3 tiles).
+- **Separate/new issue:** automated polyhedral schedule **synthesis** (domain_flow
+  `generateSchedule()` is currently a stub).
+- **Possible upstream:** a fused-operator auto-elaboration in `branes-ai/domain_flow`
+  (only if the manual-construction path proves insufficient — see §5).

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -51,6 +51,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/schedule)
     add_subdirectory(schedule)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/dataflow)
+    add_subdirectory(dataflow)
+endif()
+
 if(KPU_BUILD_PYTHON_BINDINGS)
     # Python examples are handled by the Python package
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)

--- a/examples/dataflow/CMakeLists.txt
+++ b/examples/dataflow/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ============================================================================
+# examples/dataflow/CMakeLists.txt
+# Domain-flow / SURE demonstrations
+# ============================================================================
+
+# Fused batched-MLP SURE demo: builds the fused matmul+bias+activation operator
+# as a single SURE using domain_flow's standalone primitives (option B3).
+# Only meaningful when domain_flow is available.
+add_executable(fused_mlp_sure_demo fused_mlp_sure_demo.cpp)
+
+# kpu_compiler PUBLIC-exposes KPU_HAS_DOMAIN_FLOW and the domain_flow SYSTEM
+# include path, and links whatever domain_flow needs.
+target_link_libraries(fused_mlp_sure_demo PRIVATE kpu_compiler)
+
+set_target_properties(fused_mlp_sure_demo PROPERTIES FOLDER "Examples/Dataflow")
+
+# Self-validating (exits non-zero on mismatch) — register as a CTest.
+if(KPU_BUILD_TESTS)
+    add_test(NAME fused_mlp_sure_demo COMMAND fused_mlp_sure_demo)
+    set_tests_properties(fused_mlp_sure_demo PROPERTIES LABELS "dataflow;fusion")
+endif()

--- a/examples/dataflow/CMakeLists.txt
+++ b/examples/dataflow/CMakeLists.txt
@@ -8,9 +8,9 @@
 # Only meaningful when domain_flow is available.
 add_executable(fused_mlp_sure_demo fused_mlp_sure_demo.cpp)
 
-# kpu_compiler PUBLIC-exposes KPU_HAS_DOMAIN_FLOW and the domain_flow SYSTEM
-# include path, and links whatever domain_flow needs.
-target_link_libraries(fused_mlp_sure_demo PRIVATE kpu_compiler)
+# Thin client of the reusable FusedMlpSure library (kpu_dataflow). The library's
+# public header is domain_flow-free, so the demo needs no domain_flow setup.
+target_link_libraries(fused_mlp_sure_demo PRIVATE kpu_dataflow)
 
 set_target_properties(fused_mlp_sure_demo PROPERTIES FOLDER "Examples/Dataflow")
 

--- a/examples/dataflow/fused_mlp_sure_demo.cpp
+++ b/examples/dataflow/fused_mlp_sure_demo.cpp
@@ -1,193 +1,69 @@
 // ============================================================================
-// Fused batched-MLP layer as a single SURE — "fusion in action"
+// Fused batched-MLP layer as a single SURE — "fusion in action".
 //
 //   Y[i,j] = activation( sum_k X[i,k] * W[k,j] + b[j] )
 //
-// This demo builds the FUSED operator as ONE System of Uniform Recurrence
-// Equations (SURE) over a single iteration domain D = {(i,j,k)}, using
-// domain_flow's standalone polyhedral/affine primitives (option "B3"):
-//   ConstraintSet, IndexSpace, RecurrenceVariable, AffineMap, ScheduleVector.
-// domain_flow itself is left unmodified — we use it as the math kernel and own
-// the fused-domain construction here.
+// Thin client of the reusable FusedMlpSure library API
+// (include/sw/kpu/dataflow/fused_mlp_sure.hpp). The library models the fused
+// matmul+bias+activation operator as ONE SURE over a single (i,j,k) domain,
+// with the bias+activation as boundary recurrences on the terminal face k=K-1
+// (built on domain_flow's polyhedral primitives; see docs/design/fused-mlp-sure.md).
 //
-// The point of the demo is to SHOW why fusion is a property of the recurrence
-// system, not a label:
-//   * the matmul, bias-add, and activation live in ONE domain;
-//   * the bias+activation are BOUNDARY recurrences on the terminal face k=K-1;
-//   * under the output-stationary schedule tau=(0,0,1) the epilogue rides the
-//     last wavefront — the matmul result is consumed in place and never leaves
-//     the domain as an intermediate tensor.
-//
-// See docs/design/fused-mlp-sure.md for the formalism. (issue #46, epic #45)
+// This demo prints the fused domain / recurrences / schedule and validates the
+// fused execution against a direct reference. (issue #46, epic #45)
 // ============================================================================
 
+#include <sw/kpu/dataflow/fused_mlp_sure.hpp>
+
+#include <cmath>
 #include <iostream>
 #include <vector>
-#include <map>
-#include <cmath>
-#include <string>
 
-#ifdef KPU_HAS_DOMAIN_FLOW
-
-#include <dfa/dfa.hpp>
-
-using namespace sw::dfa;
-
-namespace {
-
-// Extract the uniform dependence vector d from a "reads-from" affine map
-// f(p) = p + c  (so the value at p depends on the value at p+c, i.e. d = -c).
-std::vector<int> dependence_vector(const AffineMap<int>& reads_from, int dim) {
-    // Apply the map to the origin to recover the constant translation c, then d = -c.
-    VectorX<int> origin(static_cast<size_t>(dim), 0);
-    VectorX<int> c = reads_from.apply(origin);
-    std::vector<int> d(dim);
-    for (int t = 0; t < dim; ++t) d[t] = -c[t];
-    return d;
-}
-
-float relu(float x) { return x > 0.0f ? x : 0.0f; }
-
-} // namespace
+using sw::kpu::dataflow::Activation;
+using sw::kpu::dataflow::FusedMlpSure;
+using sw::kpu::dataflow::FusedMlpSureConfig;
+using sw::kpu::dataflow::apply_activation;
 
 int main() {
-    // ---- problem dimensions (small, single-tile, easy to read) -------------
-    const int B = 2;   // batch
-    const int K = 3;   // in-features
-    const int N = 2;   // out-features
+    FusedMlpSureConfig cfg;
+    cfg.batch = 2;          // B
+    cfg.in_features = 3;    // K
+    cfg.out_features = 2;   // N
+    cfg.activation = Activation::ReLU;
 
-    std::cout << "Fused batched-MLP SURE:  Y = relu(X[" << B << "x" << K
-              << "] . W[" << K << "x" << N << "] + b[" << N << "])\n\n";
+    FusedMlpSure sure(cfg);
 
-    // ======================================================================
-    // 1) THE FUSED DOMAIN  D = { (i,j,k) : 0<=i<B, 0<=j<N, 0<=k<K }
-    //    Bias and activation add NO iteration dimensions (they are pointwise on
-    //    the (i,j) output face), so the fused domain IS the matmul domain.
-    // ======================================================================
-    ConstraintSet<int> cs;
-    cs.add(Hyperplane<int>({1, 0, 0}, 0,     ConstraintType::GreaterOrEqual)); // i >= 0
-    cs.add(Hyperplane<int>({1, 0, 0}, B - 1, ConstraintType::LessOrEqual));    // i <= B-1
-    cs.add(Hyperplane<int>({0, 1, 0}, 0,     ConstraintType::GreaterOrEqual)); // j >= 0
-    cs.add(Hyperplane<int>({0, 1, 0}, N - 1, ConstraintType::LessOrEqual));    // j <= N-1
-    cs.add(Hyperplane<int>({0, 0, 1}, 0,     ConstraintType::GreaterOrEqual)); // k >= 0
-    cs.add(Hyperplane<int>({0, 0, 1}, K - 1, ConstraintType::LessOrEqual));    // k <= K-1
+    // [1]-[3]: the fused domain, recurrence system, and wavefront schedule.
+    std::cout << sure.describe() << "\n";
 
-    IndexSpace<int> domain(cs);  // ctor builds the bounding box and enumerates D
+    // ---- inputs (deterministic, easy to read) ------------------------------
+    const std::size_t B = cfg.batch, K = cfg.in_features, N = cfg.out_features;
+    std::vector<float> X(B * K), W(K * N), b(N);
+    for (std::size_t i = 0; i < B; ++i)
+        for (std::size_t k = 0; k < K; ++k) X[i * K + k] = 0.5f * (i + 1) + k;
+    for (std::size_t k = 0; k < K; ++k)
+        for (std::size_t j = 0; j < N; ++j) W[k * N + j] = (static_cast<float>(k) - j) * 0.25f;
+    for (std::size_t j = 0; j < N; ++j) b[j] = (j == 0) ? 1.0f : -1.0f;
 
-    // Use domain_flow's enumerated points if it produced the expected lattice;
-    // otherwise fall back to a direct enumeration (and say so), so the demo is
-    // robust to enumerator quirks while still exercising the ConstraintSet path.
-    std::vector<IndexPoint> points = domain.getPoints();
-    const size_t expected = static_cast<size_t>(B) * N * K;
-    bool used_dfa_enum = (points.size() == expected);
-    if (!used_dfa_enum) {
-        points.clear();
-        for (int i = 0; i < B; ++i)
-            for (int j = 0; j < N; ++j)
-                for (int k = 0; k < K; ++k)
-                    points.push_back(IndexPoint({i, j, k}));
-    }
-    std::cout << "[1] Single fused domain D: " << points.size()
-              << " index points (" << B << "x" << N << "x" << K << "), built from "
-              << cs.getConstraints().size() << " constraints"
-              << (used_dfa_enum ? " [enumerated by domain_flow IndexSpace]\n\n"
-                                : " [direct enumeration fallback]\n\n");
-
-    // ======================================================================
-    // 2) THE RECURRENCE SYSTEM (the SURE). Uniform dependences expressed as
-    //    affine "reads-from" maps f(p) = p + c.  d = -c is the dependence vector.
-    // ======================================================================
-    RecurrenceVariable X("X", 3), W("W", 3), C("C", 3), Y("Y", 3), bias("b", 3);
-
-    // X(i,j,k) = X(i,j-1,k)   -> reuse across output columns j     dep (0,1,0)
-    AffineMap<int> readX({{1,0,0},{0,1,0},{0,0,1}}, {0, -1, 0});
-    // W(i,j,k) = W(i-1,j,k)   -> reuse across the batch i          dep (1,0,0)
-    AffineMap<int> readW({{1,0,0},{0,1,0},{0,0,1}}, {-1, 0, 0});
-    // C(i,j,k) = C(i,j,k-1) + X*W   -> accumulation along k        dep (0,0,1)
-    AffineMap<int> readC({{1,0,0},{0,1,0},{0,0,1}}, {0, 0, -1});
-    X.dependsOn(&X, readX);
-    W.dependsOn(&W, readW);
-    C.dependsOn(&C, readC);
-
-    auto print_dep = [&](const char* name, const AffineMap<int>& m) {
-        std::vector<int> d = dependence_vector(m, 3);
-        std::cout << "      " << name << " dependence vector = ("
-                  << d[0] << "," << d[1] << "," << d[2] << ")\n";
-    };
-    std::cout << "[2] Recurrence system over D:\n";
-    std::cout << "      X(i,j,k) = X(i,j-1,k)                 (input reuse)\n";
-    print_dep("X", readX);
-    std::cout << "      W(i,j,k) = W(i-1,j,k)                 (weight reuse)\n";
-    print_dep("W", readW);
-    std::cout << "      C(i,j,k) = C(i,j,k-1) + X(i,j,k)*W(i,j,k)   (accumulate)\n";
-    print_dep("C", readC);
-    std::cout << "      EPILOGUE (boundary recurrence on terminal face k=K-1):\n";
-    std::cout << "      Y(i,j)   = relu( C(i,j,K-1) + b(j) )  <-- bias+activation, in place\n";
-    std::cout << "      (only Y leaves D; the matmul result C never becomes a tensor)\n\n";
-    (void)Y; (void)bias;
-
-    // ======================================================================
-    // 3) OUTPUT-STATIONARY SCHEDULE  tau = (0,0,1):  time(i,j,k) = k.
-    //    Each (i,j) PE accumulates over k in time; the epilogue fires at k=K-1.
-    // ======================================================================
-    ScheduleVector<int> tau({0, 0, 1});
-    std::map<long, std::vector<IndexPoint>> wavefronts;
-    for (const auto& p : points) wavefronts[tau.dot(p)].push_back(p);
-
-    std::cout << "[3] Output-stationary schedule tau=(0,0,1) -> wavefronts:\n";
-    for (const auto& [t, wf] : wavefronts) {
-        std::cout << "      t=" << t << " : ";
-        for (const auto& p : wf) std::cout << p;
-        if (t == K - 1) std::cout << "  <-- fused epilogue (bias+activation) rides this wavefront";
-        std::cout << "\n";
-    }
-    std::cout << "\n";
-
-    // ======================================================================
-    // 4) EXECUTE THE SURE in schedule order and validate vs a direct reference.
-    //    This proves the fused recurrence system computes the right answer
-    //    while materializing ZERO intermediate tensors (no A=X.W, no Z=A+b).
-    // ======================================================================
-    // Inputs
-    std::vector<std::vector<float>> Xd(B, std::vector<float>(K));
-    std::vector<std::vector<float>> Wd(K, std::vector<float>(N));
-    std::vector<float> bd(N);
-    for (int i = 0; i < B; ++i) for (int k = 0; k < K; ++k) Xd[i][k] = 0.5f * (i + 1) + k;
-    for (int k = 0; k < K; ++k) for (int j = 0; j < N; ++j) Wd[k][j] = (k - j) * 0.25f;
-    for (int j = 0; j < N; ++j) bd[j] = (j == 0) ? 1.0f : -1.0f;
-
-    // Reference: plain math, no fusion.
-    std::vector<std::vector<float>> Yref(B, std::vector<float>(N));
-    for (int i = 0; i < B; ++i)
-        for (int j = 0; j < N; ++j) {
+    // ---- reference (plain math, no fusion) ---------------------------------
+    std::vector<float> Yref(B * N, 0.0f);
+    for (std::size_t i = 0; i < B; ++i)
+        for (std::size_t j = 0; j < N; ++j) {
             float acc = 0.0f;
-            for (int k = 0; k < K; ++k) acc += Xd[i][k] * Wd[k][j];
-            Yref[i][j] = relu(acc + bd[j]);
+            for (std::size_t k = 0; k < K; ++k) acc += X[i * K + k] * W[k * N + j];
+            Yref[i * N + j] = apply_activation(cfg.activation, acc + b[j]);
         }
 
-    // Fused SURE execution: accumulate C(i,j,.) wavefront by wavefront; apply the
-    // boundary epilogue exactly when a point reaches the terminal face k=K-1.
-    std::vector<std::vector<float>> Cacc(B, std::vector<float>(N, 0.0f));
-    std::vector<std::vector<float>> Yout(B, std::vector<float>(N, 0.0f));
-    for (const auto& [t, wf] : wavefronts) {
-        (void)t;
-        for (const auto& p : wf) {
-            int i = p[0], j = p[1], k = p[2];
-            Cacc[i][j] += Xd[i][k] * Wd[k][j];        // accumulation recurrence
-            if (k == K - 1)                            // terminal face -> fused epilogue
-                Yout[i][j] = relu(Cacc[i][j] + bd[j]);
-        }
-    }
+    // ---- fused SURE execution (library) ------------------------------------
+    std::vector<float> Y = sure.evaluate(X, W, b);
 
     float max_abs_err = 0.0f;
-    for (int i = 0; i < B; ++i)
-        for (int j = 0; j < N; ++j)
-            max_abs_err = std::max(max_abs_err, std::fabs(Yout[i][j] - Yref[i][j]));
+    for (std::size_t t = 0; t < Y.size(); ++t)
+        max_abs_err = std::max(max_abs_err, std::fabs(Y[t] - Yref[t]));
 
-    std::cout << "[4] Fused SURE execution vs reference:  max |error| = "
-              << max_abs_err << "\n";
+    std::cout << "[4] Fused SURE execution vs reference:  max |error| = " << max_abs_err << "\n";
     std::cout << "      Y (fused) =";
-    for (int i = 0; i < B; ++i) for (int j = 0; j < N; ++j) std::cout << " " << Yout[i][j];
+    for (float v : Y) std::cout << " " << v;
     std::cout << "\n      intermediate tensors materialized: 0 (no A=X.W, no Z=A+b)\n\n";
 
     const bool ok = max_abs_err < 1e-5f;
@@ -195,12 +71,3 @@ int main() {
                      : "RESULT: FAIL — fused result does not match reference.\n");
     return ok ? 0 : 1;
 }
-
-#else  // !KPU_HAS_DOMAIN_FLOW
-
-int main() {
-    std::cout << "fused_mlp_sure_demo requires domain_flow (KPU_USE_DOMAIN_FLOW=ON).\n";
-    return 0;
-}
-
-#endif

--- a/examples/dataflow/fused_mlp_sure_demo.cpp
+++ b/examples/dataflow/fused_mlp_sure_demo.cpp
@@ -1,0 +1,206 @@
+// ============================================================================
+// Fused batched-MLP layer as a single SURE — "fusion in action"
+//
+//   Y[i,j] = activation( sum_k X[i,k] * W[k,j] + b[j] )
+//
+// This demo builds the FUSED operator as ONE System of Uniform Recurrence
+// Equations (SURE) over a single iteration domain D = {(i,j,k)}, using
+// domain_flow's standalone polyhedral/affine primitives (option "B3"):
+//   ConstraintSet, IndexSpace, RecurrenceVariable, AffineMap, ScheduleVector.
+// domain_flow itself is left unmodified — we use it as the math kernel and own
+// the fused-domain construction here.
+//
+// The point of the demo is to SHOW why fusion is a property of the recurrence
+// system, not a label:
+//   * the matmul, bias-add, and activation live in ONE domain;
+//   * the bias+activation are BOUNDARY recurrences on the terminal face k=K-1;
+//   * under the output-stationary schedule tau=(0,0,1) the epilogue rides the
+//     last wavefront — the matmul result is consumed in place and never leaves
+//     the domain as an intermediate tensor.
+//
+// See docs/design/fused-mlp-sure.md for the formalism. (issue #46, epic #45)
+// ============================================================================
+
+#include <iostream>
+#include <vector>
+#include <map>
+#include <cmath>
+#include <string>
+
+#ifdef KPU_HAS_DOMAIN_FLOW
+
+#include <dfa/dfa.hpp>
+
+using namespace sw::dfa;
+
+namespace {
+
+// Extract the uniform dependence vector d from a "reads-from" affine map
+// f(p) = p + c  (so the value at p depends on the value at p+c, i.e. d = -c).
+std::vector<int> dependence_vector(const AffineMap<int>& reads_from, int dim) {
+    // Apply the map to the origin to recover the constant translation c, then d = -c.
+    VectorX<int> origin(static_cast<size_t>(dim), 0);
+    VectorX<int> c = reads_from.apply(origin);
+    std::vector<int> d(dim);
+    for (int t = 0; t < dim; ++t) d[t] = -c[t];
+    return d;
+}
+
+float relu(float x) { return x > 0.0f ? x : 0.0f; }
+
+} // namespace
+
+int main() {
+    // ---- problem dimensions (small, single-tile, easy to read) -------------
+    const int B = 2;   // batch
+    const int K = 3;   // in-features
+    const int N = 2;   // out-features
+
+    std::cout << "Fused batched-MLP SURE:  Y = relu(X[" << B << "x" << K
+              << "] . W[" << K << "x" << N << "] + b[" << N << "])\n\n";
+
+    // ======================================================================
+    // 1) THE FUSED DOMAIN  D = { (i,j,k) : 0<=i<B, 0<=j<N, 0<=k<K }
+    //    Bias and activation add NO iteration dimensions (they are pointwise on
+    //    the (i,j) output face), so the fused domain IS the matmul domain.
+    // ======================================================================
+    ConstraintSet<int> cs;
+    cs.add(Hyperplane<int>({1, 0, 0}, 0,     ConstraintType::GreaterOrEqual)); // i >= 0
+    cs.add(Hyperplane<int>({1, 0, 0}, B - 1, ConstraintType::LessOrEqual));    // i <= B-1
+    cs.add(Hyperplane<int>({0, 1, 0}, 0,     ConstraintType::GreaterOrEqual)); // j >= 0
+    cs.add(Hyperplane<int>({0, 1, 0}, N - 1, ConstraintType::LessOrEqual));    // j <= N-1
+    cs.add(Hyperplane<int>({0, 0, 1}, 0,     ConstraintType::GreaterOrEqual)); // k >= 0
+    cs.add(Hyperplane<int>({0, 0, 1}, K - 1, ConstraintType::LessOrEqual));    // k <= K-1
+
+    IndexSpace<int> domain(cs);  // ctor builds the bounding box and enumerates D
+
+    // Use domain_flow's enumerated points if it produced the expected lattice;
+    // otherwise fall back to a direct enumeration (and say so), so the demo is
+    // robust to enumerator quirks while still exercising the ConstraintSet path.
+    std::vector<IndexPoint> points = domain.getPoints();
+    const size_t expected = static_cast<size_t>(B) * N * K;
+    bool used_dfa_enum = (points.size() == expected);
+    if (!used_dfa_enum) {
+        points.clear();
+        for (int i = 0; i < B; ++i)
+            for (int j = 0; j < N; ++j)
+                for (int k = 0; k < K; ++k)
+                    points.push_back(IndexPoint({i, j, k}));
+    }
+    std::cout << "[1] Single fused domain D: " << points.size()
+              << " index points (" << B << "x" << N << "x" << K << "), built from "
+              << cs.getConstraints().size() << " constraints"
+              << (used_dfa_enum ? " [enumerated by domain_flow IndexSpace]\n\n"
+                                : " [direct enumeration fallback]\n\n");
+
+    // ======================================================================
+    // 2) THE RECURRENCE SYSTEM (the SURE). Uniform dependences expressed as
+    //    affine "reads-from" maps f(p) = p + c.  d = -c is the dependence vector.
+    // ======================================================================
+    RecurrenceVariable X("X", 3), W("W", 3), C("C", 3), Y("Y", 3), bias("b", 3);
+
+    // X(i,j,k) = X(i,j-1,k)   -> reuse across output columns j     dep (0,1,0)
+    AffineMap<int> readX({{1,0,0},{0,1,0},{0,0,1}}, {0, -1, 0});
+    // W(i,j,k) = W(i-1,j,k)   -> reuse across the batch i          dep (1,0,0)
+    AffineMap<int> readW({{1,0,0},{0,1,0},{0,0,1}}, {-1, 0, 0});
+    // C(i,j,k) = C(i,j,k-1) + X*W   -> accumulation along k        dep (0,0,1)
+    AffineMap<int> readC({{1,0,0},{0,1,0},{0,0,1}}, {0, 0, -1});
+    X.dependsOn(&X, readX);
+    W.dependsOn(&W, readW);
+    C.dependsOn(&C, readC);
+
+    auto print_dep = [&](const char* name, const AffineMap<int>& m) {
+        std::vector<int> d = dependence_vector(m, 3);
+        std::cout << "      " << name << " dependence vector = ("
+                  << d[0] << "," << d[1] << "," << d[2] << ")\n";
+    };
+    std::cout << "[2] Recurrence system over D:\n";
+    std::cout << "      X(i,j,k) = X(i,j-1,k)                 (input reuse)\n";
+    print_dep("X", readX);
+    std::cout << "      W(i,j,k) = W(i-1,j,k)                 (weight reuse)\n";
+    print_dep("W", readW);
+    std::cout << "      C(i,j,k) = C(i,j,k-1) + X(i,j,k)*W(i,j,k)   (accumulate)\n";
+    print_dep("C", readC);
+    std::cout << "      EPILOGUE (boundary recurrence on terminal face k=K-1):\n";
+    std::cout << "      Y(i,j)   = relu( C(i,j,K-1) + b(j) )  <-- bias+activation, in place\n";
+    std::cout << "      (only Y leaves D; the matmul result C never becomes a tensor)\n\n";
+    (void)Y; (void)bias;
+
+    // ======================================================================
+    // 3) OUTPUT-STATIONARY SCHEDULE  tau = (0,0,1):  time(i,j,k) = k.
+    //    Each (i,j) PE accumulates over k in time; the epilogue fires at k=K-1.
+    // ======================================================================
+    ScheduleVector<int> tau({0, 0, 1});
+    std::map<long, std::vector<IndexPoint>> wavefronts;
+    for (const auto& p : points) wavefronts[tau.dot(p)].push_back(p);
+
+    std::cout << "[3] Output-stationary schedule tau=(0,0,1) -> wavefronts:\n";
+    for (const auto& [t, wf] : wavefronts) {
+        std::cout << "      t=" << t << " : ";
+        for (const auto& p : wf) std::cout << p;
+        if (t == K - 1) std::cout << "  <-- fused epilogue (bias+activation) rides this wavefront";
+        std::cout << "\n";
+    }
+    std::cout << "\n";
+
+    // ======================================================================
+    // 4) EXECUTE THE SURE in schedule order and validate vs a direct reference.
+    //    This proves the fused recurrence system computes the right answer
+    //    while materializing ZERO intermediate tensors (no A=X.W, no Z=A+b).
+    // ======================================================================
+    // Inputs
+    std::vector<std::vector<float>> Xd(B, std::vector<float>(K));
+    std::vector<std::vector<float>> Wd(K, std::vector<float>(N));
+    std::vector<float> bd(N);
+    for (int i = 0; i < B; ++i) for (int k = 0; k < K; ++k) Xd[i][k] = 0.5f * (i + 1) + k;
+    for (int k = 0; k < K; ++k) for (int j = 0; j < N; ++j) Wd[k][j] = (k - j) * 0.25f;
+    for (int j = 0; j < N; ++j) bd[j] = (j == 0) ? 1.0f : -1.0f;
+
+    // Reference: plain math, no fusion.
+    std::vector<std::vector<float>> Yref(B, std::vector<float>(N));
+    for (int i = 0; i < B; ++i)
+        for (int j = 0; j < N; ++j) {
+            float acc = 0.0f;
+            for (int k = 0; k < K; ++k) acc += Xd[i][k] * Wd[k][j];
+            Yref[i][j] = relu(acc + bd[j]);
+        }
+
+    // Fused SURE execution: accumulate C(i,j,.) wavefront by wavefront; apply the
+    // boundary epilogue exactly when a point reaches the terminal face k=K-1.
+    std::vector<std::vector<float>> Cacc(B, std::vector<float>(N, 0.0f));
+    std::vector<std::vector<float>> Yout(B, std::vector<float>(N, 0.0f));
+    for (const auto& [t, wf] : wavefronts) {
+        (void)t;
+        for (const auto& p : wf) {
+            int i = p[0], j = p[1], k = p[2];
+            Cacc[i][j] += Xd[i][k] * Wd[k][j];        // accumulation recurrence
+            if (k == K - 1)                            // terminal face -> fused epilogue
+                Yout[i][j] = relu(Cacc[i][j] + bd[j]);
+        }
+    }
+
+    float max_abs_err = 0.0f;
+    for (int i = 0; i < B; ++i)
+        for (int j = 0; j < N; ++j)
+            max_abs_err = std::max(max_abs_err, std::fabs(Yout[i][j] - Yref[i][j]));
+
+    std::cout << "[4] Fused SURE execution vs reference:  max |error| = "
+              << max_abs_err << "\n";
+    std::cout << "      Y (fused) =";
+    for (int i = 0; i < B; ++i) for (int j = 0; j < N; ++j) std::cout << " " << Yout[i][j];
+    std::cout << "\n      intermediate tensors materialized: 0 (no A=X.W, no Z=A+b)\n\n";
+
+    const bool ok = max_abs_err < 1e-5f;
+    std::cout << (ok ? "RESULT: PASS — fused matmul+bias+activation SURE validated.\n"
+                     : "RESULT: FAIL — fused result does not match reference.\n");
+    return ok ? 0 : 1;
+}
+
+#else  // !KPU_HAS_DOMAIN_FLOW
+
+int main() {
+    std::cout << "fused_mlp_sure_demo requires domain_flow (KPU_USE_DOMAIN_FLOW=ON).\n";
+    return 0;
+}
+
+#endif

--- a/examples/dataflow/fused_mlp_sure_demo.cpp
+++ b/examples/dataflow/fused_mlp_sure_demo.cpp
@@ -15,6 +15,7 @@
 
 #include <sw/kpu/dataflow/fused_mlp_sure.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <vector>

--- a/include/sw/kpu/dataflow/fused_mlp_sure.hpp
+++ b/include/sw/kpu/dataflow/fused_mlp_sure.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+// ============================================================================
+// FusedMlpSure — the fused batched-MLP operator as a single SURE.
+//
+//   Y[i,j] = activation( sum_k X[i,k] * W[k,j] + b[j] )
+//
+// Models the fused matmul+bias+activation operator as ONE System of Uniform
+// Recurrence Equations over a single iteration domain D = {(i,j,k)}: the
+// matmul accumulates along k, and the bias+activation are BOUNDARY recurrences
+// on the terminal face k=K-1, so the matmul result is consumed in place and
+// never materializes as an intermediate tensor.
+//
+// This is an OWNERSHIP / OBSERVATION + lowering-input structure, not a dataflow
+// control API. Internally it uses domain_flow's standalone polyhedral/affine
+// primitives as the math kernel when available (KPU_HAS_DOMAIN_FLOW), with a
+// direct fallback otherwise; the public API below is domain_flow-free so
+// consumers (the demo, the #47 tiled-DMProgram lowering) need not depend on it.
+//
+// See docs/design/fused-mlp-sure.md. (issue #46, epic #45)
+// ============================================================================
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace sw::kpu::dataflow {
+
+/// Output-face activation applied by the fused epilogue.
+enum class Activation { Identity, ReLU, GELU, SiLU, Sigmoid };
+
+/// Human-readable name, e.g. for `.dfg` attributes / debug.
+const char* to_string(Activation a);
+
+/// Apply a single activation value (used by the epilogue and reference checks).
+float apply_activation(Activation a, float x);
+
+/// Problem shape + epilogue kind for a fused MLP layer.
+struct FusedMlpSureConfig {
+    std::size_t batch = 1;         ///< B — rows of X / Y
+    std::size_t in_features = 1;   ///< K — reduction (accumulation) length
+    std::size_t out_features = 1;  ///< N — columns of W / Y
+    Activation activation = Activation::ReLU;
+};
+
+/// A point (i,j,k) in the fused iteration domain D.
+struct Index3 {
+    int i = 0;
+    int j = 0;
+    int k = 0;
+};
+
+/// The fused matmul+bias+activation operator as a single SURE.
+class FusedMlpSure {
+public:
+    explicit FusedMlpSure(const FusedMlpSureConfig& config);
+
+    const FusedMlpSureConfig& config() const noexcept { return config_; }
+
+    // --- Iteration domain D = {(i,j,k): 0<=i<B, 0<=j<N, 0<=k<K} -------------
+    const std::vector<Index3>& domain_points() const noexcept { return points_; }
+    std::size_t domain_size() const noexcept { return points_.size(); }
+    /// True if the domain was enumerated by domain_flow's IndexSpace (vs the
+    /// direct fallback used when domain_flow is unavailable).
+    bool enumerated_by_domain_flow() const noexcept { return dfa_enumerated_; }
+    /// Number of polyhedral constraints used to define D (2 per axis = 6).
+    std::size_t constraint_count() const noexcept { return constraint_count_; }
+
+    // --- SURE structure ------------------------------------------------------
+    /// Uniform dependence vectors of the recurrence system.
+    static constexpr Index3 x_reuse_vector()      { return {0, 1, 0}; } ///< X reused across columns
+    static constexpr Index3 w_reuse_vector()      { return {1, 0, 0}; } ///< W reused across batch
+    static constexpr Index3 c_accumulate_vector() { return {0, 0, 1}; } ///< C accumulates along k
+    /// Terminal accumulation face k = K-1 where the fused epilogue fires.
+    int terminal_k() const noexcept { return static_cast<int>(config_.in_features) - 1; }
+    /// True if the bias+activation epilogue is applied at this point (k == K-1).
+    bool is_epilogue_point(const Index3& p) const noexcept { return p.k == terminal_k(); }
+
+    // --- Output-stationary schedule tau = (0,0,1): time(i,j,k) = k ----------
+    std::array<int, 3> schedule_tau() const noexcept { return {0, 0, 1}; }
+    long time_of(const Index3& p) const noexcept;
+    /// Points grouped by schedule time (wavefronts); the epilogue rides t=K-1.
+    std::map<long, std::vector<Index3>> wavefronts() const;
+
+    // --- Behavioral execution of the fused SURE ------------------------------
+    /// Execute the fused recurrence system. `X` row-major [B,K], `W` row-major
+    /// [K,N], `bias` [N]; returns `Y` row-major [B,N]. No intermediate tensors
+    /// are materialized — the epilogue rides the accumulation's terminal face.
+    std::vector<float> evaluate(const std::vector<float>& X,
+                                const std::vector<float>& W,
+                                const std::vector<float>& bias) const;
+
+    // --- Human-readable description (domain, recurrences, wavefronts) --------
+    std::string describe() const;
+
+private:
+    FusedMlpSureConfig config_;
+    std::vector<Index3> points_;
+    bool dfa_enumerated_ = false;
+    std::size_t constraint_count_ = 0;
+};
+
+} // namespace sw::kpu::dataflow

--- a/src/software/dataflow/CMakeLists.txt
+++ b/src/software/dataflow/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(DATAFLOW_SOURCES
     tile_dataflow_graph.cpp
     block_mover_compiler.cpp
+    fused_mlp_sure.cpp
 )
 
 add_library(kpu_dataflow ${DATAFLOW_SOURCES})
@@ -19,6 +20,17 @@ target_link_libraries(kpu_dataflow
     PUBLIC
         kpu_datamovement_components
 )
+
+# fused_mlp_sure.cpp uses domain_flow as its polyhedral math kernel. Add the
+# include as SYSTEM (so -Wall/-Wextra/-Wpedantic + CI -Werror do not trip on
+# domain_flow's headers), mirroring kpu_compiler. The public header is
+# domain_flow-free, so this stays PRIVATE to the library.
+if(DOMAIN_FLOW_AVAILABLE)
+    target_compile_definitions(kpu_dataflow PRIVATE KPU_HAS_DOMAIN_FLOW)
+    if(DOMAIN_FLOW_INCLUDE_DIR)
+        target_include_directories(kpu_dataflow SYSTEM PRIVATE ${DOMAIN_FLOW_INCLUDE_DIR})
+    endif()
+endif()
 
 set_target_properties(kpu_dataflow PROPERTIES
     CXX_STANDARD 20

--- a/src/software/dataflow/fused_mlp_sure.cpp
+++ b/src/software/dataflow/fused_mlp_sure.cpp
@@ -1,0 +1,196 @@
+#include <sw/kpu/dataflow/fused_mlp_sure.hpp>
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+#ifdef KPU_HAS_DOMAIN_FLOW
+#include <dfa/dfa.hpp>
+#endif
+
+namespace sw::kpu::dataflow {
+
+const char* to_string(Activation a) {
+    switch (a) {
+        case Activation::Identity: return "identity";
+        case Activation::ReLU:     return "relu";
+        case Activation::GELU:     return "gelu";
+        case Activation::SiLU:     return "silu";
+        case Activation::Sigmoid:  return "sigmoid";
+    }
+    return "unknown";
+}
+
+float apply_activation(Activation a, float x) {
+    switch (a) {
+        case Activation::Identity: return x;
+        case Activation::ReLU:     return x > 0.0f ? x : 0.0f;
+        case Activation::Sigmoid:  return 1.0f / (1.0f + std::exp(-x));
+        case Activation::SiLU:     return x / (1.0f + std::exp(-x));
+        case Activation::GELU: {
+            // tanh approximation of GELU
+            constexpr float kSqrt2OverPi = 0.7978845608028654f;
+            const float u = kSqrt2OverPi * (x + 0.044715f * x * x * x);
+            return 0.5f * x * (1.0f + std::tanh(u));
+        }
+    }
+    return x;
+}
+
+namespace {
+
+// Direct (fallback) enumeration of the box domain, used when domain_flow is
+// unavailable or its IndexSpace did not yield the expected lattice.
+std::vector<Index3> enumerate_box(std::size_t B, std::size_t N, std::size_t K) {
+    std::vector<Index3> pts;
+    pts.reserve(B * N * K);
+    for (int i = 0; i < static_cast<int>(B); ++i)
+        for (int j = 0; j < static_cast<int>(N); ++j)
+            for (int k = 0; k < static_cast<int>(K); ++k)
+                pts.push_back(Index3{i, j, k});
+    return pts;
+}
+
+} // namespace
+
+FusedMlpSure::FusedMlpSure(const FusedMlpSureConfig& config) : config_(config) {
+    const std::size_t B = config_.batch;
+    const std::size_t K = config_.in_features;
+    const std::size_t N = config_.out_features;
+    const std::size_t expected = B * N * K;
+    constraint_count_ = (B && K && N) ? 6 : 0;
+
+#ifdef KPU_HAS_DOMAIN_FLOW
+    // Build the fused domain D = {(i,j,k)} as a single polyhedron via
+    // domain_flow's ConstraintSet -> IndexSpace (the math kernel). Bias and
+    // activation add no iteration dimensions, so D is exactly the matmul domain.
+    if (B && K && N) {
+        using namespace sw::dfa;
+        ConstraintSet<int> cs;
+        cs.add(Hyperplane<int>({1, 0, 0}, 0, ConstraintType::GreaterOrEqual));
+        cs.add(Hyperplane<int>({1, 0, 0}, static_cast<int>(B) - 1, ConstraintType::LessOrEqual));
+        cs.add(Hyperplane<int>({0, 1, 0}, 0, ConstraintType::GreaterOrEqual));
+        cs.add(Hyperplane<int>({0, 1, 0}, static_cast<int>(N) - 1, ConstraintType::LessOrEqual));
+        cs.add(Hyperplane<int>({0, 0, 1}, 0, ConstraintType::GreaterOrEqual));
+        cs.add(Hyperplane<int>({0, 0, 1}, static_cast<int>(K) - 1, ConstraintType::LessOrEqual));
+
+        IndexSpace<int> domain(cs);  // ctor builds bounding box and enumerates
+        const auto& dfa_points = domain.getPoints();
+        if (dfa_points.size() == expected) {
+            points_.reserve(expected);
+            for (const auto& p : dfa_points) {
+                points_.push_back(Index3{p[0], p[1], p[2]});
+            }
+            dfa_enumerated_ = true;
+        }
+    }
+#endif
+
+    if (!dfa_enumerated_) {
+        points_ = enumerate_box(B, N, K);
+    }
+}
+
+long FusedMlpSure::time_of(const Index3& p) const noexcept {
+    const auto tau = schedule_tau();  // (0,0,1)
+    return static_cast<long>(tau[0]) * p.i +
+           static_cast<long>(tau[1]) * p.j +
+           static_cast<long>(tau[2]) * p.k;
+}
+
+std::map<long, std::vector<Index3>> FusedMlpSure::wavefronts() const {
+    std::map<long, std::vector<Index3>> wf;
+    for (const auto& p : points_) {
+        wf[time_of(p)].push_back(p);
+    }
+    return wf;
+}
+
+std::vector<float> FusedMlpSure::evaluate(const std::vector<float>& X,
+                                          const std::vector<float>& W,
+                                          const std::vector<float>& bias) const {
+    const std::size_t B = config_.batch;
+    const std::size_t K = config_.in_features;
+    const std::size_t N = config_.out_features;
+    if (X.size() != B * K) throw std::invalid_argument("FusedMlpSure::evaluate: X must be [B,K]");
+    if (W.size() != K * N) throw std::invalid_argument("FusedMlpSure::evaluate: W must be [K,N]");
+    if (bias.size() != N)  throw std::invalid_argument("FusedMlpSure::evaluate: bias must be [N]");
+
+    const int term = terminal_k();
+    std::vector<float> acc(B * N, 0.0f);  // C(i,j,.) accumulator, one per output (output-stationary)
+    std::vector<float> Y(B * N, 0.0f);
+
+    // Execute the fused recurrence system in schedule (wavefront) order. The
+    // accumulation runs along k; the epilogue (bias + activation) fires exactly
+    // when a point reaches the terminal face k=K-1 — in place, no intermediate.
+    for (const auto& [t, wf] : wavefronts()) {
+        (void)t;
+        for (const auto& p : wf) {
+            const std::size_t out = static_cast<std::size_t>(p.i) * N + static_cast<std::size_t>(p.j);
+            acc[out] += X[static_cast<std::size_t>(p.i) * K + static_cast<std::size_t>(p.k)] *
+                        W[static_cast<std::size_t>(p.k) * N + static_cast<std::size_t>(p.j)];
+            if (p.k == term) {
+                Y[out] = apply_activation(config_.activation,
+                                          acc[out] + bias[static_cast<std::size_t>(p.j)]);
+            }
+        }
+    }
+    return Y;
+}
+
+std::string FusedMlpSure::describe() const {
+    const std::size_t B = config_.batch;
+    const std::size_t K = config_.in_features;
+    const std::size_t N = config_.out_features;
+
+    std::ostringstream os;
+    os << "Fused batched-MLP SURE:  Y = " << to_string(config_.activation)
+       << "( X[" << B << "x" << K << "] . W[" << K << "x" << N << "] + b[" << N << "] )\n\n";
+
+    os << "[1] Single fused domain D: " << domain_size() << " index points ("
+       << B << "x" << N << "x" << K << "), from " << constraint_count_ << " constraints"
+       << (dfa_enumerated_ ? " [enumerated by domain_flow IndexSpace]\n\n"
+                           : " [direct enumeration]\n\n");
+
+    os << "[2] Recurrence system over D:\n";
+#ifdef KPU_HAS_DOMAIN_FLOW
+    // Declare the SURE with domain_flow's RecurrenceVariable + AffineMap and
+    // recover the dependence vectors from the affine "reads-from" maps.
+    {
+        using namespace sw::dfa;
+        RecurrenceVariable X("X", 3), W("W", 3), C("C", 3);
+        AffineMap<int> readX({{1,0,0},{0,1,0},{0,0,1}}, {0, -1, 0});  // X(i,j,k)=X(i,j-1,k)
+        AffineMap<int> readW({{1,0,0},{0,1,0},{0,0,1}}, {-1, 0, 0});  // W(i,j,k)=W(i-1,j,k)
+        AffineMap<int> readC({{1,0,0},{0,1,0},{0,0,1}}, {0, 0, -1});  // C(i,j,k)=C(i,j,k-1)+X*W
+        X.dependsOn(&X, readX);
+        W.dependsOn(&W, readW);
+        C.dependsOn(&C, readC);
+        auto dep = [](const AffineMap<int>& m) {
+            VectorX<int> c = m.apply(VectorX<int>(static_cast<size_t>(3), 0));
+            return Index3{-c[0], -c[1], -c[2]};
+        };
+        const Index3 dx = dep(readX), dw = dep(readW), dc = dep(readC);
+        os << "      X(i,j,k) = X(i,j-1,k)   dep (" << dx.i << "," << dx.j << "," << dx.k << ")  input reuse\n";
+        os << "      W(i,j,k) = W(i-1,j,k)   dep (" << dw.i << "," << dw.j << "," << dw.k << ")  weight reuse\n";
+        os << "      C(i,j,k) = C(i,j,k-1)+X*W  dep (" << dc.i << "," << dc.j << "," << dc.k << ")  accumulate\n";
+    }
+#else
+    os << "      X(i,j,k) = X(i,j-1,k)   dep (0,1,0)  input reuse\n";
+    os << "      W(i,j,k) = W(i-1,j,k)   dep (1,0,0)  weight reuse\n";
+    os << "      C(i,j,k) = C(i,j,k-1)+X*W  dep (0,0,1)  accumulate\n";
+#endif
+    os << "      EPILOGUE (boundary recurrence on terminal face k=" << terminal_k() << "):\n";
+    os << "      Y(i,j) = " << to_string(config_.activation)
+       << "( C(i,j,K-1) + b(j) )   <-- bias+activation in place; only Y leaves D\n\n";
+
+    os << "[3] Output-stationary schedule tau=(0,0,1) -> wavefronts:\n";
+    for (const auto& [t, wf] : wavefronts()) {
+        os << "      t=" << t << " : ";
+        for (const auto& p : wf) os << "(" << p.i << "," << p.j << "," << p.k << ") ";
+        if (t == terminal_k()) os << " <-- fused epilogue rides this wavefront";
+        os << "\n";
+    }
+    return os.str();
+}
+
+} // namespace sw::kpu::dataflow

--- a/src/software/dataflow/fused_mlp_sure.cpp
+++ b/src/software/dataflow/fused_mlp_sure.cpp
@@ -1,6 +1,7 @@
 #include <sw/kpu/dataflow/fused_mlp_sure.hpp>
 
 #include <cmath>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -57,8 +58,24 @@ FusedMlpSure::FusedMlpSure(const FusedMlpSureConfig& config) : config_(config) {
     const std::size_t B = config_.batch;
     const std::size_t K = config_.in_features;
     const std::size_t N = config_.out_features;
+
+    // Reject degenerate / oversized shapes before deriving the domain. With
+    // K == 0 there is no terminal accumulation face (the epilogue cannot fire);
+    // a 0 in any dimension is an empty operator, not a valid fused MLP layer.
+    // Bounding each dimension by INT_MAX keeps the (i,j,k) index coordinates and
+    // the constraint right-hand sides within the int domain used by the polyhedron.
+    if (B == 0 || K == 0 || N == 0) {
+        throw std::invalid_argument(
+            "FusedMlpSure: batch, in_features, and out_features must all be >= 1");
+    }
+    constexpr std::size_t kMaxDim = static_cast<std::size_t>(std::numeric_limits<int>::max());
+    if (B > kMaxDim || K > kMaxDim || N > kMaxDim) {
+        throw std::invalid_argument(
+            "FusedMlpSure: a dimension exceeds the supported range (INT_MAX)");
+    }
+
     const std::size_t expected = B * N * K;
-    constraint_count_ = (B && K && N) ? 6 : 0;
+    constraint_count_ = 6;
 
 #ifdef KPU_HAS_DOMAIN_FLOW
     // Build the fused domain D = {(i,j,k)} as a single polyhedron via


### PR DESCRIPTION
## Summary

Resolves #46 (part of epic #45): formalize the fused batched-MLP operator
`Y = activation(X·W + b)` as a **single SURE** over one `(i,j,k)` iteration
domain, and derive its domain-flow program — using domain_flow's **standalone**
polyhedral/affine primitives, leaving the vendored library **unmodified**
(approach **B3**).

## Why B3 (and why not "fusion as metadata")

Fusion is a property of the *recurrence system*: it **merges domains** and
rewrites the bias+activation as **boundary recurrences on the terminal `k`-face**,
so the matmul result is consumed in place and never leaves the domain as an
intermediate tensor. Composing three separate operator nodes (and tagging them
"fused") does not change any recurrence equation and keeps the inter-domain
communication — so it is *not* fusion.

Verification of the domain_flow headers showed a `DomainFlowNode`'s domain is
elaborated **purely from `opType`**, and `RecurrenceVariable` is **decoupled**
from the graph path — there is no API to attach a custom boundary recurrence to
a graph node. Hence **B3**: build the fused domain in kpu-sim from
`ConstraintSet`/`IndexSpace`/`RecurrenceVariable`/`AffineMap`/`ScheduleVector`,
with domain_flow as the math kernel.

## What's here

- `docs/design/fused-mlp-sure.md` — the SURE formalism (domain, dependence
  vectors, terminal-face epilogue, output-stationary τ), the domain_flow type
  mapping, the resolved B3 decision, and scope boundaries vs #47/#48.
- `examples/dataflow/fused_mlp_sure_demo.cpp` — a runnable, annotated demo that
  builds the merged domain, prints the recurrence system + dependence vectors,
  schedules into wavefronts (epilogue rides `t=K-1`), executes the SURE, and
  **validates** `Y` vs a reference with **zero** intermediate tensors. Registered
  as the `fused_mlp_sure_demo` CTest (labels: dataflow, fusion).

Sample output:

```
[1] Single fused domain D: 12 index points (2x2x3), built from 6 constraints [enumerated by domain_flow IndexSpace]
[3] Output-stationary schedule tau=(0,0,1) -> wavefronts:
      t=2 : (0,0,2) (0,1,2) (1,0,2) (1,1,2)   <-- fused epilogue (bias+activation) rides this wavefront
[4] Fused SURE execution vs reference:  max |error| = 0   (intermediate tensors materialized: 0)
RESULT: PASS
```

## Upstream follow-ups (filed so they're not lost)

- `branes-ai/domain_flow#1` — fused `MATMUL` epilogue via output-face activation attribute (B1).
- `branes-ai/domain_flow#2` — dedicated `FUSED_MATMUL_BIAS_ACT` operator (B2).

## Validation

Build green on **linux-gcc**; **96/96** ctest pass (incl. the new self-validating demo). CI adds Windows/MSVC + Clang.

Closes #46 · epic #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fused batched MLP operation that combines matrix multiplication, bias, and activation into a single evaluation path.
  * Supported multiple activations: Identity, ReLU, GELU, SiLU, and Sigmoid.
  * Added a runnable dataflow example demonstrating fused execution and correctness checking.
* **Documentation**
  * Added a design document detailing the fused execution model, schedule behavior, and validation expectations.
* **Tests**
  * Introduced automated build/run coverage for the new fused MLP example (with labeled test registration when enabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->