### PR TITLE
docs: wrapup — changelog + session log (2026-06-30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fused batched-MLP SURE (`FusedMlpSure`) (#46, epic #45).** Models the fused
+  `Y = activation(X·W + b)` operator as a single System of Uniform Recurrence
+  Equations over one `(i,j,k)` domain, with the bias + activation as boundary
+  recurrences on the terminal accumulation face `k=K-1` (fusion = merged domain,
+  no materialized intermediate tensor).
+  - `include/sw/kpu/dataflow/fused_mlp_sure.hpp` + `src/software/dataflow/fused_mlp_sure.cpp`
+    (in `kpu_dataflow`): a domain_flow-free public API — `FusedMlpSureConfig`,
+    `Activation` (Identity/ReLU/GELU/SiLU/Sigmoid), domain/schedule accessors,
+    and `evaluate(X, W, bias) → Y` (behavioral execution of the fused recurrence).
+  - Built on domain_flow's standalone polyhedral primitives
+    (`ConstraintSet`/`IndexSpace`/`RecurrenceVariable`/`AffineMap`/`ScheduleVector`)
+    as the math kernel — domain_flow itself is unmodified (approach "B3"); the two
+    upstream alternatives are filed as `branes-ai/domain_flow#1`/`#2`.
+  - `examples/dataflow/fused_mlp_sure_demo.cpp` — a runnable, self-validating demo
+    (registered as the `fused_mlp_sure_demo` CTest).
+  - Design: `docs/design/fused-mlp-sure.md`.
+
 - **CSP Schedule Generators (Phase 4)** — Complete schedule generation infrastructure
   for livelock-safe DNN operation scheduling:
   - `IScheduleGenerator` interface with `ScheduleOperation`, `ScheduleResult`,

--- a/docs/sessions/2026-06-30_v0.9_memory-layers-and-fused-mlp-sure.md
+++ b/docs/sessions/2026-06-30_v0.9_memory-layers-and-fused-mlp-sure.md
@@ -1,0 +1,159 @@
+# v0.8/v0.9 Memory-Layer Aggregates + Fused-MLP SURE Decision Log
+
+**Date:** 2026-06-28 – 2026-06-30
+**Version:** v0.8 (memory layers) → v0.9 (fused-MLP SURE)
+**Status:** Complete (for the work landed); epic #45 ongoing
+**Tests:** 96/96 passing
+
+## 1. Summary
+
+Restructured the KPU on-chip memory hierarchy so each storage layer is owned by a
+symmetric aggregate — `L3Layer`, `L2Layer`, `L1Layer` — over the retained
+addressable elements (`L3Tile`, `L2Bank`, `L1Buffer`), replacing flat
+`std::vector` members and flat `KPUSimulator::Config` fields with a
+`group → element-config → multiplicity` config (breaking change, no shims).
+Established the principle that the Layers are **monitoring/ownership** structures,
+not a ResourceManager/dataflow API ("the Layers observe; the CSPs drive"). Then
+kicked off the batched-MLP validation epic (#45) and delivered its first piece
+(#46): the fused `matmul+bias+activation` operator formalized as a single SURE
+and implemented as the reusable `FusedMlpSure` library, using domain_flow as the
+polyhedral math kernel (unmodified). All work landed via green PRs.
+
+## 2. Scope
+
+| Work | Issue/PR | Status | Tests |
+|------|----------|--------|-------|
+| Restructuring design plan | #35 / #36 | Merged | — |
+| L3Layer aggregate (owns L3Tiles, BlockMovers, interconnect) | #32 / #37, #38 | Merged, closed | 95/95 |
+| L2Layer aggregate (owns L2Banks) | #33 / #40 | Merged, closed | 95/95 |
+| L1Layer aggregate (owns L1Buffers; monitoring) | #34 / #41 | Merged, closed | 95/95 |
+| Untrack accidentally-committed CLAUDE.sw21.md | #39 | Merged | — |
+| Follow-ups: monitoring accessors / L3 routing / L2 interconnect | #42, #43, #44 | Filed | — |
+| MLP-sweep validation epic + 5 sub-issues | #45, #46–#50 | Filed | — |
+| Fused-MLP SURE library `FusedMlpSure` (B3) | #46 / #51 | Merged, closed | 96/96 |
+| Upstream fused-operator requests | domain_flow #1, #2 | Filed | — |
+
+## 3. Technical Decisions
+
+- **Decision 1: Introduce aggregate Layers; do NOT rename the elements.**
+  - **Choice:** Add `L3Layer`/`L2Layer`/`L1Layer` that own the retained
+    `L3Tile`/`L2Bank`/`L1Buffer` elements.
+  - **Alternatives:** Rename the elements to `*Layer` (the original issue framing).
+  - **Rationale:** The defect was a *missing aggregate*, not a bad element name —
+    the code conflated "the L3 as a whole" with a single distributed tile.
+    Renaming would relocate the conflation onto the element.
+  - **Files:** `include/sw/kpu/models/temporal/memory/l{3,2,1}_layer.hpp`,
+    `src/system/simulator/l{3,2,1}_layer.cpp`, `kpu_simulator.{hpp,cpp}`.
+
+- **Decision 2: Staged migration (1A additive → 1B internal → 1C hard break).**
+  - **Choice:** Land an additive aggregate, wire it internally behavior-preserving,
+    then hard-break the flat config in a separate step.
+  - **Rationale:** Each step builds green; reviewable, bisectable PRs.
+
+- **Decision 3: `group → element-config → multiplicity` config, hard break.**
+  - **Choice:** `*LayerConfig` with named non-uniform groups + scalar uniform
+    convenience; remove flat `l3_tile_count`/`l2_bank_count`/`l1_buffer_count`
+    etc. No `[[deprecated]]` shims. Python keeps attribute names via `def_property`
+    proxies; the C ABI struct is unchanged.
+  - **Rationale:** Heterogeneous compute fabrics require non-uniform layers; the
+    flat design is wrong (user directive).
+
+- **Decision 4: L1Layer IS wanted (reversal).**
+  - **Choice:** Give L1 its own aggregate, symmetric with L2/L3.
+  - **Alternatives:** Fold `L1Buffer` into `ComputeFabric` (earlier plan).
+  - **Rationale:** The "L1 is fabric-derived" argument doesn't distinguish L1 from
+    L2 (L2 bank shape is also fabric/schedule-derived); and the Layers are
+    monitoring/ownership structures, so L1 deserves an owner too.
+  - **Files:** issue #34, `docs/plans/memory-layer-restructuring.md`, l1_layer.*.
+
+- **Decision 5: Fused MLP as a single SURE; approach B3.**
+  - **Choice:** Build the merged `(i,j,k)` domain + recurrence system in kpu-sim
+    from domain_flow's *standalone* primitives; domain_flow unmodified.
+  - **Alternatives:** B1 (extend domain_flow MATMUL with an activation attribute),
+    B2 (new `FUSED_MATMUL_BIAS_ACT` op) — both edit the vendored library.
+  - **Rationale:** Verified domain_flow's graph DoC is `opType`-driven and
+    `RecurrenceVariable` is decoupled from the graph path — a custom boundary
+    recurrence cannot be attached to a graph node. B3 gives genuine fusion without
+    forking; B1/B2 filed upstream (`branes-ai/domain_flow#1`/`#2`).
+  - **Files:** `docs/design/fused-mlp-sure.md`, `fused_mlp_sure.{hpp,cpp}`, demo.
+
+## 4. Issues Encountered
+
+- **Two parallel config systems.** `KPUSimulator::Config` (real construction path)
+  vs. the fidelity `L3TileConfig`. Only the former was in scope; the JSON parser
+  uses the separate fidelity path and was left untouched.
+- **Shared field names across unrelated structs.** `l2_bank_count` /
+  `l1_buffer_count` etc. are also fields of `MemoryModelConfig`,
+  `ConcurrentTimingExecutor`, `ScheduleValidator`, and the C ABI struct — see
+  Wrong Decisions #1.
+- **domain_flow schedule synthesis is a stub** (`generateSchedule()` returns
+  `{1,1,1}`); we supply an explicit output-stationary `τ=(0,0,1)`. Filed as a
+  future concern in the design doc.
+- **`-Werror` on vendored headers.** Added the domain_flow include as
+  `SYSTEM PRIVATE` to `kpu_dataflow` (mirroring `kpu_compiler`) so its headers
+  don't trip the warning-as-error build.
+
+## 5. Wrong Decisions (CRITICAL)
+
+- **Wrong #1 — Blunt global `sed` for the config-field migration (#32 Phase 1C).**
+  - *What:* Ran a repo-wide `sed` replacing `.l3_tile_count` → `.l3_layer.num_tiles`
+    etc. It rewrote 7 files that used *other* structs sharing the field names
+    (`MemoryModelConfig`, `HardwareConfig`, `L3SchedulerConfig`).
+  - *Why wrong:* Field-name identity is not struct identity; the blunt replace
+    corrupted unrelated code.
+  - *Correction:* The build caught it; audited every modified file by owning
+    struct and reverted the 7 wrong ones. For #33 and #34 I did the per-file
+    owning-struct audit **up front**, and those migrations built green first try.
+  - *Lesson:* Before a mechanical mass-rename, enumerate the structs that own the
+    symbol and scope the edit to the confirmed set — don't rely on the compiler as
+    the first line of defense.
+
+- **Wrong #2 — `git add -A` swept an untracked file onto main (#38); cleanup then
+  deleted it.**
+  - *What:* `git add -A` in the 1C commit committed `CLAUDE.sw21.md` (a pre-existing
+    untracked working-tree file) into the #32 squash merge. The follow-up "untrack"
+    (#39) plus a fast-forward of main then removed the file from the working tree —
+    contradicting my "the file stays on disk" claim.
+  - *Why wrong:* `-A` stages unrelated untracked files; and `git rm --cached` keeps
+    the file only on the branch — fast-forwarding main onto the deletion commit
+    removes the working-tree copy.
+  - *Correction:* Restored the file from history (`git show 19e38ab:… > …`),
+    gitignored it, and switched to explicit staging (`git add -u` / named paths)
+    thereafter.
+  - *Lesson:* Never `git add -A` with unrelated untracked files present; understand
+    that ff-merge updates the working tree to the committed (deleted) state.
+
+- **Wrong #3 — Initial design calls that needed user correction.**
+  - *What:* (a) planned "no L1Layer / fold into compute fabric"; (b) proposed
+    representing operator fusion as node *metadata* on three separate domains.
+  - *Why wrong:* (a) didn't distinguish L1 from L2; (b) fusion is a property of the
+    recurrence system — it merges domains and rewrites the epilogue as boundary
+    recurrences; a metadata tag changes no equation and keeps the inter-domain
+    communication.
+  - *Correction:* Reversed to L1Layer (Decision 4); adopted the single-SURE
+    fused-domain model (Decision 5). Both design docs updated.
+  - *Lesson:* Pressure-test symmetry ("does this argument also apply to the
+    neighbor?") and reason from the formalism, not the annotation.
+
+## 6. Verification
+
+```bash
+cmake -S . -B build && cmake --build build
+ctest --test-dir build                       # 96/96 pass
+./build/examples/dataflow/fused_mlp_sure_demo # prints fused domain/recurrences; RESULT: PASS
+ctest --test-dir build -R fused_mlp_sure_demo # self-validating fusion test
+```
+
+All PRs (#36–#41, #51) merged with green CI (gcc/clang/MSVC + benchmark + snyk +
+CodeRabbit). CodeRabbit review on #51 resolved (shape validation, missing
+include, two doc-accuracy fixes) and acknowledged.
+
+## 7. Next Steps
+
+- **#47** — lower the fused SURE to a tiled `DMProgram` (matmul epilogue), building
+  on `FusedMlpSure::evaluate()` + the domain/schedule accessors.
+- **#48–#50** — per-tile tiling/reuse configs (1…33 tiles), latency/throughput/
+  efficiency metrics, and the sweep driver + validation harness.
+- **#42/#43/#44** — symmetric monitoring accessors on L2/L3Layer; wire L3
+  interconnect routing; L2 interconnect when needed.
+- Watch `branes-ai/domain_flow#1`/`#2` for upstream fused-operator support.


### PR DESCRIPTION
## Summary

Day wrap-up documentation.

- **CHANGELOG** — adds the `FusedMlpSure` library/demo entry (#46) under Added.
  (The L3/L2/L1 memory-layer breaking-change entries #32/#33/#34 were already
  recorded as the work landed.)
- **Session log** `docs/sessions/2026-06-30_v0.9_memory-layers-and-fused-mlp-sure.md`
  — covers the memory-layer aggregate restructuring (epic #35: #32/#33/#34 +
  follow-ups #42–#44) and the fused-MLP SURE (epic #45: #46 delivered, #47–#50
  filed). Includes the mandatory **Wrong Decisions** section: the blunt-`sed`
  config migration, the `git add -A` file sweep, and two user-corrected design
  calls (no-L1Layer; fusion-as-metadata).

Docs-only. 96/96 tests passing at time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new changelog entry for the fused batched-MLP SURE feature, including the public API, demo, and design reference.
  * Added a new versioned decision log covering the latest memory-layer restructuring, implementation notes, verification results, and next-step items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->