### PR TITLE
fix: multi-tile livelock in CSP ConcurrentTimingExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CSP timing: multi-tile schedules livelocked in `ConcurrentTimingExecutor` (#61).**
+  `run_matmul` failed with livelock at its default 64x64x64 / 16^3-tile
+  configuration; 128^3 and 256^3 also failed. Four root causes, all in the
+  timing tier headers:
+  - `DMAEngineProcess::schedule_load/schedule_store` silently dropped requests
+    beyond `queue_depth` (32), so most of a schedule's loads never executed and
+    downstream BlockMovers/Streamers tag-stalled forever. The pending list is
+    now an unbounded software staging queue; `queue_depth` bounds concurrently
+    *submitted* MC requests instead.
+  - Credit leak on tile reuse: each duplicate MOVE of an L2-resident tile
+    acquired a new L2 credit, but the ref-counted TagCAM entry releases only
+    one credit when it drains — leaking (uses-1) credits per reused tile.
+    `BlockMoverProcess` now deduplicates moves for L2-resident tiles
+    (ref_count++ without a credit), matching the documented schedule-generator
+    contract ("execution layer deduplicates").
+  - Duplicate in-flight loads: a second load of the same tile could be
+    submitted while the first was still in the MC, double-acquiring L3 credits
+    for one TagCAM entry. Loads now defer when the tile already has a
+    submitted load (resolved via the dedup path on arrival). Work assignment
+    changed from round-robin to tile-affine (hash of TileID) so one tile's
+    operations serialize on one DMA/BlockMover/Streamer and cannot race
+    across processes.
+  - Instance-state bugs: `StreamerProcess::allocate_l2_slot` used a `static`
+    counter shared across all streamer instances; the executor's compute-slot
+    counter was a function-local `static` shared across executor instances and
+    not reset. Both are instance members now.
+  Also: DMA stall accounting now counts at most one stall cycle per tick
+  (matching BlockMover/Streamer semantics) instead of one per pending request,
+  and optional `l3_writeback_credit_reserve` / `l2_drain_credit_reserve`
+  executor knobs (default 0) guard against prefetch starving writeback/drain
+  credit acquisition on extreme schedules. `run_matmul` now completes for
+  32^3 through 256^3 across all strategies (including BLOCKED_AB).
+
 ### Changed
 
 - **BREAKING — L1 memory layer restructuring (#34).** Introduced the `L1Layer`

--- a/docs/sessions/2026-07-09_v0.9_multi_tile_livelock_fix.md
+++ b/docs/sessions/2026-07-09_v0.9_multi_tile_livelock_fix.md
@@ -16,7 +16,8 @@ independent defects that compounded: a silent request drop in the DMA staging
 queue, a credit leak on tile reuse in the BlockMover, duplicate in-flight
 loads double-acquiring L3 credits, and two `static`-state bugs. After the fix,
 all strategy x size combinations (interleaved / output_stationary / blocked x
-32^3..256^3) complete, credits fully conserved.
+32^3..256^3) complete successfully; credit conservation ("every acquire has a
+matching release") was verified via `csp_pipeline_demo`.
 
 ## 2. Scope
 
@@ -31,11 +32,13 @@ all strategy x size combinations (interleaved / output_stationary / blocked x
 | DMA stall accounting (per-request -> per-tick) | Fixed | stalls <= total cycles |
 | Credit reserve knobs (optional, default 0) | Added | executor Config |
 
-Files modified (all header-only timing tier):
-- `include/sw/kpu/timing/dma_engine_process.hpp`
-- `include/sw/kpu/timing/block_mover_process.hpp`
-- `include/sw/kpu/timing/streamer_process.hpp`
-- `include/sw/kpu/timing/concurrent_timing_executor.hpp`
+Files modified:
+- `include/sw/kpu/timing/dma_engine_process.hpp` (implementation)
+- `include/sw/kpu/timing/block_mover_process.hpp` (implementation)
+- `include/sw/kpu/timing/streamer_process.hpp` (implementation)
+- `include/sw/kpu/timing/concurrent_timing_executor.hpp` (implementation)
+- `CHANGELOG.md` (Unreleased > Fixed entry)
+- `docs/sessions/2026-07-09_v0.9_multi_tile_livelock_fix.md` (this log)
 
 ## 3. Technical Decisions
 
@@ -118,9 +121,9 @@ No other wrong decisions identified this session.
 
 ```bash
 cmake --build --preset release
-cd build && ctest -L timing --output-on-failure   # 12/12 pass
-cd build && ctest                                  # 95/95 pass
-./build/examples/schedule/run_matmul               # SUCCESS, 1132 cycles
+ctest --test-dir build -L timing --output-on-failure   # 12/12 pass
+ctest --test-dir build                                  # 95/95 pass
+./build/examples/schedule/run_matmul                    # SUCCESS, 1132 cycles
 for s in interleaved output_stationary blocked; do
   for n in 32 64 128 256; do
     ./build/examples/schedule/run_matmul -M $n -N $n -K $n --strategy $s

--- a/docs/sessions/2026-07-09_v0.9_multi_tile_livelock_fix.md
+++ b/docs/sessions/2026-07-09_v0.9_multi_tile_livelock_fix.md
@@ -1,0 +1,142 @@
+# v0.9 CSP Multi-Tile Livelock Fix Decision Log
+
+**Date:** 2026-07-09
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 95/95 passing (12/12 timing suites)
+**Issue:** #61
+
+## 1. Summary
+
+Diagnosed and fixed the livelock that made every multi-tile schedule fail in
+the CSP `ConcurrentTimingExecutor`. `run_matmul` at its default 64x64x64 /
+16^3-tile configuration reported livelock at 10,400 cycles with 61k BlockMover
+tag-stall cycles; 128^3 and 256^3 also failed. The investigation found four
+independent defects that compounded: a silent request drop in the DMA staging
+queue, a credit leak on tile reuse in the BlockMover, duplicate in-flight
+loads double-acquiring L3 credits, and two `static`-state bugs. After the fix,
+all strategy x size combinations (interleaved / output_stationary / blocked x
+32^3..256^3) complete, credits fully conserved.
+
+## 2. Scope
+
+| Item | Status | Verification |
+|------|--------|--------------|
+| DMA silent drop on queue-full | Fixed | run_matmul 64^3 SUCCESS (957-1132 cycles) |
+| BlockMover move dedup (credit leak) | Fixed | 128^3 SUCCESS, 8,130 cycles |
+| DMA duplicate in-flight load dedup | Fixed | 256^3 SUCCESS, 92,382 cycles |
+| Tile-affine work assignment | Fixed | all strategies pass |
+| Streamer static slot counter | Fixed | instance member + reset |
+| Executor static compute-slot counter | Fixed | instance member + reset |
+| DMA stall accounting (per-request -> per-tick) | Fixed | stalls <= total cycles |
+| Credit reserve knobs (optional, default 0) | Added | executor Config |
+
+Files modified (all header-only timing tier):
+- `include/sw/kpu/timing/dma_engine_process.hpp`
+- `include/sw/kpu/timing/block_mover_process.hpp`
+- `include/sw/kpu/timing/streamer_process.hpp`
+- `include/sw/kpu/timing/concurrent_timing_executor.hpp`
+
+## 3. Technical Decisions
+
+**Decision 1: DMA pending list is a software staging queue, not a hardware queue**
+- **Choice:** `schedule_load/schedule_store` accept every request;
+  `queue_depth` bounds concurrently SUBMITTED MC requests.
+- **Alternatives:** (a) return bool and make `ScheduleExecutor` retry —
+  changes the `IProcess` API and every caller; (b) feed schedules
+  incrementally from the executor — larger redesign.
+- **Rationale:** `ScheduleExecutor` enqueues entire schedules upfront by
+  design; BlockMover/Streamer WorkQueues are already unbounded. The DMA was
+  the only process that dropped work — silently, while the executor counted
+  the op as completed.
+
+**Decision 2: Deduplicate at the execution layer, per the generator contract**
+- **Choice:** BlockMover dedups moves for L2-resident tiles (ref_count++
+  without acquiring a credit, still consuming the L3 reference); DMA defers
+  loads whose tile already has a submitted load.
+- **Rationale:** The schedule generators explicitly document "execution layer
+  handles deduplication: DMA skips loads for tiles already in L3, BlockMover
+  skips moves for tiles already in L2". The DMA half existed; the BlockMover
+  half did not, and every duplicate move leaked one L2 credit (N acquires,
+  one release when the ref-counted entry drains).
+
+**Decision 3: Tile-affine work assignment instead of round-robin**
+- **Choice:** `select_dma_engine/select_block_mover/select_streamer` hash the
+  TileID so all operations for one tile serialize on one process.
+- **Alternatives:** shared in-flight registry across processes (adds shared
+  mutable state and constructor churn); per-process locks (not applicable in
+  a DES).
+- **Rationale:** Round-robin spread a reused tile's 8 moves across 4
+  BlockMovers, which could start concurrent duplicate transfers of the same
+  tile — same credit-leak mechanism, racier window. Distribution tests only
+  assert totals, so the policy change is test-compatible.
+
+**Decision 4: Credit reserves configurable but default 0**
+- **Choice:** `l3_writeback_credit_reserve` / `l2_drain_credit_reserve`
+  (clamped to (pool-1)/2), default 0.
+- **Rationale:** see Wrong Decision 1.
+
+## 4. Issues Encountered
+
+1. **Symptom:** 448/448 ops "completed" yet livelock; BlockMover utilization
+   0%. **Root cause:** ops counted at enqueue; 112 of 144 DMA requests were
+   silently dropped (single engine, `queue_depth` 32). **Fix:** Decision 1.
+2. **Symptom:** After fix 1, 128^3 still wedged with dominant BM/STR *credit*
+   stalls. **Root cause:** L2 credit leak on tile reuse (Decision 2) plus
+   duplicate in-flight loads leaking L3 credits. **Fix:** Decisions 2-3.
+3. **Symptom:** 256^3 run timed out (>10 min). **Root cause:** O(n^2)
+   `has_submitted_load` scan per tick over ~14k pending requests. **Fix:**
+   `unordered_set<TileID>` of submitted loads; 256^3 completes in seconds.
+4. **Symptom:** DMA credit stalls (17,604) exceeded total cycles (957).
+   **Root cause:** stall counted per pending request per tick. **Fix:**
+   at most one stall cycle per tick, matching BM/STR semantics.
+
+## 5. Wrong Decisions (CRITICAL)
+
+**Wrong Decision 1: Credit-reserve-first hypothesis.** The initial diagnosis
+attributed the 128^3 wedge to prefetch starvation (DMA ticks before
+BlockMovers and re-acquires every freed L3 credit before a writeback can),
+and I implemented credit reserves with nonzero defaults. The reserves did not
+fix 128^3 — the actual mechanism was the credit *leak* on tile reuse — and
+the nonzero defaults broke two load-only executor tests that legitimately
+fill the whole L3 pool. **Correction:** found and fixed the leaks; reverted
+reserve defaults to 0, keeping the knobs as an optional guard. **Lesson:**
+verify a starvation hypothesis against credit-conservation arithmetic
+(total acquires vs releases per entry) before adding policy mechanisms;
+a leak and a starvation produce similar stall signatures but only the leak
+breaks conservation.
+
+**Wrong Decision 2: O(n) in-flight scan.** The first implementation of the
+duplicate-load check scanned the pending list per request per tick,
+turning 256^3 from minutes into a >10-minute run misdiagnosable as a hang.
+**Correction:** constant-time set lookup. **Lesson:** any per-tick check in
+a DES must be O(1) against schedule-sized queues.
+
+No other wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+cd build && ctest -L timing --output-on-failure   # 12/12 pass
+cd build && ctest                                  # 95/95 pass
+./build/examples/schedule/run_matmul               # SUCCESS, 1132 cycles
+for s in interleaved output_stationary blocked; do
+  for n in 32 64 128 256; do
+    ./build/examples/schedule/run_matmul -M $n -N $n -K $n --strategy $s
+  done
+done                                               # all SUCCESS
+./build/examples/schedule/csp_pipeline_demo        # credits fully conserved
+```
+
+## 7. Next Steps
+
+- Add a CI regression test that executes (not just validates) a multi-tile
+  schedule matrix through `ScheduleExecutor` — the livelock was invisible to
+  the existing suites because none of them executed a generated multi-tile
+  schedule end-to-end.
+- Credit/ref-count conservation invariants (INV-3xx style) checked against
+  executor traces, per the LPDDR5 validation pattern.
+- The `ExecutionResult.ops_completed` counter still counts enqueued ops, not
+  completed ones — misleading on failure; consider deriving from executor
+  statistics.

--- a/include/sw/kpu/timing/block_mover_process.hpp
+++ b/include/sw/kpu/timing/block_mover_process.hpp
@@ -48,6 +48,8 @@ public:
         double clock_ghz = 1.0;        ///< Reference clock in GHz
         bool supports_transpose = true; ///< Can transpose during move
         bool priority_aging = false;   ///< If true, prefer oldest ready tile (prevents starvation)
+        size_t l2_credit_reserve = 0;  ///< L2 credits moves may NOT consume (reserved for
+                                       ///< compute-result drains; prevents credit starvation)
         std::string name = "BM";       ///< Human-readable name
 
         /// Generate human-readable name: "L3(0,0):BM" format
@@ -122,7 +124,11 @@ public:
         // Step 1: Check for completed transfer
         check_completion(current_cycle, events);
 
-        // Step 2: If idle, try to start new work
+        // Step 2: Deduplicate moves for tiles already resident in L2
+        // (tile reuse - no transfer, no L2 credit)
+        process_dedup_moves(current_cycle, events);
+
+        // Step 3: If idle, try to start new work
         if (!in_flight_.has_value()) {
             // Priority: moves over writebacks (keep pipeline fed)
             if (!try_start_move(current_cycle, events)) {
@@ -317,6 +323,70 @@ private:
     }
 
     /**
+     * @brief Complete moves for tiles already resident in L2 (tile reuse)
+     *
+     * The schedule emits one MOVE per tile *use*; the execution layer
+     * deduplicates. A duplicate move increments the L2 entry's ref_count
+     * (one ref per pending FEED) WITHOUT acquiring a new L2 credit - the
+     * entry holds exactly one credit for its lifetime. Acquiring a credit
+     * per duplicate move leaks credits (N acquires, 1 release when the
+     * ref_count reaches 0) and exhausts the L2 pool on reuse-heavy
+     * schedules (issue #61).
+     *
+     * The L3 side is still consumed per move: each dedup decrements the
+     * L3 ref_count and releases the L3 credit when it reaches 0.
+     */
+    void process_dedup_moves(Cycle current_cycle, std::vector<TimingEvent>& events) {
+        size_t i = 0;
+        while (i < move_queue_.size()) {
+            const auto& tile = move_queue_.at(i);
+            auto l2_entry = l2_tag_cam_.match(tile.tile_id);
+            auto l3_entry = l3_tag_cam_.match(tile.tile_id);
+            // Dedup only when the tile is present on BOTH sides: resident in
+            // L2 (reuse target) and arrived in L3 (this move's L3 ref is due)
+            if (!l2_entry.has_value() || !l3_entry.has_value()) {
+                ++i;
+                continue;
+            }
+
+            TileDescriptor dedup_tile = move_queue_.remove_at(i);
+            if (i < transpose_flags_.size()) {
+                transpose_flags_.erase(transpose_flags_.begin() +
+                                       static_cast<std::ptrdiff_t>(i));
+            }
+
+            // ref_count++ in L2 (no credit - entry already holds one)
+            l2_tag_cam_.insert(dedup_tile.tile_id, l2_entry->slot_id, current_cycle);
+            // Consume this move's L3 reference
+            bool credit_released = l3_tag_cam_.invalidate(dedup_tile.tile_id);
+            if (credit_released) {
+                l3_credits_.release();
+            }
+            total_tiles_moved_++;
+
+            events.push_back(TimingEvent(
+                EventType::TILE_ARRIVED_L2,
+                current_cycle,
+                config_.mover_id,
+                dedup_tile.tile_id,
+                name()
+            ));
+            events.back().slot_id = l2_entry->slot_id;
+
+            if (credit_released) {
+                events.push_back(TimingEvent(
+                    EventType::CREDIT_RELEASED,
+                    current_cycle,
+                    config_.mover_id,
+                    dedup_tile.tile_id,
+                    name()
+                ));
+            }
+            // Do not advance i - remove_at shifted the next element into i
+        }
+    }
+
+    /**
      * @brief Try to start a move transfer (L3→L2) using work-conserving scan
      * @return true if a move was started
      *
@@ -371,8 +441,11 @@ private:
             return false;
         }
 
-        // Check if L2 credit available
-        if (!l2_credits_.acquire()) {
+        // Check if L2 credit available. Moves may not consume the reserved
+        // credits - those are kept for compute-result drains (Streamer),
+        // which otherwise starve because BlockMovers tick before Streamers.
+        if (l2_credits_.available() <= config_.l2_credit_reserve ||
+            !l2_credits_.acquire()) {
             const auto& tile = move_queue_.at(found_index);
             events.push_back(TimingEvent(
                 EventType::BM_STALL_CREDIT,

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -101,6 +101,28 @@ public:
         // Work-conserving and priority aging
         bool enable_work_conserving = true;
         bool enable_priority_aging = false;
+
+        // Credit reserves (optional guard against upstream producers
+        // starving downstream completion paths - see issue #61):
+        // - L3 reserve: credits DMA loads may not consume, kept for C-tile
+        //   writebacks (BlockMover L2->L3)
+        // - L2 reserve: credits BlockMover moves may not consume, kept for
+        //   compute-result drains (Streamer)
+        // Default 0: tile-reuse deduplication (DMA in-flight dedup, BlockMover
+        // move dedup, tile-affine work assignment) removes the credit leaks
+        // that caused livelock, and a reserve of 0 keeps load-only workloads
+        // able to fill the entire pool. Set >0 for schedules with extreme
+        // prefetch depth if writeback/drain starvation is observed.
+        // Effective values are clamped to (pool_size - 1) / 2 so small pools
+        // keep at least half their credits usable by the primary producer.
+        size_t l3_writeback_credit_reserve = 0;
+        size_t l2_drain_credit_reserve = 0;
+
+        /// Reserve clamp: never reserve more than half of (pool - 1)
+        [[nodiscard]] static size_t clamp_reserve(size_t reserve, size_t pool_size) {
+            size_t max_reserve = pool_size > 0 ? (pool_size - 1) / 2 : 0;
+            return reserve < max_reserve ? reserve : max_reserve;
+        }
     };
 
     /**
@@ -350,11 +372,8 @@ private:
     // Livelock detection
     std::unique_ptr<LivelockDetector> livelock_detector_;
 
-    // Round-robin counters for work distribution
-    mutable uint32_t next_dma_engine_ = 0;
-    mutable uint32_t next_block_mover_ = 0;
-    mutable uint32_t next_row_streamer_ = 0;
-    mutable uint32_t next_col_streamer_ = 0;
+    // Slot counter for compute results (instance-local, reset with executor)
+    uint32_t next_compute_slot_ = 0;
 
     // ========================================================================
     // Work Assignment
@@ -449,6 +468,8 @@ inline void ConcurrentTimingExecutor::create_components() {
         DMAEngineProcess::Config dma_config;
         dma_config.engine_id = static_cast<uint32_t>(dma);
         dma_config.queue_depth = config_.dma_queue_depth;
+        dma_config.l3_credit_reserve = Config::clamp_reserve(
+            config_.l3_writeback_credit_reserve, config_.l3_buffer_count);
         dma_config.name = dma_config.display_name();
 
         // Assign DMA to MC (round-robin if more DMAs than MCs)
@@ -474,6 +495,8 @@ inline void ConcurrentTimingExecutor::create_components() {
         bm_config.startup_latency = config_.bm_startup_latency;
         bm_config.clock_ghz = config_.clock_ghz;
         bm_config.priority_aging = config_.enable_priority_aging;
+        bm_config.l2_credit_reserve = Config::clamp_reserve(
+            config_.l2_drain_credit_reserve, config_.l2_bank_count);
         bm_config.name = bm_config.display_name();
 
         block_movers_.push_back(std::make_unique<BlockMoverProcess>(
@@ -653,8 +676,7 @@ inline bool ConcurrentTimingExecutor::step() {
     while (it != pending_computes_.end()) {
         if (it->started && current_cycle_ >= it->complete_cycle) {
             // Compute completed - result tile is now ready for DRAIN
-            static uint32_t next_compute_slot = 0;
-            uint32_t slot = next_compute_slot++;
+            uint32_t slot = next_compute_slot_++;
             compute_result_tag_cam_.insert(it->tile.tile_id, slot, current_cycle_);
 
             // Emit COMPUTE_COMPLETE event
@@ -785,10 +807,7 @@ inline void ConcurrentTimingExecutor::reset() {
         livelock_detector_->reset();
     }
 
-    next_dma_engine_ = 0;
-    next_block_mover_ = 0;
-    next_row_streamer_ = 0;
-    next_col_streamer_ = 0;
+    next_compute_slot_ = 0;
 }
 
 inline ConcurrentTimingExecutor::Statistics ConcurrentTimingExecutor::get_statistics() const {
@@ -870,34 +889,25 @@ inline size_t ConcurrentTimingExecutor::count_completed_tiles() const {
 }
 
 inline uint32_t ConcurrentTimingExecutor::select_dma_engine(const TileDescriptor& tile) const {
-    // Strategy: Round-robin for load balancing
-    // For multi-DMA configs, could also use matrix-based assignment
-    uint32_t dma = next_dma_engine_;
-    next_dma_engine_ = (next_dma_engine_ + 1) % static_cast<uint32_t>(dma_engines_.size());
-    (void)tile;  // Could use tile matrix for assignment
-    return dma;
+    // Strategy: Tile-affine assignment - all operations for the same tile go
+    // to the same engine. Round-robin spreads a reused tile's operations
+    // across engines, which allows concurrent duplicate transfers of the
+    // same tile: each acquires a credit but the ref-counted TagCAM entry
+    // releases only one, leaking credits until the pipeline wedges (#61).
+    return static_cast<uint32_t>(
+        TileIDHash{}(tile.tile_id) % dma_engines_.size());
 }
 
 inline uint32_t ConcurrentTimingExecutor::select_block_mover(const TileDescriptor& tile) const {
-    // Strategy: Round-robin for load balancing
-    uint32_t mover = next_block_mover_;
-    next_block_mover_ = (next_block_mover_ + 1) % static_cast<uint32_t>(block_movers_.size());
-    (void)tile;
-    return mover;
+    // Tile-affine assignment (see select_dma_engine for rationale)
+    return static_cast<uint32_t>(
+        TileIDHash{}(tile.tile_id) % block_movers_.size());
 }
 
 inline uint32_t ConcurrentTimingExecutor::select_streamer(const TileDescriptor& tile, bool is_row) const {
-    if (is_row) {
-        uint32_t streamer = next_row_streamer_;
-        next_row_streamer_ = (next_row_streamer_ + 1) % static_cast<uint32_t>(row_streamers_.size());
-        (void)tile;
-        return streamer;
-    } else {
-        uint32_t streamer = next_col_streamer_;
-        next_col_streamer_ = (next_col_streamer_ + 1) % static_cast<uint32_t>(col_streamers_.size());
-        (void)tile;
-        return streamer;
-    }
+    // Tile-affine assignment (see select_dma_engine for rationale)
+    size_t n = is_row ? row_streamers_.size() : col_streamers_.size();
+    return static_cast<uint32_t>(TileIDHash{}(tile.tile_id) % n);
 }
 
 inline void ConcurrentTimingExecutor::export_chrome_trace(const std::string& filename) const {

--- a/include/sw/kpu/timing/dma_engine_process.hpp
+++ b/include/sw/kpu/timing/dma_engine_process.hpp
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include <optional>
+#include <unordered_set>
 #include <vector>
 
 namespace sw::kpu::timing {
@@ -54,7 +55,9 @@ public:
      */
     struct Config {
         uint32_t engine_id = 0;        ///< Unique engine identifier
-        size_t queue_depth = 32;       ///< Max pending requests in queue
+        size_t queue_depth = 32;       ///< Max requests concurrently submitted to the MC
+        size_t l3_credit_reserve = 0;  ///< L3 credits loads may NOT consume (reserved for
+                                       ///< downstream writebacks; prevents credit starvation)
         std::string name = "DMA";      ///< Human-readable name
 
         /// Generate human-readable name
@@ -111,10 +114,9 @@ public:
      * 2. MC can accept the request
      */
     void schedule_load(const TileDescriptor& tile) {
-        if (pending_requests_.size() >= config_.queue_depth) {
-            return;  // Queue full
-        }
-
+        // The pending list is a software staging queue and accepts every
+        // scheduled request; the hardware constraint (queue_depth) bounds how
+        // many requests are concurrently SUBMITTED to the memory controller.
         PendingRequest req;
         req.tile = tile;
         req.is_load = true;
@@ -133,10 +135,7 @@ public:
      * 2. MC can accept the request
      */
     void schedule_store(const TileDescriptor& tile) {
-        if (pending_requests_.size() >= config_.queue_depth) {
-            return;  // Queue full
-        }
-
+        // Staging queue accepts every scheduled request (see schedule_load).
         PendingRequest req;
         req.tile = tile;
         req.is_load = false;
@@ -201,6 +200,7 @@ public:
 
     void reset() override {
         pending_requests_.clear();
+        submitted_load_tiles_.clear();
         next_slot_id_ = 0;
         stall_cycles_credit_ = 0;
         stall_cycles_tag_ = 0;
@@ -255,6 +255,7 @@ private:
     TagCAM& l3_tag_cam_;
 
     std::vector<PendingRequest> pending_requests_;
+    std::unordered_set<TileID, TileIDHash> submitted_load_tiles_;
 
     Cycle current_cycle_ = 0;
     uint32_t next_slot_id_ = 0;
@@ -280,6 +281,7 @@ private:
                     if (completed->is_load) {
                         // Load complete: tile arrived at L3
                         l3_tag_cam_.insert(completed->tile.tile_id, req.slot_id, current_cycle_);
+                        submitted_load_tiles_.erase(completed->tile.tile_id);
                         total_bytes_loaded_ += completed->tile.size_bytes;
 
                         events.push_back(TimingEvent(
@@ -318,6 +320,9 @@ private:
      * @brief Try to acquire credits and submit pending loads to MC
      */
     void process_pending_loads(std::vector<TimingEvent>& events) {
+        size_t in_flight = submitted_count();
+        bool credit_stalled = false;
+        TileID stalled_tile{};
         for (auto& req : pending_requests_) {
             if (!req.is_load || req.state != RequestState::WAITING_CREDIT) {
                 continue;
@@ -341,16 +346,31 @@ private:
                 continue;
             }
 
-            // Need L3 credit
-            if (!l3_credits_.acquire()) {
-                events.push_back(TimingEvent(
-                    EventType::DMA_STALL_CREDIT,
-                    current_cycle_,
-                    config_.engine_id,
-                    req.tile.tile_id,
-                    name()
-                ));
-                stall_cycles_credit_++;
+            // Defer if a load for the same tile is already in flight: when it
+            // completes and inserts into L3, this request resolves via the
+            // dedup path above. Submitting a second real load would acquire a
+            // second credit for a single TagCAM entry (which releases only
+            // one credit), leaking credits on reuse-heavy schedules (#61).
+            if (submitted_load_tiles_.count(req.tile.tile_id) > 0) {
+                continue;
+            }
+
+            // Hardware queue slot required beyond this point
+            if (in_flight >= config_.queue_depth) {
+                continue;  // All slots occupied - dedup hits above can still complete
+            }
+
+            // Need L3 credit. Loads may not consume the reserved credits -
+            // those are kept for C-tile writebacks (BlockMover L2->L3).
+            // Without the reserve, greedy prefetch loads re-acquire every
+            // freed credit before a writeback can, starving the downstream
+            // path and wedging the pipeline (credit cycle livelock).
+            if (l3_credits_.available() <= config_.l3_credit_reserve ||
+                !l3_credits_.acquire()) {
+                if (!credit_stalled) {
+                    credit_stalled = true;
+                    stalled_tile = req.tile.tile_id;
+                }
                 continue;  // Try other requests
             }
 
@@ -363,6 +383,8 @@ private:
             }
 
             req.state = RequestState::SUBMITTED;
+            submitted_load_tiles_.insert(req.tile.tile_id);
+            ++in_flight;
 
             events.push_back(TimingEvent(
                 EventType::CREDIT_ACQUIRED,
@@ -372,28 +394,42 @@ private:
                 name()
             ));
         }
+
+        // Stall accounting: at most one stall cycle per tick (matches BM/STR)
+        if (credit_stalled) {
+            events.push_back(TimingEvent(
+                EventType::DMA_STALL_CREDIT,
+                current_cycle_,
+                config_.engine_id,
+                stalled_tile,
+                name()
+            ));
+            stall_cycles_credit_++;
+        }
     }
 
     /**
      * @brief Try to match tags and submit pending stores to MC
      */
     void process_pending_stores(std::vector<TimingEvent>& events) {
+        size_t in_flight = submitted_count();
+        bool tag_stalled = false;
+        TileID stalled_tile{};
         for (auto& req : pending_requests_) {
             if (req.is_load || req.state != RequestState::WAITING_TAG) {
                 continue;
+            }
+            if (in_flight >= config_.queue_depth) {
+                break;  // All hardware queue slots occupied
             }
 
             // Need tile to be in L3 (TagCAM match)
             auto entry = l3_tag_cam_.match(req.tile.tile_id);
             if (!entry.has_value()) {
-                events.push_back(TimingEvent(
-                    EventType::DMA_STALL_TAG,
-                    current_cycle_,
-                    config_.engine_id,
-                    req.tile.tile_id,
-                    name()
-                ));
-                stall_cycles_tag_++;
+                if (!tag_stalled) {
+                    tag_stalled = true;
+                    stalled_tile = req.tile.tile_id;
+                }
                 continue;  // Try other requests
             }
 
@@ -404,6 +440,19 @@ private:
             }
 
             req.state = RequestState::SUBMITTED;
+            ++in_flight;
+        }
+
+        // Stall accounting: at most one stall cycle per tick (matches BM/STR)
+        if (tag_stalled) {
+            events.push_back(TimingEvent(
+                EventType::DMA_STALL_TAG,
+                current_cycle_,
+                config_.engine_id,
+                stalled_tile,
+                name()
+            ));
+            stall_cycles_tag_++;
         }
     }
 

--- a/include/sw/kpu/timing/streamer_process.hpp
+++ b/include/sw/kpu/timing/streamer_process.hpp
@@ -155,6 +155,7 @@ public:
         feed_queue_.reset();
         drain_queue_.reset();
         in_flight_.reset();
+        next_l2_slot_ = 0;
         stall_cycles_tag_ = 0;
         stall_cycles_credit_ = 0;
         stall_cycles_compute_ = 0;
@@ -213,6 +214,7 @@ private:
     std::optional<InFlightTransfer> in_flight_;
 
     Cycle current_cycle_ = 0;
+    uint32_t next_l2_slot_ = 0;
     double cycles_per_byte_ = 0.01;  // ~100 bytes/cycle at 102.4 GB/s @ 1GHz
 
     // For in-flight tracking
@@ -465,9 +467,8 @@ private:
      * @brief Allocate an L2 bank slot (round-robin)
      */
     uint32_t allocate_l2_slot() {
-        static uint32_t next_slot = 0;
-        uint32_t slot = next_slot;
-        next_slot = (next_slot + 1) % static_cast<uint32_t>(l2_tag_cam_.capacity());
+        uint32_t slot = next_l2_slot_;
+        next_l2_slot_ = (next_l2_slot_ + 1) % static_cast<uint32_t>(l2_tag_cam_.capacity());
         return slot;
     }
 };


### PR DESCRIPTION
Fixes #61.

## Problem

`run_matmul` (examples/schedule) livelocked at its **default** 64x64x64 / 16^3-tile configuration — and at every larger size — despite the schedule validating as livelock-safe. The 1x1x1 `csp_pipeline_demo` worked; anything with tile reuse or more ops than the DMA queue wedged.

## Root causes (four, compounding)

1. **Silent request drop.** `DMAEngineProcess::schedule_load/schedule_store` returned silently when the pending list hit `queue_depth` (32). `ScheduleExecutor` enqueues entire schedules upfront (128 loads + 16 stores at 64^3), so 112 requests vanished while being counted as completed; BlockMovers/Streamers then tag-stalled forever on tiles that were never loaded. The pending list is now an unbounded software staging queue and `queue_depth` bounds concurrently **submitted** MC requests.
2. **Credit leak on tile reuse.** Each duplicate MOVE of an L2-resident tile acquired a fresh L2 credit, but the ref-counted TagCAM entry releases exactly one credit when it drains — leaking (uses−1) credits per reused tile. At 128^3 each tile is reused 8x, exhausting the L2 pool. `BlockMoverProcess` now dedups moves for resident tiles (ref_count++ without a credit), implementing the schedule generators' documented contract ("execution layer deduplicates").
3. **Duplicate in-flight loads.** A second load of the same tile could be submitted while the first was still in the MC, double-acquiring L3 credits for one entry. Loads now defer while the tile has a submitted load (O(1) set), and work assignment is **tile-affine** (TileID hash) instead of round-robin, so one tile's operations serialize on one DMA/BlockMover/Streamer and cannot race across processes.
4. **`static` state bugs.** `StreamerProcess::allocate_l2_slot` used a counter shared across all streamer instances; the executor's compute-slot counter was function-local static, shared across executors and never reset. Both are instance members now.

Also included: DMA stall accounting is now at most one stall cycle per tick (matching BM/STR semantics — previously per pending request, yielding stall counts 18x total cycles), and optional `l3_writeback_credit_reserve` / `l2_drain_credit_reserve` executor knobs (default 0, clamped for small pools) as a guard against prefetch starving writeback/drain credit acquisition on extreme schedules.

## Verification

| strategy | 32^3 | 64^3 | 128^3 | 256^3 |
|---|---|---|---|---|
| interleaved | 302 | 1132 | 8130 | 92382 |
| output_stationary | 302 | 1132 | 8130 | 92382 |
| blocked (documented livelock-prone) | 303 | 1132 | 8137 | 92442 |

All SUCCESS (cycles shown); previously FAILED with livelock at 64^3 and above.

- `ctest`: 95/95 pass (12/12 timing suites)
- `csp_pipeline_demo`: credit conservation intact ("every acquire has a matching release")

Session log: `docs/sessions/2026-07-09_v0.9_multi_tile_livelock_fix.md` (includes wrong-decision documentation per governance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved multi-tile CSP timing livelocks that could block matrix multiplication from completing.
  - Improved reliability by deduplicating duplicate tile loads and handling tiles already resident in cache.
  - Corrected DMA credit/queue depth and stall accounting, including more consistent per-tick stall emission.
  - Ensured tile-affine work assignment to prevent cross-tile state conflicts.
  - Prevented state bleed by switching shared counters to per-executor/per-component state.
- **New Features**
  - Added optional credit-reserve controls (`l3_writeback_credit_reserve`, `l2_drain_credit_reserve`) with safe defaults.
- **Documentation**
  - Added release notes and a decision log covering the diagnosis and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->