### PR TITLE
feat: COMPUTE all-K-slice dependencies, K-scaled latency, execution regression suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CSP timing: multi-tile execution regression suite (#64).**
+  `tests/timing/test_multi_tile_execution.cpp` executes generated matmul
+  schedules end-to-end through `ConcurrentTimingExecutor` across all four
+  strategies x 32^3/64^3/128^3, asserting completion, no livelock, exact
+  per-stage tile accounting (moves/writebacks/feeds/drains match schedule op
+  counts), and per-tick stall-accounting bounds. Closes the coverage hole
+  that let #61 reach main: no prior test executed a generated multi-tile
+  schedule.
+
 ### Fixed
+
+- **CSP timing: COMPUTE dependencies now cover all K-slice feeds, and
+  compute latency scales with K (#63).** The matmul schedule generators
+  previously keyed COMPUTE for C(ti,tj) to only the last B feed; a compute
+  could start before its A tiles or earlier K slices were fed. COMPUTE now
+  carries the full dependency set (every A(ti,*,k) and B(*,tj,k)), the
+  executor starts compute only when all of them have been fed, and latency
+  is `compute_latency + (k_slices - 1) * compute_cycles_per_k_slice` (new
+  config knob, default 32). `ScheduleOperation` gains a `dependency_tiles`
+  list (the single-dependency field and executor overload remain for
+  backward compatibility); `is_complete()` now also accounts for pending
+  computes. Known remaining approximation: fed-tile tracking is a monotonic
+  was-ever-fed set, so a tile fed for an earlier output iteration satisfies
+  later iterations' dependencies (per-instance accounting arrives with real
+  data movement).
+- **CSP timing: PREFETCH_NEXT strategy livelocked at 128^3 and above** —
+  caught immediately by the new regression suite (#64). The generator
+  emitted each tile's load twice per output iteration (prefetch + current)
+  but only one MOVE, stranding L3 TagCAM references and credits (the same
+  leak class as #61). Loads are now emitted once (at k=0 directly, k>=1 via
+  the previous iteration's prefetch), keeping the LOAD:MOVE pairing 1:1.
 
 - **CSP timing: multi-tile schedules livelocked in `ConcurrentTimingExecutor` (#61).**
   `run_matmul` failed with livelock at its default 64x64x64 / 16^3-tile

--- a/docs/sessions/2026-07-10_v0.9_phase0_compute_deps_regression.md
+++ b/docs/sessions/2026-07-10_v0.9_phase0_compute_deps_regression.md
@@ -1,0 +1,117 @@
+# v0.9 Phase 0 Completion: COMPUTE Dependencies + Execution Regression Decision Log
+
+**Date:** 2026-07-10
+**Version:** v0.9
+**Status:** Complete
+**Tests:** all suites passing incl. new test_multi_tile_execution (345 assertions)
+**Issues:** #63 (COMPUTE dependencies), #64 (execution regression suite)
+
+## 1. Summary
+
+Completed the two remaining Phase 0 items from
+`docs/architecture/simulator-assessment-and-plan.md`. COMPUTE operations now
+depend on ALL K-slice A and B feeds for their result tile (previously only
+the last B feed) and compute latency scales with accumulation depth. A new
+regression suite executes generated schedules end-to-end across the full
+strategy x size matrix — and immediately caught a real liveness bug the #61
+work had missed: the PREFETCH_NEXT strategy livelocked at 128^3 because its
+generator emitted duplicate loads without matching moves (the same
+reference/credit-stranding class as #61). Fixed in the generator.
+
+## 2. Scope
+
+| Item | Status | Verification |
+|------|--------|--------------|
+| ScheduleOperation dependency list | Done | compute() overload; legacy field mirrored |
+| Generator emits full A+B x K dependency set | Done | test: 8 deps per COMPUTE at 64^3 |
+| Executor waits on all dependencies | Done | matrix executes; 32^3 shifted 302->334 cycles |
+| K-scaled compute latency (`compute_cycles_per_k_slice`) | Done | test: COMPUTE_COMPLETE duration == base + (k-1)*slice |
+| `is_complete()` accounts for pending computes | Done | completeness hole closed |
+| Regression suite (4 strategies x 3 sizes) | Done | tests/timing/test_multi_tile_execution.cpp |
+| PREFETCH_NEXT livelock (found by the suite) | Fixed | 1:1 LOAD:MOVE pairing restored |
+
+Files modified:
+- `include/sw/kpu/timing/schedule/schedule_generator_interface.hpp` (implementation)
+- `include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp` (implementation)
+- `include/sw/kpu/timing/schedule/schedule_executor.hpp` (implementation)
+- `include/sw/kpu/timing/concurrent_timing_executor.hpp` (implementation)
+- `tests/timing/test_multi_tile_execution.cpp` (new)
+- `tests/timing/test_schedule_generators.cpp` (prefetch load-count expectation)
+- `tests/timing/CMakeLists.txt` (register new test)
+- `CHANGELOG.md`
+- `docs/sessions/2026-07-10_v0.9_phase0_compute_deps_regression.md` (this log)
+
+## 3. Technical Decisions
+
+**Decision 1: Dependency list with a legacy mirror, not a breaking change**
+- **Choice:** `ScheduleOperation.dependency_tiles` (vector) is authoritative;
+  `dependency_tile` retained, holding the last entry; the executor keeps the
+  single-dependency `schedule_compute` overload delegating to the vector one.
+- **Alternatives:** replace the field outright (breaks demos/tests that call
+  the single-dep API); a separate COMPUTE_MULTI op type (schema sprawl).
+- **Rationale:** all existing call sites keep compiling with identical
+  semantics; new code opts into the full set.
+
+**Decision 2: Latency model = base + (k_slices - 1) x per-slice**
+- **Choice:** K-slice count derived from the dependency set
+  (dependencies/2, one A + one B per slice); new Config knob
+  `compute_cycles_per_k_slice` (default 32, same as `compute_latency`).
+- **Rationale:** single-dependency computes get k_slices = 1 and therefore
+  exactly the old latency — existing tests and demos are timing-identical.
+  A K-proportional term captures accumulation depth without inventing
+  per-element systolic detail that belongs to Phase 1 (real compute).
+
+**Decision 3: Fix PREFETCH_NEXT in the generator, not the executor**
+- **Choice:** emit each tile's load once per output iteration (k = 0
+  directly, k >= 1 via the previous iteration's prefetch), preserving the
+  early-issue intent while restoring the 1:1 LOAD:MOVE pairing.
+- **Alternatives:** teach the DMA to drop "redundant" loads (hides schedule
+  bugs and breaks the reference-counting contract where every load-insert
+  is consumed by exactly one move).
+- **Rationale:** conservation is a schedule invariant: #L3-inserts(tile) ==
+  #L3-invalidates(tile). Generators own it; the execution layer enforces it.
+  The generator test now asserts LOAD == MOVE for prefetch schedules.
+
+## 4. Issues Encountered
+
+1. **Symptom:** new regression suite failed: PREFETCH_NEXT at 128^3,
+   "Livelock detected" at 11,000 cycles. **Root cause:** duplicate loads
+   (prefetch + current) with single moves stranded L3 TagCAM references and
+   credits — the #61 leak class, in a strategy `run_matmul`'s matrix never
+   exercised. **Fix:** Decision 3.
+2. **Symptom:** `-Werror=maybe-uninitialized` on the new
+   `PendingCompute::latency`. **Fix:** default member initializers on the
+   struct.
+3. **Symptom:** `test_schedule_generators` prefetch case asserted
+   `load_ops > 2*k*c` (duplication as a feature). **Fix:** assertion now
+   encodes the conservation invariant (`load_ops == move_ops`).
+
+## 5. Wrong Decisions (CRITICAL)
+
+**Wrong decision (scope of #61 verification):** the #61 fix was verified
+against `run_matmul`'s strategy flags (interleaved / output_stationary /
+blocked) — PREFETCH_NEXT is not exposed by that example and went untested,
+shipping #61 with a latent livelock in the fourth strategy. **Correction:**
+the regression suite iterates the strategy enum, not an example's CLI
+surface. **Lesson:** verify against the type system's full surface (all
+enum values), not against whichever subset a demo happens to expose.
+
+No other wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build -L timing --output-on-failure   # 13/13 suites pass
+ctest --test-dir build                                  # full suite passes
+./build/tests/timing/test_multi_tile_execution          # 345 assertions
+./build/examples/schedule/run_matmul                    # SUCCESS
+```
+
+## 7. Next Steps
+
+- Phase 1 (transactional-functional unification): tile payloads + a real
+  accumulating ComputeProcess; replaces the was-ever-fed dependency
+  approximation with per-instance feed accounting.
+- Consider credit/ref-count conservation as executor-trace invariants
+  (INV-3xx style) per the LPDDR5 validation pattern.

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -88,7 +88,10 @@ public:
         Cycle str_startup_latency = 2;    ///< Streamer startup latency
 
         // Compute configuration
-        Cycle compute_latency = 32;       ///< Cycles for tile computation (after all inputs fed)
+        Cycle compute_latency = 32;       ///< Base cycles for tile computation (after all inputs fed)
+        Cycle compute_cycles_per_k_slice = 32;  ///< Additional cycles per K slice beyond the
+                                                ///< first (accumulation depth; K-slice count is
+                                                ///< derived from the COMPUTE dependency set)
 
         // Timing parameters
         double clock_ghz = 1.0;           ///< Reference clock in GHz
@@ -237,13 +240,30 @@ public:
     /**
      * @brief Schedule a compute completion (signals result tile is ready)
      * @param tile Result tile descriptor (C matrix tile)
-     * @param dependency_tile Last input tile that must be FED before compute starts
+     * @param dependency_tile Single input tile that must be FED before
+     *        compute starts (legacy single-dependency form)
      *
      * This must be called after all FEED operations for the input tiles
      * that contribute to this result. DRAIN waits for this before proceeding.
-     * Compute only starts when dependency_tile has been FED to compute.
      */
     void schedule_compute(const TileDescriptor& tile, const TileID& dependency_tile);
+
+    /**
+     * @brief Schedule a compute with the full dependency set
+     * @param tile Result tile descriptor (C matrix tile)
+     * @param dependencies ALL input tiles (every A and B K-slice) that must
+     *        be FED before compute starts
+     *
+     * Compute starts only when every dependency has been FED, and its
+     * latency scales with the K-slice count (dependencies.size() / 2):
+     * latency = compute_latency + (k_slices - 1) * compute_cycles_per_k_slice.
+     *
+     * Known approximation: fed-tile tracking is a monotonic was-ever-fed
+     * set, so a tile fed for an earlier output iteration also satisfies
+     * later iterations' dependencies. Per-instance feed accounting arrives
+     * with real data movement (Phase 1).
+     */
+    void schedule_compute(const TileDescriptor& tile, std::vector<TileID> dependencies);
 
     /**
      * @brief Schedule a compute completion (no explicit dependency)
@@ -349,13 +369,14 @@ private:
     TagCAM l2_tag_cam_;
     TagCAM compute_result_tag_cam_;  ///< Tracks result tiles ready for DRAIN
 
-    // Pending compute operations (tile + dependency + state)
+    // Pending compute operations (tile + dependencies + state)
     struct PendingCompute {
-        TileDescriptor tile;         ///< Result tile (C)
-        TileID dependency_tile;      ///< Last input tile that must be FED
-        Cycle schedule_cycle;        ///< When scheduled
-        Cycle complete_cycle;        ///< When computation will complete (set when started)
-        bool started;                ///< Has computation started?
+        TileDescriptor tile;              ///< Result tile (C)
+        std::vector<TileID> dependencies; ///< ALL input tiles that must be FED
+        Cycle schedule_cycle = 0;    ///< When scheduled
+        Cycle complete_cycle = 0;    ///< When computation will complete (set when started)
+        Cycle latency = 0;           ///< Computed latency (set when started)
+        bool started = false;        ///< Has computation started?
     };
     std::vector<PendingCompute> pending_computes_;
 
@@ -600,14 +621,18 @@ inline void ConcurrentTimingExecutor::schedule_drain(const TileDescriptor& tile,
 
 inline void ConcurrentTimingExecutor::schedule_compute(
     const TileDescriptor& tile, const TileID& dependency_tile) {
-    // Schedule compute with explicit dependency
+    schedule_compute(tile, std::vector<TileID>{dependency_tile});
+}
+
+inline void ConcurrentTimingExecutor::schedule_compute(
+    const TileDescriptor& tile, std::vector<TileID> dependencies) {
     PendingCompute pc;
     pc.tile = tile;
-    pc.dependency_tile = dependency_tile;
+    pc.dependencies = std::move(dependencies);
     pc.schedule_cycle = current_cycle_;
     pc.complete_cycle = 0;  // Set when started
     pc.started = false;
-    pending_computes_.push_back(pc);
+    pending_computes_.push_back(std::move(pc));
 }
 
 inline void ConcurrentTimingExecutor::schedule_compute(const TileDescriptor& tile) {
@@ -656,11 +681,24 @@ inline bool ConcurrentTimingExecutor::step() {
     // Step 0a: Check pending computes for dependency satisfaction and start them
     for (auto& pc : pending_computes_) {
         if (!pc.started) {
-            // Check if dependency tile has been fed
-            if (fed_tiles_.count(pc.dependency_tile) > 0) {
-                // Dependency satisfied - start compute
+            // Compute starts only when ALL dependencies (every A and B
+            // K-slice for this result tile) have been fed
+            bool all_fed = true;
+            for (const auto& dep : pc.dependencies) {
+                if (fed_tiles_.count(dep) == 0) {
+                    all_fed = false;
+                    break;
+                }
+            }
+            if (all_fed) {
+                // Latency scales with accumulation depth: the K-slice count
+                // is dependencies/2 (one A and one B tile per K slice)
+                size_t k_slices = pc.dependencies.size() >= 2
+                    ? pc.dependencies.size() / 2 : 1;
+                pc.latency = config_.compute_latency +
+                    static_cast<Cycle>(k_slices - 1) * config_.compute_cycles_per_k_slice;
                 pc.started = true;
-                pc.complete_cycle = current_cycle_ + config_.compute_latency;
+                pc.complete_cycle = current_cycle_ + pc.latency;
 
                 // Emit COMPUTE_START event
                 TimingEvent event(EventType::COMPUTE_START, current_cycle_, 0,
@@ -682,8 +720,8 @@ inline bool ConcurrentTimingExecutor::step() {
             // Emit COMPUTE_COMPLETE event
             TimingEvent event = TimingEvent::duration_event(
                 EventType::COMPUTE_COMPLETE,
-                it->complete_cycle - config_.compute_latency,
-                config_.compute_latency,
+                it->complete_cycle - it->latency,
+                it->latency,
                 0, it->tile.tile_id, "Compute");
             event.matrix_base_address = it->tile.matrix_base_address;
             events_.push_back(event);
@@ -748,6 +786,9 @@ inline bool ConcurrentTimingExecutor::step() {
 
 inline bool ConcurrentTimingExecutor::is_complete() const {
     // Complete when all queues are empty and no in-flight work
+
+    // Check pending computes (started or waiting on dependencies)
+    if (!pending_computes_.empty()) return false;
 
     // Check MCs (should be idle when DMA is complete)
     for (const auto& mc : memory_controllers_) {

--- a/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
@@ -245,14 +245,10 @@ private:
                 }
 
                 // Signal compute complete, then drain C tile
-                // COMPUTE depends on last B tile being fed: B[0,tj,k-1]
+                // COMPUTE depends on ALL K-slice A and B feeds for this C tile
                 auto c_tile = make_tile(isa::MatrixID::C, ti, tj, 0);
-                TileID last_b;
-                last_b.matrix = isa::MatrixID::B;
-                last_b.ti = 0;
-                last_b.tj = tj;
-                last_b.tk = k_tiles - 1;
-                result.operations.push_back(ScheduleOperation::compute(c_tile, last_b));
+                result.operations.push_back(ScheduleOperation::compute(
+                    c_tile, make_compute_dependencies(ti, tj, k_tiles)));
                 result.operations.push_back(ScheduleOperation::drain(c_tile));
                 result.operations.push_back(ScheduleOperation::writeback(c_tile));
                 result.operations.push_back(ScheduleOperation::store(c_tile));
@@ -305,14 +301,10 @@ private:
                 }
 
                 // Signal compute complete, then drain and store C tile
-                // COMPUTE depends on last B tile being fed: B[0,tj,k-1]
+                // COMPUTE depends on ALL K-slice A and B feeds for this C tile
                 auto c_tile = make_tile(isa::MatrixID::C, ti, tj, 0);
-                TileID last_b;
-                last_b.matrix = isa::MatrixID::B;
-                last_b.ti = 0;
-                last_b.tj = tj;
-                last_b.tk = k_tiles - 1;
-                result.operations.push_back(ScheduleOperation::compute(c_tile, last_b));
+                result.operations.push_back(ScheduleOperation::compute(
+                    c_tile, make_compute_dependencies(ti, tj, k_tiles)));
                 result.operations.push_back(ScheduleOperation::drain(c_tile));
                 result.operations.push_back(ScheduleOperation::writeback(c_tile));
                 result.operations.push_back(ScheduleOperation::store(c_tile));
@@ -337,9 +329,16 @@ private:
                     auto a_tile = make_tile(isa::MatrixID::A, ti, 0, tk);
                     auto b_tile = make_tile(isa::MatrixID::B, 0, tj, tk);
 
-                    // Load current tiles (execution layer deduplicates)
-                    result.operations.push_back(ScheduleOperation::load(a_tile));
-                    result.operations.push_back(ScheduleOperation::load(b_tile));
+                    // Load current tiles only at tk == 0; tiles for tk >= 1
+                    // were already loaded by the previous iteration's
+                    // prefetch. Every LOAD must pair 1:1 with a MOVE:
+                    // each load inserts an L3 TagCAM reference and each move
+                    // consumes one, so duplicate loads leave references (and
+                    // the L3 credit) stranded -> livelock at scale.
+                    if (tk == 0) {
+                        result.operations.push_back(ScheduleOperation::load(a_tile));
+                        result.operations.push_back(ScheduleOperation::load(b_tile));
+                    }
 
                     // Prefetch next tiles if available
                     if (tk + 1 < k_tiles) {
@@ -357,14 +356,10 @@ private:
                 }
 
                 // Signal compute complete, then drain and store C
-                // COMPUTE depends on last B tile being fed: B[0,tj,k-1]
+                // COMPUTE depends on ALL K-slice A and B feeds for this C tile
                 auto c_tile = make_tile(isa::MatrixID::C, ti, tj, 0);
-                TileID last_b;
-                last_b.matrix = isa::MatrixID::B;
-                last_b.ti = 0;
-                last_b.tj = tj;
-                last_b.tk = k_tiles - 1;
-                result.operations.push_back(ScheduleOperation::compute(c_tile, last_b));
+                result.operations.push_back(ScheduleOperation::compute(
+                    c_tile, make_compute_dependencies(ti, tj, k_tiles)));
                 result.operations.push_back(ScheduleOperation::drain(c_tile));
                 result.operations.push_back(ScheduleOperation::writeback(c_tile));
                 result.operations.push_back(ScheduleOperation::store(c_tile));
@@ -409,19 +404,43 @@ private:
                 }
 
                 // Signal compute complete, then drain and store C
-                // COMPUTE depends on last B tile being fed: B[0,tj,k-1]
+                // COMPUTE depends on ALL K-slice A and B feeds for this C tile
                 auto c_tile = make_tile(isa::MatrixID::C, ti, tj, 0);
-                TileID last_b;
-                last_b.matrix = isa::MatrixID::B;
-                last_b.ti = 0;
-                last_b.tj = tj;
-                last_b.tk = k_tiles - 1;
-                result.operations.push_back(ScheduleOperation::compute(c_tile, last_b));
+                result.operations.push_back(ScheduleOperation::compute(
+                    c_tile, make_compute_dependencies(ti, tj, k_tiles)));
                 result.operations.push_back(ScheduleOperation::drain(c_tile));
                 result.operations.push_back(ScheduleOperation::writeback(c_tile));
                 result.operations.push_back(ScheduleOperation::store(c_tile));
             }
         }
+    }
+
+    /**
+     * @brief Build the full COMPUTE dependency set for C[ti,tj]
+     *
+     * Every A[ti,*,k] and B[*,tj,k] K-slice must be FED before the compute
+     * for C[ti,tj] can start. The K-slice count (dependencies / 2) also
+     * scales compute latency in the executor.
+     */
+    std::vector<TileID> make_compute_dependencies(Size ti, Size tj, Size k_tiles) const {
+        std::vector<TileID> deps;
+        deps.reserve(2 * k_tiles);
+        for (Size tk = 0; tk < k_tiles; ++tk) {
+            TileID a;
+            a.matrix = isa::MatrixID::A;
+            a.ti = ti;
+            a.tj = 0;
+            a.tk = tk;
+            deps.push_back(a);
+
+            TileID b;
+            b.matrix = isa::MatrixID::B;
+            b.ti = 0;
+            b.tj = tj;
+            b.tk = tk;
+            deps.push_back(b);
+        }
+        return deps;
     }
 
     /**

--- a/include/sw/kpu/timing/schedule/schedule_executor.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_executor.hpp
@@ -257,7 +257,11 @@ private:
                 break;
 
             case ScheduleOpType::COMPUTE:
-                executor_.schedule_compute(op.tile, op.dependency_tile);
+                if (!op.dependency_tiles.empty()) {
+                    executor_.schedule_compute(op.tile, op.dependency_tiles);
+                } else {
+                    executor_.schedule_compute(op.tile, op.dependency_tile);
+                }
                 break;
 
             case ScheduleOpType::DRAIN:

--- a/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
@@ -75,8 +75,12 @@ struct ScheduleOperation {
     int mover_id = -1;                      ///< Target BlockMover
     int streamer_id = -1;                   ///< Target Streamer
 
-    // For COMPUTE operations: the tile that must be FED before compute starts
-    TileID dependency_tile;                 ///< COMPUTE waits for this tile to be FED
+    // For COMPUTE operations: ALL tiles that must be FED before compute
+    // starts (every A and B K-slice contributing to the result tile).
+    // dependency_tile is retained for backward compatibility and holds the
+    // last entry of dependency_tiles.
+    std::vector<TileID> dependency_tiles;   ///< COMPUTE waits for all of these
+    TileID dependency_tile;                 ///< Last dependency (legacy field)
 
     /**
      * @brief Create a LOAD operation
@@ -142,13 +146,36 @@ struct ScheduleOperation {
      * transferring the result from compute fabric to L2.
      *
      * @param tile Result tile (C matrix)
-     * @param dependency Last input tile that must be FED before compute starts
+     * @param dependency Single input tile that must be FED before compute
+     *                   starts (legacy single-dependency form)
      */
     static ScheduleOperation compute(const TileDescriptor& tile, const TileID& dependency) {
         ScheduleOperation op;
         op.type = ScheduleOpType::COMPUTE;
         op.tile = tile;
+        op.dependency_tiles = {dependency};
         op.dependency_tile = dependency;
+        return op;
+    }
+
+    /**
+     * @brief Create a COMPUTE operation with the full dependency set
+     *
+     * @param tile Result tile (C matrix)
+     * @param dependencies ALL input tiles (every A and B K-slice) that must
+     *                     be FED before compute starts; the K-slice count
+     *                     (dependencies.size() / 2) also scales compute
+     *                     latency in the executor
+     */
+    static ScheduleOperation compute(const TileDescriptor& tile,
+                                     std::vector<TileID> dependencies) {
+        ScheduleOperation op;
+        op.type = ScheduleOpType::COMPUTE;
+        op.tile = tile;
+        if (!dependencies.empty()) {
+            op.dependency_tile = dependencies.back();
+        }
+        op.dependency_tiles = std::move(dependencies);
         return op;
     }
 

--- a/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
@@ -80,7 +80,7 @@ struct ScheduleOperation {
     // dependency_tile is retained for backward compatibility and holds the
     // last entry of dependency_tiles.
     std::vector<TileID> dependency_tiles;   ///< COMPUTE waits for all of these
-    TileID dependency_tile;                 ///< Last dependency (legacy field)
+    TileID dependency_tile{};               ///< Last dependency (legacy field)
 
     /**
      * @brief Create a LOAD operation

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -118,3 +118,13 @@ kpu_add_component_test(test_schedule_validation "timing"
 set_tests_properties(test_schedule_validation PROPERTIES
     LABELS "timing;schedule;validation;v0.9"
 )
+
+# Multi-tile execution regression (issues #61/#63/#64):
+# executes generated schedules end-to-end across the strategy x size matrix
+kpu_add_component_test(test_multi_tile_execution "timing"
+    test_multi_tile_execution.cpp
+)
+
+set_tests_properties(test_multi_tile_execution PROPERTIES
+    LABELS "timing;executor;regression;v0.9"
+)

--- a/tests/timing/test_multi_tile_execution.cpp
+++ b/tests/timing/test_multi_tile_execution.cpp
@@ -42,7 +42,7 @@ ConcurrentTimingExecutor::Config make_executor_config() {
 }
 
 MatMulScheduleGenerator::Config make_generator_config(
-    size_t n, MatMulScheduleGenerator::Strategy strategy) {
+    Size n, MatMulScheduleGenerator::Strategy strategy) {
     MatMulScheduleGenerator::Config config;
     config.M = n;
     config.N = n;
@@ -70,7 +70,7 @@ constexpr StrategyCase kStrategies[] = {
 };
 
 struct SizeCase {
-    size_t n;        // M = N = K (16^3 tiles -> n/16 tile grid per dim)
+    Size n;          // M = N = K (16^3 tiles -> n/16 tile grid per dim)
     Cycle ceiling;   // generous total-cycle bound; cycle counts vary across
                      // platforms (work assignment hashes with std::hash)
 };

--- a/tests/timing/test_multi_tile_execution.cpp
+++ b/tests/timing/test_multi_tile_execution.cpp
@@ -1,0 +1,217 @@
+// ============================================================================
+// tests/timing/test_multi_tile_execution.cpp
+// End-to-end regression: execute generated multi-tile schedules through the
+// ConcurrentTimingExecutor across the strategy x size matrix.
+//
+// Locks in the fix for issue #61 (multi-tile livelock): the livelock was
+// invisible to CI because component suites test in isolation and schedule
+// suites only generate/validate — no test EXECUTED a generated multi-tile
+// schedule. This one does. See also issue #64.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2025 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+#include <string>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+// Mirrors examples/schedule/run_matmul.cpp defaults
+ConcurrentTimingExecutor::Config make_executor_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.num_memory_controllers = 1;
+    config.l3_buffer_count = 32;
+    config.num_block_movers = 4;
+    config.l2_bank_count = 64;
+    config.num_row_streamers = 2;
+    config.num_col_streamers = 2;
+    config.max_cycles = 1'000'000;
+    config.enable_livelock_detection = true;
+    config.livelock_threshold = 10000;
+    return config;
+}
+
+MatMulScheduleGenerator::Config make_generator_config(
+    size_t n, MatMulScheduleGenerator::Strategy strategy) {
+    MatMulScheduleGenerator::Config config;
+    config.M = n;
+    config.N = n;
+    config.K = n;
+    config.Ti = 16;
+    config.Tj = 16;
+    config.Tk = 16;
+    config.strategy = strategy;
+    config.a_base = 0x00001000;
+    config.b_base = 0x00100000;
+    config.c_base = 0x00200000;
+    return config;
+}
+
+struct StrategyCase {
+    MatMulScheduleGenerator::Strategy strategy;
+    const char* name;
+};
+
+constexpr StrategyCase kStrategies[] = {
+    {MatMulScheduleGenerator::Strategy::OUTPUT_STATIONARY, "output_stationary"},
+    {MatMulScheduleGenerator::Strategy::INTERLEAVED_AB,    "interleaved_ab"},
+    {MatMulScheduleGenerator::Strategy::PREFETCH_NEXT,     "prefetch_next"},
+    {MatMulScheduleGenerator::Strategy::BLOCKED_AB,        "blocked_ab"},
+};
+
+struct SizeCase {
+    size_t n;        // M = N = K (16^3 tiles -> n/16 tile grid per dim)
+    Cycle ceiling;   // generous total-cycle bound; cycle counts vary across
+                     // platforms (work assignment hashes with std::hash)
+};
+
+constexpr SizeCase kSizes[] = {
+    {32,  10'000},    // 2x2x2 tile grid   (measured ~334 on linux/gcc)
+    {64,  30'000},    // 4x4x4 tile grid   (measured ~1132)
+    {128, 150'000},   // 8x8x8 tile grid   (measured ~8034)
+};
+
+} // namespace
+
+// ============================================================================
+// Strategy x size execution matrix
+// ============================================================================
+
+TEST_CASE("Multi-tile schedules execute to completion across strategies and sizes",
+          "[timing][executor][regression]") {
+    for (const auto& strat : kStrategies) {
+        for (const auto& size : kSizes) {
+            DYNAMIC_SECTION(strat.name << " " << size.n << "^3") {
+                auto gen_config = make_generator_config(size.n, strat.strategy);
+                MatMulScheduleGenerator generator(gen_config);
+                auto schedule = generator.generate();
+                REQUIRE(schedule.valid);
+
+                ConcurrentTimingExecutor executor(make_executor_config());
+                ScheduleExecutor sched_exec(executor);
+                auto result = sched_exec.execute(schedule);
+
+                INFO("strategy=" << strat.name << " n=" << size.n
+                     << " cycles=" << result.total_cycles
+                     << " error=" << result.error_message);
+
+                // The #61 regression surface: completion without livelock
+                REQUIRE(result.success);
+                REQUIRE_FALSE(result.livelock_detected);
+                REQUIRE(result.total_cycles > 0);
+                REQUIRE(result.total_cycles < size.ceiling);
+
+                // Every scheduled pipeline stage completed exactly once
+                // (dedup completions count as completions)
+                auto stats = executor.get_statistics();
+                REQUIRE(stats.tiles_moved ==
+                        schedule.count_ops(ScheduleOpType::MOVE));
+                REQUIRE(stats.tiles_writeback ==
+                        schedule.count_ops(ScheduleOpType::WRITEBACK));
+                REQUIRE(stats.tiles_fed ==
+                        schedule.count_ops(ScheduleOpType::FEED));
+                REQUIRE(stats.tiles_drained ==
+                        schedule.count_ops(ScheduleOpType::DRAIN));
+
+                // Stall accounting invariant: each component counts at most
+                // one stall cycle per tick, so aggregate stalls are bounded
+                // by component count x total cycles. Catches per-request
+                // over-counting regressions.
+                const auto& config = executor.config();
+                REQUIRE(stats.dma_credit_stalls <=
+                        config.num_dma_engines * stats.total_cycles);
+                REQUIRE(stats.bm_tag_stalls + stats.bm_credit_stalls <=
+                        config.num_block_movers * stats.total_cycles);
+                size_t n_streamers =
+                    config.num_row_streamers + config.num_col_streamers;
+                REQUIRE(stats.str_tag_stalls + stats.str_credit_stalls <=
+                        n_streamers * stats.total_cycles);
+            }
+        }
+    }
+}
+
+// ============================================================================
+// COMPUTE dependency coverage (issue #63)
+// ============================================================================
+
+TEST_CASE("COMPUTE operations carry the full K-slice dependency set",
+          "[timing][schedule][regression]") {
+    // 64^3 at 16^3 tiles: k_tiles = 4, so every COMPUTE must depend on
+    // 4 A tiles + 4 B tiles
+    auto gen_config = make_generator_config(
+        64, MatMulScheduleGenerator::Strategy::INTERLEAVED_AB);
+    MatMulScheduleGenerator generator(gen_config);
+    auto schedule = generator.generate();
+    REQUIRE(schedule.valid);
+
+    size_t compute_count = 0;
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::COMPUTE) continue;
+        compute_count++;
+
+        REQUIRE(op.dependency_tiles.size() == 8);
+
+        size_t a_deps = 0;
+        size_t b_deps = 0;
+        for (const auto& dep : op.dependency_tiles) {
+            if (dep.matrix == MatrixID::A) {
+                a_deps++;
+                REQUIRE(dep.ti == op.tile.tile_id.ti);
+            } else if (dep.matrix == MatrixID::B) {
+                b_deps++;
+                REQUIRE(dep.tj == op.tile.tile_id.tj);
+            }
+        }
+        REQUIRE(a_deps == 4);
+        REQUIRE(b_deps == 4);
+
+        // Legacy single-dependency field mirrors the last entry
+        REQUIRE(op.dependency_tile == op.dependency_tiles.back());
+    }
+    REQUIRE(compute_count == 16);  // 4x4 C tiles
+}
+
+// ============================================================================
+// K-scaled compute latency (issue #63)
+// ============================================================================
+
+TEST_CASE("Compute latency scales with the K-slice count",
+          "[timing][executor][regression]") {
+    // 32^3 at 16^3 tiles: k_tiles = 2, so compute latency must be
+    // compute_latency + (2 - 1) * compute_cycles_per_k_slice
+    auto exec_config = make_executor_config();
+    ConcurrentTimingExecutor executor(exec_config);
+
+    auto gen_config = make_generator_config(
+        32, MatMulScheduleGenerator::Strategy::INTERLEAVED_AB);
+    MatMulScheduleGenerator generator(gen_config);
+    auto schedule = generator.generate();
+    REQUIRE(schedule.valid);
+
+    ScheduleExecutor sched_exec(executor);
+    auto result = sched_exec.execute(schedule);
+    REQUIRE(result.success);
+
+    Cycle expected_latency =
+        exec_config.compute_latency + exec_config.compute_cycles_per_k_slice;
+
+    size_t complete_events = 0;
+    for (const auto& event : executor.events()) {
+        if (event.type == EventType::COMPUTE_COMPLETE) {
+            complete_events++;
+            REQUIRE(event.duration == expected_latency);
+        }
+    }
+    REQUIRE(complete_events == 4);  // 2x2 C tiles
+}

--- a/tests/timing/test_schedule_generators.cpp
+++ b/tests/timing/test_schedule_generators.cpp
@@ -308,14 +308,17 @@ TEST_CASE("MatMulScheduleGenerator prefetch_next", "[timing][schedule][matmul]")
     REQUIRE(result.valid);
     REQUIRE(result.metadata.strategy == "prefetch_next");
 
-    // Prefetch strategy has more loads due to prefetching
+    // Prefetch shifts loads one iteration earlier but must NOT duplicate
+    // them: every LOAD pairs 1:1 with a MOVE (each load inserts an L3
+    // TagCAM reference, each move consumes one; duplicate loads strand
+    // references and L3 credits -> livelock at scale, see #61/#64)
     Size expected_k_tiles = 4;  // 64/16
     Size expected_c_tiles = 4;  // 2x2
 
-    // Each C tile has k_tiles iterations, and each loads A+B
-    // Plus prefetch loads for all but the last iteration
     size_t load_ops = result.count_ops(ScheduleOpType::LOAD);
-    REQUIRE(load_ops > expected_k_tiles * 2 * expected_c_tiles);  // More due to prefetch
+    size_t move_ops = result.count_ops(ScheduleOpType::MOVE);
+    REQUIRE(load_ops == expected_k_tiles * 2 * expected_c_tiles);
+    REQUIRE(load_ops == move_ops);
 }
 
 TEST_CASE("MatMulScheduleGenerator address calculation", "[timing][schedule][matmul]") {


### PR DESCRIPTION
Fixes #63. Fixes #64. Completes the remaining Phase 0 items from `docs/architecture/simulator-assessment-and-plan.md`.

## COMPUTE dependencies (#63)

The matmul generators keyed COMPUTE for C(ti,tj) to only the **last B feed**, so a compute could start before its A tiles or earlier K slices were fed, and its latency was a constant regardless of accumulation depth.

- `ScheduleOperation` gains a `dependency_tiles` list; all four strategies emit the full set — every A(ti,\*,k) and B(\*,tj,k). The legacy single-dependency field and executor overload remain, so existing call sites are source- and timing-compatible.
- The executor starts compute only when **all** dependencies have been fed; latency = `compute_latency + (k_slices−1) × compute_cycles_per_k_slice` (new config knob, default 32). Single-dependency computes get k_slices = 1 → identical timing to before.
- `is_complete()` now accounts for pending computes (previously a schedule ending in COMPUTE without DRAIN could "complete" with computes outstanding).
- Documented remaining approximation: fed-tile tracking is a monotonic was-ever-fed set; per-instance feed accounting arrives with real data movement (Phase 1).

## Execution regression suite (#64)

`tests/timing/test_multi_tile_execution.cpp` — the coverage the #61 livelock proved was missing (no test *executed* a generated multi-tile schedule):

- All four strategies × 32³/64³/128³ (16³ tiles), asserting: completion, no livelock, generous cross-platform cycle ceilings, **exact per-stage tile accounting** (moves/writebacks/feeds/drains == schedule op counts), and the per-tick stall-accounting bounds.
- Plus direct checks that COMPUTE ops carry the full 2×k_tiles dependency set and that COMPUTE_COMPLETE duration equals the K-scaled latency.

## Bonus: the suite caught a real bug on its first run

**PREFETCH_NEXT livelocked at 128³** — the one strategy `run_matmul`'s CLI never exposed, so the #61 verification matrix missed it. Its generator emitted each tile's load twice per output iteration (prefetch + current) with only one MOVE, stranding L3 TagCAM references and credits (same leak class as #61). Loads are now emitted once (k=0 directly, k≥1 via the previous iteration's prefetch), restoring the 1:1 LOAD:MOVE pairing; the generator test now asserts `load_ops == move_ops` instead of treating duplication as a feature.

## Verification

- Full suite: **98/98 pass** (new suite: 345 assertions)
- `run_matmul` SUCCESS 32³–256³; 32³ shifts 302→334 cycles (K-scaled compute visible where compute is on the critical path; larger sizes remain transfer-bound, unchanged)
- Session log: `docs/sessions/2026-07-10_v0.9_phase0_compute_deps_regression.md` (wrong-decision documentation included: verifying #61 against a demo's CLI surface instead of the strategy enum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a multi-tile livelock for larger workloads using the `PREFETCH_NEXT` strategy.
  * Updated compute scheduling to require all required K-slice inputs before starting.
  * Adjusted compute timing to scale with K-slice count for more accurate execution durations.
* **Tests**
  * Added a multi-tile execution regression suite covering strategy/size combinations.
  * Added checks for full compute dependency coverage, compute completion timing, and strict LOAD/MOVE consistency.
* **Documentation**
  * Updated release documentation to reflect the compute dependency and multi-tile execution improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->