### PR TITLE
docs: fix Mermaid parse error in class diagram Section 1 (#56)

### DIFF
--- a/docs/architecture/class-diagram.md
+++ b/docs/architecture/class-diagram.md
@@ -56,7 +56,7 @@ classDiagram
     class TemporalModels {
         <<subsystem>>
         L3Layer / L2Layer / L1Layer
-        (own L3Tile / L2Bank / L1Buffer)
+        own L3Tile / L2Bank / L1Buffer
         DMAEngine / BlockMover / Streamer
         ComputeFabric / SystolicArray
     }


### PR DESCRIPTION
Closes #56

## Summary
The Section 1 (Overview) diagram in `docs/architecture/class-diagram.md` stopped rendering on GitHub after #54: the `TemporalModels` class box contained the line `(own L3Tile / L2Bank / L1Buffer)`, and a class-body line starting with `(` makes Mermaid's classDiagram parser treat it as a method with an empty name, crashing the renderer with `Cannot read properties of undefined (reading 'startsWith')`. This PR drops the parentheses.

## Changes
- One-line change in the Section 1 `TemporalModels` box: `(own L3Tile / L2Bank / L1Buffer)` → `own L3Tile / L2Bank / L1Buffer`.

## Testing
- Docs-only; no code touched.
- Root cause reproduced locally: the merged (pre-fix) Section 1 block fails under mermaid-cli 11.16.0 with the exact `startsWith` TypeError reported on GitHub.
- All seven Mermaid blocks in the file extracted and rendered successfully with mermaid-cli 11.16.0 after the fix.
- Also linted every class-body line in all blocks for parser-hostile leading characters — none remain.

## Risk
Low — one line in one documentation file, render-verified locally. Confirm the rich diff of Section 1 renders in the PR view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the class diagram label to more clearly show ownership relationships for `L3Tile`, `L2Bank`, and `L1Buffer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->