### PR TITLE
feat: standard SoC configuration report for KPUSimulator (#58)

### DIFF
--- a/include/sw/kpu/kpu_simulator.hpp
+++ b/include/sw/kpu/kpu_simulator.hpp
@@ -8,6 +8,8 @@
 #include <chrono>
 #include <stdexcept>
 #include <iomanip>
+#include <string>
+#include <iosfwd>
 
 // Windows/MSVC compatibility
 #ifdef _MSC_VER
@@ -145,6 +147,11 @@ public:
     };
     
 private:
+    // Snapshot of the construction configuration. Immutable after construction
+    // (no mutator); component collections below are built from it, so it stays
+    // consistent with the instantiated SoC for the simulator's lifetime.
+    Config soc_config;
+
     // Component vectors - value semantics, addressable
     std::vector<ExternalMemory> host_memory_regions;  // Host system memory (NUMA regions)
     std::vector<ExternalMemory> memory_banks;  // KPU local memory banks
@@ -309,6 +316,19 @@ public:
     double get_elapsed_time_ms() const;
     void print_stats() const;
     void print_component_status() const;
+
+    // Configuration reporting
+    // The construction-time configuration this SoC model was built from.
+    const Config& get_config() const { return soc_config; }
+    // Standard SoC configuration report: renders the floorplan (host + on-chip
+    // memory hierarchy + data movers + compute fabric, in dataflow order) and
+    // per-asset attribute tables (counts, capacities, clocks, bandwidths, base
+    // addresses) plus the unified memory map.
+    // Post: non-empty; contains one section per asset class. Does not modify
+    // simulator state.
+    std::string generate_config_report() const;
+    void print_config_report(std::ostream& os) const;
+    void print_config_report() const;  // convenience: writes to std::cout
     
     // Component status queries
     bool is_host_memory_region_ready(size_t region_id) const;

--- a/include/sw/kpu/models/temporal/datamovement/dma_engine.hpp
+++ b/include/sw/kpu/models/temporal/datamovement/dma_engine.hpp
@@ -184,6 +184,8 @@ public:
     // Status and identification
     size_t get_engine_id() const { return engine_id; }
     size_t get_queue_size() const { return transfer_queue.size(); }
+    double get_clock_freq_ghz() const { return clock_freq_ghz_; }
+    double get_bandwidth_gb_s() const { return bandwidth_gb_s_; }
 };
 
 } // namespace sw::kpu

--- a/include/sw/kpu/models/temporal/datamovement/streamer.hpp
+++ b/include/sw/kpu/models/temporal/datamovement/streamer.hpp
@@ -172,6 +172,8 @@ public:
     bool is_streaming() const { return current_stream != nullptr && current_stream->is_active; }
     size_t get_queue_size() const { return stream_queue.size(); }
     size_t get_streamer_id() const { return streamer_id; }
+    double get_clock_freq_ghz() const { return clock_freq_ghz_; }
+    double get_bandwidth_gb_s() const { return bandwidth_gb_s_; }
 
     // Configuration helpers
     static Size calculate_stream_cycles(Size matrix_height, Size matrix_width, Size fabric_size);

--- a/src/system/simulator/kpu_simulator.cpp
+++ b/src/system/simulator/kpu_simulator.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <random>
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 #include <cassert>
 #include <cstring>
 
@@ -10,7 +12,7 @@
 namespace sw::kpu {
 
 // KPUSimulator implementation - clean delegation-based API
-KPUSimulator::KPUSimulator(const Config& config) : current_cycle(0) {
+KPUSimulator::KPUSimulator(const Config& config) : soc_config(config), current_cycle(0) {
     // Initialize host memory regions (NUMA)
     host_memory_regions.reserve(config.host_memory_region_count);
     for (size_t i = 0; i < config.host_memory_region_count; ++i) {
@@ -628,6 +630,260 @@ void KPUSimulator::print_component_status() const {
         std::cout << "  Tile[" << i << "]: Busy: "
                   << (compute_tiles[i].is_busy() ? "Yes" : "No") << std::endl;
     }
+}
+
+// Configuration reporting helpers
+namespace {
+
+std::string fmt_capacity(Size bytes) {
+    constexpr Size KB = 1024;
+    constexpr Size MB = KB * 1024;
+    constexpr Size GB = MB * 1024;
+    std::ostringstream os;
+    if (bytes >= GB && bytes % GB == 0) {
+        os << (bytes / GB) << " GB";
+    } else if (bytes >= MB && bytes % MB == 0) {
+        os << (bytes / MB) << " MB";
+    } else if (bytes >= KB && bytes % KB == 0) {
+        os << (bytes / KB) << " KB";
+    } else {
+        os << bytes << " B";
+    }
+    return os.str();
+}
+
+std::string fmt_addr(Address addr) {
+    std::ostringstream os;
+    os << "0x" << std::hex << std::uppercase
+       << std::setw(12) << std::setfill('0') << addr;
+    return os.str();
+}
+
+std::string fmt_rate(double value, const char* unit) {
+    std::ostringstream os;
+    os << value << " " << unit;
+    return os.str();
+}
+
+// Render a titled ASCII box around pre-formatted content lines.
+void emit_box(std::ostringstream& os, const std::string& title,
+              const std::vector<std::string>& lines, const char* indent) {
+    size_t inner = title.size();
+    for (const auto& l : lines) {
+        inner = std::max(inner, l.size());
+    }
+    const size_t middle = inner + 2;  // one space either side of content
+    const size_t title_pad = middle - title.size() - 2;
+    os << indent << '+' << std::string(title_pad / 2, '-') << ' ' << title << ' '
+       << std::string(title_pad - title_pad / 2, '-') << "+\n";
+    for (const auto& l : lines) {
+        os << indent << "| " << l << std::string(inner - l.size(), ' ') << " |\n";
+    }
+    os << indent << '+' << std::string(middle, '-') << "+\n";
+}
+
+} // namespace
+
+std::string KPUSimulator::generate_config_report() const {
+    const auto& cfg = soc_config;
+    std::ostringstream os;
+
+    const std::string rule(80, '=');
+    const std::string thin_rule(80, '-');
+    os << rule << "\n KPU SoC Configuration Report\n" << rule << "\n\n";
+
+    // ---- Layer summary lines (shared by floorplan and detail sections) ----
+    const size_t l3_tiles = l3_layer.tile_count();
+    const size_t l2_banks = l2_layer.bank_count();
+    const size_t l1_buffers = l1_layer.buffer_count();
+
+    Size l3_total = 0, l2_total = 0, l1_total = 0;
+    for (const auto& t : l3_layer.tiles())   l3_total += t.get_capacity();
+    for (const auto& b : l2_layer.banks())   l2_total += b.get_capacity();
+    for (const auto& b : l1_layer.buffers()) l1_total += b.get_capacity();
+
+    // ---- Floorplan (dataflow order: credits flow UP, data flows DOWN) ----
+    os << "Floorplan (credit-based dataflow: credits flow UP, data flows DOWN)\n\n";
+
+    std::vector<std::string> host_lines;
+    if (host_memory_regions.empty()) {
+        host_lines.push_back("Host Memory     : (none)");
+    } else {
+        host_lines.push_back("Host Memory     : " + std::to_string(host_memory_regions.size())
+            + " region(s) x " + fmt_capacity(cfg.host_memory_region_capacity_mb * 1024 * 1024)
+            + " @ " + fmt_rate(static_cast<double>(cfg.host_memory_bandwidth_gbps), "GB/s"));
+    }
+    emit_box(os, "HOST", host_lines, "    ");
+
+    os << "          |\n"
+       << "          |  " << dma_engines.size() << " DMA engine(s)  (push on L3 credit)\n"
+       << "          v\n";
+
+    std::vector<std::string> soc_lines;
+    if (memory_banks.empty()) {
+        soc_lines.push_back("External Memory : (none)");
+    } else {
+        soc_lines.push_back("External Memory : " + std::to_string(memory_banks.size())
+            + " bank(s) x " + fmt_capacity(cfg.memory_bank_capacity_mb * 1024 * 1024)
+            + " @ " + fmt_rate(static_cast<double>(cfg.memory_bandwidth_gbps), "GB/s"));
+    }
+    soc_lines.push_back("Memory Ctrl     : " + std::to_string(cfg.memory_controller_count)
+        + " controller(s), " + std::to_string(page_buffers.size())
+        + " page buffer(s) x " + fmt_capacity(cfg.page_buffer_capacity_kb * 1024));
+    soc_lines.push_back("      |");
+    soc_lines.push_back("      v  DMA push (on L3 credit)");
+    soc_lines.push_back("L3 Layer        : " + std::to_string(l3_tiles) + " tile(s), "
+        + fmt_capacity(l3_total) + " total   [interconnect: "
+        + (l3_layer.has_interconnect() ? "present" : "none") + "]");
+    soc_lines.push_back("      |");
+    soc_lines.push_back("      v  " + std::to_string(l3_layer.block_mover_count())
+        + " BlockMover(s), push on L2 credit");
+    soc_lines.push_back("L2 Layer        : " + std::to_string(l2_banks) + " bank(s), "
+        + fmt_capacity(l2_total) + " total");
+    soc_lines.push_back("      |");
+    soc_lines.push_back("      v  " + std::to_string(streamers.size())
+        + " Streamer(s), feed on L1 credit");
+    soc_lines.push_back("L1 Layer        : " + std::to_string(l1_buffers)
+        + " stream buffer(s), " + fmt_capacity(l1_total) + " total");
+    soc_lines.push_back("      |");
+    soc_lines.push_back("      v  feed / drain");
+    std::string fabric_line = "Compute Fabric  : " + std::to_string(compute_tiles.size()) + " tile(s)";
+    if (!compute_tiles.empty()) {
+        if (cfg.use_systolic_array_mode) {
+            fabric_line += ", systolic " + std::to_string(get_systolic_array_rows(0))
+                + "x" + std::to_string(get_systolic_array_cols(0))
+                + " (" + std::to_string(get_systolic_array_total_pes(0)) + " PEs)";
+        } else {
+            fabric_line += ", basic matmul (functional)";
+        }
+        fabric_line += ", " + topology_to_string(cfg.processor_array_topology);
+    }
+    soc_lines.push_back(fabric_line);
+    emit_box(os, "KPU SoC", soc_lines, "    ");
+
+    // ---- Asset attribute tables ----
+    os << "\n" << thin_rule << "\nAsset Attributes\n" << thin_rule << "\n";
+
+    os << "\nHost memory regions (" << host_memory_regions.size() << "):\n";
+    for (size_t i = 0; i < host_memory_regions.size(); ++i) {
+        os << "  Region[" << i << "]: " << fmt_capacity(host_memory_regions[i].get_capacity())
+           << " @ " << cfg.host_memory_bandwidth_gbps << " GB/s"
+           << ", base " << fmt_addr(get_host_memory_region_base(i)) << "\n";
+    }
+
+    os << "\nExternal memory banks (" << memory_banks.size() << "):\n";
+    for (size_t i = 0; i < memory_banks.size(); ++i) {
+        os << "  Bank[" << i << "]: " << fmt_capacity(memory_banks[i].get_capacity())
+           << " @ " << cfg.memory_bandwidth_gbps << " GB/s"
+           << ", base " << fmt_addr(get_external_bank_base(i)) << "\n";
+    }
+
+    os << "\nMemory controllers (" << cfg.memory_controller_count
+       << "), page buffers (" << page_buffers.size() << "):\n";
+    for (size_t i = 0; i < page_buffers.size(); ++i) {
+        os << "  PageBuffer[" << i << "]: " << fmt_capacity(page_buffers[i].get_capacity())
+           << ", base " << fmt_addr(get_page_buffer_base(i)) << "\n";
+    }
+
+    os << "\nL3 layer (" << l3_tiles << " tile(s), " << fmt_capacity(l3_total)
+       << " total; interconnect: " << (l3_layer.has_interconnect() ? "present" : "none") << "):\n";
+    if (!cfg.l3_layer.tile_groups.empty()) {
+        os << "  groups:";
+        for (const auto& g : cfg.l3_layer.tile_groups) {
+            os << " " << g.name << " x" << g.multiplicity
+               << " @ " << fmt_capacity(g.tile.capacity_kb * 1024);
+        }
+        os << "\n";
+    } else if (l3_tiles > 0) {
+        os << "  groups: uniform\n";
+    }
+    for (size_t i = 0; i < l3_tiles; ++i) {
+        os << "  L3Tile[" << i << "]: " << fmt_capacity(l3_layer.tiles()[i].get_capacity())
+           << ", base " << fmt_addr(get_l3_tile_base(i)) << "\n";
+    }
+
+    os << "\nBlock movers (" << l3_layer.block_mover_count() << ", owned by L3 layer):\n";
+    for (size_t i = 0; i < l3_layer.block_mover_count(); ++i) {
+        os << "  BlockMover[" << i << "]: serves L3Tile["
+           << l3_layer.block_movers()[i].get_associated_l3_tile() << "], "
+           << fmt_rate(cfg.l3_layer.block_mover_clock_ghz, "GHz") << ", "
+           << fmt_rate(cfg.l3_layer.block_mover_bandwidth_gb_s, "GB/s") << "\n";
+    }
+
+    os << "\nL2 layer (" << l2_banks << " bank(s), " << fmt_capacity(l2_total) << " total):\n";
+    if (!cfg.l2_layer.bank_groups.empty()) {
+        os << "  groups:";
+        for (const auto& g : cfg.l2_layer.bank_groups) {
+            os << " " << g.name << " x" << g.multiplicity
+               << " @ " << fmt_capacity(g.bank.capacity_kb * 1024);
+        }
+        os << "\n";
+    } else if (l2_banks > 0) {
+        os << "  groups: uniform\n";
+    }
+    for (size_t i = 0; i < l2_banks; ++i) {
+        os << "  L2Bank[" << i << "]: " << fmt_capacity(l2_layer.banks()[i].get_capacity())
+           << ", base " << fmt_addr(get_l2_bank_base(i)) << "\n";
+    }
+
+    os << "\nL1 layer (" << l1_buffers << " stream buffer(s), "
+       << fmt_capacity(l1_total) << " total):\n";
+    if (!cfg.l1_layer.buffer_groups.empty()) {
+        os << "  groups:";
+        for (const auto& g : cfg.l1_layer.buffer_groups) {
+            os << " " << g.name << " x" << g.multiplicity
+               << " @ " << fmt_capacity(g.buffer.capacity_kb * 1024);
+        }
+        os << "\n";
+    } else if (l1_buffers > 0) {
+        os << "  groups: uniform\n";
+    }
+    for (size_t i = 0; i < l1_buffers; ++i) {
+        os << "  L1Buffer[" << i << "]: " << fmt_capacity(l1_layer.buffers()[i].get_capacity())
+           << ", base " << fmt_addr(get_l1_buffer_base(i)) << "\n";
+    }
+
+    os << "\nDMA engines (" << dma_engines.size() << "):\n";
+    for (size_t i = 0; i < dma_engines.size(); ++i) {
+        os << "  DMA[" << i << "]: " << fmt_rate(dma_engines[i].get_clock_freq_ghz(), "GHz")
+           << ", " << fmt_rate(dma_engines[i].get_bandwidth_gb_s(), "GB/s") << "\n";
+    }
+
+    os << "\nStreamers (" << streamers.size() << "):\n";
+    for (size_t i = 0; i < streamers.size(); ++i) {
+        os << "  Streamer[" << i << "]: " << fmt_rate(streamers[i].get_clock_freq_ghz(), "GHz")
+           << ", " << fmt_rate(streamers[i].get_bandwidth_gb_s(), "GB/s") << "\n";
+    }
+
+    os << "\nCompute fabric (" << compute_tiles.size() << " tile(s); topology "
+       << topology_to_string(cfg.processor_array_topology) << "):\n";
+    for (size_t i = 0; i < compute_tiles.size(); ++i) {
+        os << "  Tile[" << i << "]: ";
+        if (cfg.use_systolic_array_mode) {
+            os << "systolic " << get_systolic_array_rows(i) << "x" << get_systolic_array_cols(i)
+               << " (" << get_systolic_array_total_pes(i) << " PEs)";
+        } else {
+            os << "basic matmul (functional)";
+        }
+        os << "\n";
+    }
+
+    const auto& regions = address_decoder.get_regions();
+    os << "\nMemory map (" << regions.size() << " region(s)):\n";
+    for (const auto& r : regions) {
+        os << "  " << fmt_addr(r.base) << "  " << std::setw(8) << fmt_capacity(r.size)
+           << "  " << r.name << "\n";
+    }
+
+    return os.str();
+}
+
+void KPUSimulator::print_config_report(std::ostream& os) const {
+    os << generate_config_report();
+}
+
+void KPUSimulator::print_config_report() const {
+    print_config_report(std::cout);
 }
 
 // Component status queries

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -25,3 +25,6 @@ target_link_libraries(test_config_formatting
     PRIVATE
     StillwaterKPU::System
 )
+
+# KPU SoC configuration report tests
+kpu_add_component_test(test_config_report "system" test_config_report.cpp)

--- a/tests/system/test_config_report.cpp
+++ b/tests/system/test_config_report.cpp
@@ -1,0 +1,128 @@
+#include <catch2/catch_test_macros.hpp>
+#include <sw/kpu/kpu_simulator.hpp>
+#include <sstream>
+
+using namespace sw::kpu;
+
+namespace {
+
+KPUSimulator::Config make_test_config() {
+    KPUSimulator::Config config;
+    config.host_memory_region_count = 1;
+    config.host_memory_region_capacity_mb = 64;
+    config.host_memory_bandwidth_gbps = 100;
+    config.memory_bank_count = 2;
+    config.memory_bank_capacity_mb = 4;
+    config.memory_bandwidth_gbps = 100;
+    config.memory_controller_count = 1;
+    config.page_buffer_count = 2;
+    config.page_buffer_capacity_kb = 64;
+    config.l3_layer.num_tiles = 4;
+    config.l3_layer.capacity_kb = 128;
+    config.l3_layer.block_mover_count = 4;
+    config.l2_layer.num_banks = 8;
+    config.l2_layer.capacity_kb = 64;
+    config.l1_layer.num_buffers = 8;
+    config.l1_layer.capacity_kb = 32;
+    config.dma_engine_count = 2;
+    config.streamer_count = 4;
+    config.compute_tile_count = 1;
+    config.processor_array_rows = 16;
+    config.processor_array_cols = 16;
+    config.use_systolic_array_mode = true;
+    return config;
+}
+
+} // namespace
+
+TEST_CASE("KPUSimulator retains its construction config", "[system][config-report]") {
+    auto config = make_test_config();
+    KPUSimulator sim(config);
+
+    // I1: snapshot matches the constructed SoC
+    const auto& cfg = sim.get_config();
+    REQUIRE(cfg.memory_bank_count == config.memory_bank_count);
+    REQUIRE(cfg.l3_layer.num_tiles == config.l3_layer.num_tiles);
+    REQUIRE(cfg.l2_layer.num_banks == config.l2_layer.num_banks);
+    REQUIRE(cfg.l1_layer.num_buffers == config.l1_layer.num_buffers);
+    REQUIRE(cfg.l3_layer.total_tiles() == sim.get_l3_tile_count());
+    REQUIRE(cfg.l2_layer.total_banks() == sim.get_l2_bank_count());
+    REQUIRE(cfg.l1_layer.total_buffers() == sim.get_l1_buffer_count());
+    REQUIRE(cfg.dma_engine_count == sim.get_dma_engine_count());
+    REQUIRE(cfg.streamer_count == sim.get_streamer_count());
+}
+
+TEST_CASE("Config report renders floorplan and all asset sections", "[system][config-report]") {
+    KPUSimulator sim(make_test_config());
+    std::string report = sim.generate_config_report();
+
+    // Post: non-empty, one section per asset class
+    REQUIRE_FALSE(report.empty());
+    REQUIRE(report.find("KPU SoC Configuration Report") != std::string::npos);
+
+    SECTION("floorplan sketch") {
+        REQUIRE(report.find("HOST") != std::string::npos);
+        REQUIRE(report.find("KPU SoC") != std::string::npos);
+        REQUIRE(report.find("credits flow UP, data flows DOWN") != std::string::npos);
+        REQUIRE(report.find("L3 Layer") != std::string::npos);
+        REQUIRE(report.find("L2 Layer") != std::string::npos);
+        REQUIRE(report.find("L1 Layer") != std::string::npos);
+        REQUIRE(report.find("Compute Fabric") != std::string::npos);
+    }
+
+    SECTION("asset attribute sections") {
+        REQUIRE(report.find("Host memory regions (1)") != std::string::npos);
+        REQUIRE(report.find("External memory banks (2)") != std::string::npos);
+        REQUIRE(report.find("page buffers (2)") != std::string::npos);
+        REQUIRE(report.find("L3 layer (4 tile(s)") != std::string::npos);
+        REQUIRE(report.find("Block movers (4") != std::string::npos);
+        REQUIRE(report.find("L2 layer (8 bank(s)") != std::string::npos);
+        REQUIRE(report.find("L1 layer (8 stream buffer(s)") != std::string::npos);
+        REQUIRE(report.find("DMA engines (2)") != std::string::npos);
+        REQUIRE(report.find("Streamers (4)") != std::string::npos);
+        REQUIRE(report.find("Compute fabric (1 tile(s)") != std::string::npos);
+        REQUIRE(report.find("Memory map (") != std::string::npos);
+    }
+
+    SECTION("asset attributes present") {
+        REQUIRE(report.find("128 KB") != std::string::npos);   // L3 tile capacity
+        REQUIRE(report.find("systolic 16x16 (256 PEs)") != std::string::npos);
+        REQUIRE(report.find("100 GB/s") != std::string::npos); // bandwidth
+        REQUIRE(report.find("base 0x") != std::string::npos);  // memory-map bases
+    }
+
+    SECTION("non-uniform group summary") {
+        auto config = make_test_config();
+        config.l3_layer.num_tiles = 0;
+        config.l3_layer.tile_groups = {
+            {"default", {128}, 2},
+            {"hbw", {256}, 2},
+        };
+        KPUSimulator hetero(config);
+        std::string hetero_report = hetero.generate_config_report();
+        REQUIRE(hetero_report.find("default x2 @ 128 KB") != std::string::npos);
+        REQUIRE(hetero_report.find("hbw x2 @ 256 KB") != std::string::npos);
+    }
+}
+
+TEST_CASE("Config report generation is const and repeatable", "[system][config-report]") {
+    KPUSimulator sim(make_test_config());
+
+    // I2: purity — repeated generation yields identical output, state untouched
+    std::string first = sim.generate_config_report();
+    std::string second = sim.generate_config_report();
+    REQUIRE(first == second);
+    REQUIRE(sim.get_current_cycle() == 0);
+
+    // print_config_report(ostream) streams exactly the generated report
+    std::ostringstream oss;
+    sim.print_config_report(oss);
+    REQUIRE(oss.str() == first);
+}
+
+TEST_CASE("Config report handles an empty default configuration", "[system][config-report]") {
+    KPUSimulator sim{KPUSimulator::Config{}};
+    std::string report = sim.generate_config_report();
+    REQUIRE_FALSE(report.empty());
+    REQUIRE(report.find("(none)") != std::string::npos);
+}


### PR DESCRIPTION
Closes #58

## Summary
`KPUSimulator` gains a standard configuration report that renders the SoC floorplan with all asset attributes. `generate_config_report()` returns a text report with three parts: (1) an ASCII **floorplan** in credit-based dataflow order (credits UP, data DOWN) — HOST → DMA → External Memory / Memory Controller → L3 Layer (BlockMovers, interconnect) → L2 Layer (Streamers) → L1 Layer → Compute Fabric, with counts and aggregate capacities inline; (2) **per-asset attribute tables** — capacity, bandwidth, clock, unified-address base, BlockMover→L3Tile association, systolic array geometry, and layer group summaries (uniform vs. named group × multiplicity); (3) the full **memory map** from the AddressDecoder. To make config-only attributes reportable, the simulator now retains its construction `Config` as an immutable snapshot.

## Changes
- `include/sw/kpu/kpu_simulator.hpp`: new private `Config soc_config` snapshot (invariant: equals construction config, consistent with the instantiated components; no mutator). Public API: `get_config()`, `generate_config_report()`, `print_config_report(std::ostream&)`, `print_config_report()` (cout convenience, matching the `print_stats()` family). Adds `<string>`/`<iosfwd>` includes.
- `src/system/simulator/kpu_simulator.cpp`: report implementation with file-local helpers (`fmt_capacity`, `fmt_addr`, `fmt_rate`, auto-sizing `emit_box`); constructor initializes the snapshot.
- `include/sw/kpu/models/temporal/datamovement/{dma_engine,streamer}.hpp`: `get_clock_freq_ghz()` / `get_bandwidth_gb_s()` getters for previously private attributes (public API addition, header-only).
- `tests/system/test_config_report.cpp` (+ CMake registration): 4 Catch2 test cases / 46 assertions — snapshot consistency, floorplan + section presence, attribute rendering, non-uniform group summaries, purity/repeatability, empty default config.

## Testing
- Built locally: GCC, Linux, Release (CMake `release` preset, Ninja)
- Unit tests: **97/97 pass** via ctest (full suite, includes the 4 new test cases)
- Rendering manually verified by linking a harness against the built library: floorplan boxes align correctly for a 4-tile L3 / 8-bank L2 / 16-buffer L1 config; memory map lists all 33 regions with hex bases
- clang-format/clang-tidy, MSVC/Clang builds, sanitizers: deferred to CI

## Risk
Low — additive API only; no existing behavior changed. The `Config` snapshot adds one value member to `KPUSimulator` (copy at construction). Report code is `const` and touched only by the new entry points. Existing tests unaffected (97/97 green).

## Notes for reviewers
- The floorplan intentionally reports the *layer aggregates* as ownership/monitoring structures per `docs/kpu-execution-model.md` — connector labels say "push on L3/L2/L1 credit" to keep dataflow semantics front and center.
- Group summaries print for both uniform ("groups: uniform") and heterogeneous configs ("default x2 @ 128 KB, hbw x2 @ 256 KB"); the non-uniform path is covered by a dedicated test section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration report for the simulator, including a readable summary and printable output.
  * Exposed read-only configuration details and performance metrics for key simulator components.
* **Bug Fixes**
  * Simulator now reliably preserves its startup configuration for later inspection.
  * Improved report generation for both populated and empty configurations.
* **Tests**
  * Added system coverage for configuration retention, report content, determinism, and empty-config output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->