### PR TITLE
feat: unify functional MLP with CSP timing

### DIFF
--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -145,6 +145,11 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
+        # Fork PRs run with a read-only token (the permissions block cannot
+        # raise it), so posting the comment fails with "Resource not
+        # accessible by integration". The report is still in the step log and
+        # benchmark_report.md; never fail the benchmark gate over the comment.
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/docs/02-simulation/functional-csp-mlp.md
+++ b/docs/02-simulation/functional-csp-mlp.md
@@ -1,0 +1,61 @@
+# Functional CSP MLP vertical slice
+
+The concurrent CSP timing executor can execute value-producing MLP layers while
+preserving its existing credit, TagCAM, queue, dependency, and backpressure
+semantics.
+
+## What is unified
+
+`FunctionalMLPExecutor` executes each dense layer through:
+
+```text
+DMA load -> L3 -> BlockMover -> L2 -> Streamer -> Compute
+         -> Drain -> L2 -> Writeback -> L3 -> DMA store
+```
+
+Numeric tile payloads are owned by `ConcurrentTimingExecutor`. A functional
+matmul consumes payloads only after every required feed occurrence completes.
+The result becomes visible at the modeled compute-completion cycle, immediately
+before the result tag is published for `DRAIN`.
+
+Feed dependencies use occurrence counts rather than an "ever seen" bit. Reusing
+the same tile in a later operation therefore cannot start a later compute from
+an earlier feed.
+
+## Run the proof
+
+```bash
+cmake --build build --target unified_xor_mlp
+./build/examples/schedule/unified_xor_mlp
+```
+
+Expected completion markers:
+
+```text
+Numerical result: PASS
+Transaction-ordered execution: PASS
+```
+
+The example deliberately configures one L3 buffer and one L2 bank. It must
+produce the correct XOR outputs while reporting non-zero credit/tag stall
+cycles.
+
+## Scope boundary
+
+This is the first honest functional/transactional vertical slice, not the final
+general simulator:
+
+- Dense FP32 matmul, optional bias, and ReLU are supported.
+- Each MLP layer currently uses one logical A, B, and C tile; the matmul compute
+  primitive itself accepts multiple K tiles.
+- Payloads use a functional backing store. Transfers control when values become
+  consumable but do not yet copy bytes through separate physical L3/L2/L1
+  storage arrays.
+- Conv, attention, reductions, mixed precision, and arbitrary Domain Flow
+  programs still need functional compute implementations.
+- `FunctionalMLPExecutor` creates a fresh CSP executor per layer. Cross-layer
+  fusion and persistent on-chip activation residency remain future work.
+
+The next extension should lower generated tiled matmul schedules into the same
+functional compute specification, then validate multi-K accumulation and
+multi-output-tile execution against the behavioral oracle.

--- a/docs/02-simulation/functional-csp-mlp.md
+++ b/docs/02-simulation/functional-csp-mlp.md
@@ -6,14 +6,19 @@ semantics.
 
 ## What is unified
 
-`FunctionalMLPExecutor` executes each dense layer through:
+`FunctionalMLPExecutor` executes inputs and weights through:
 
 ```text
 DMA load -> L3 -> BlockMover -> L2 -> Streamer -> Compute
-         -> Drain -> L2 -> Writeback -> L3 -> DMA store
+                                             |
+                              next layer Compute (resident)
+                                             |
+                         final Drain -> L2 -> L3 -> DMA store
 ```
 
-Numeric tile payloads are owned by `ConcurrentTimingExecutor`. A functional
+DRAM, L3, L2, L1, and compute each own distinct serialized byte arrays. Bytes
+are copied only in response to the corresponding CSP completion event and are
+retired when the final TagCAM/credit reference disappears. A functional
 matmul consumes payloads only after every required feed occurrence completes.
 The result becomes visible at the modeled compute-completion cycle, immediately
 before the result tag is published for `DRAIN`.
@@ -40,22 +45,26 @@ The example deliberately configures one L3 buffer and one L2 bank. It must
 produce the correct XOR outputs while reporting non-zero credit/tag stall
 cycles.
 
-## Scope boundary
+## General Domain Flow execution
 
-This is the first honest functional/transactional vertical slice, not the final
-general simulator:
+`FunctionalDomainFlowProgram` represents an arbitrary dependency DAG. Its
+event-driven runner dispatches all ready branches concurrently and completes a
+node only when the matching DMA, BlockMover, Streamer, compute, or store event
+occurs. Nodes can use tiled matmul or a user-supplied functional tile operation,
+which covers elementwise operations, activations, reductions, and new kernels
+without adding another disconnected simulator.
+
+## Current kernel coverage
 
 - Dense FP32 matmul, optional bias, and ReLU are supported.
 - Each MLP layer currently uses one logical A, B, and C tile; the matmul compute
   primitive itself accepts multiple K tiles.
-- Payloads use a functional backing store. Transfers control when values become
-  consumable but do not yet copy bytes through separate physical L3/L2/L1
-  storage arrays.
-- Conv, attention, reductions, mixed precision, and arbitrary Domain Flow
-  programs still need functional compute implementations.
-- `FunctionalMLPExecutor` creates a fresh CSP executor per layer. Cross-layer
-  fusion and persistent on-chip activation residency remain future work.
+- Generic compute callbacks allow arbitrary tile transformations under the same
+  transactional ordering, while optimized built-in implementations for conv,
+  attention, mixed precision, and other kernels remain future library work.
+- Intermediate MLP activations remain in compute storage across layers; only
+  the final activation takes the drain/writeback/store path.
 
-The next extension should lower generated tiled matmul schedules into the same
-functional compute specification, then validate multi-K accumulation and
-multi-output-tile execution against the behavioral oracle.
+The next extension should lower the compiler's existing `TileDataFlowGraph`
+nodes into `FunctionalDomainFlowProgram` and add optimized operator-library
+implementations, without changing the simulator's memory or ordering model.

--- a/examples/schedule/CMakeLists.txt
+++ b/examples/schedule/CMakeLists.txt
@@ -20,6 +20,19 @@ set_target_properties(run_matmul PROPERTIES
     FOLDER "Examples/Schedule"
 )
 
+# Unified functional + CSP timing MLP vertical slice
+add_executable(unified_xor_mlp unified_xor_mlp.cpp)
+target_link_libraries(unified_xor_mlp PRIVATE kpu_simulator)
+set_target_properties(unified_xor_mlp PROPERTIES
+    FOLDER "Examples/Schedule"
+)
+if(KPU_BUILD_TESTS)
+    add_test(NAME unified_xor_mlp COMMAND unified_xor_mlp)
+    set_tests_properties(unified_xor_mlp PROPERTIES
+        LABELS "behavioral;transactional;timing;mlp;v0.9"
+    )
+endif()
+
 # CSP Pipeline Educational Demo - shows credit/debit flow and TagCAM operations
 add_executable(csp_pipeline_demo csp_pipeline_demo.cpp)
 target_link_libraries(csp_pipeline_demo PRIVATE kpu_simulator)

--- a/examples/schedule/unified_xor_mlp.cpp
+++ b/examples/schedule/unified_xor_mlp.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file unified_xor_mlp.cpp
+ * @brief Value-producing XOR MLP on the CSP concurrent timing executor.
+ */
+
+#include <sw/kpu/timing/functional_mlp_executor.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using sw::kpu::timing::ConcurrentTimingExecutor;
+using sw::kpu::timing::FunctionalMLPExecutor;
+
+int main() {
+    ConcurrentTimingExecutor::Config config;
+    config.num_memory_controllers = 1;
+    config.num_dma_engines = 1;
+    config.num_block_movers = 1;
+    config.num_row_streamers = 1;
+    config.num_col_streamers = 1;
+    config.l3_buffer_count = 1;
+    config.l2_bank_count = 1;
+    config.compute_latency = 8;
+    config.max_cycles = 100000;
+    config.enable_livelock_detection = false;
+
+    FunctionalMLPExecutor mlp(config);
+    mlp.add_layer(2, 4,
+        {1.0f, 1.0f, -1.0f, -1.0f,
+         1.0f, 1.0f, -1.0f, -1.0f},
+        {-0.5f, -1.5f, 0.5f, 1.5f},
+        ConcurrentTimingExecutor::FunctionalActivation::RELU,
+        "hidden");
+    mlp.add_layer(4, 1,
+        {2.0f, -6.0f, 0.0f, 0.0f}, {0.0f},
+        ConcurrentTimingExecutor::FunctionalActivation::NONE,
+        "output");
+
+    const std::vector<float> input = {
+        0.0f, 0.0f,
+        0.0f, 1.0f,
+        1.0f, 0.0f,
+        1.0f, 1.0f
+    };
+    const std::vector<float> expected = {0.0f, 1.0f, 1.0f, 0.0f};
+    const auto output = mlp.forward(input, 4);
+
+    bool values_pass = output.size() == expected.size();
+    for (size_t i = 0; i < output.size() && i < expected.size(); ++i) {
+        values_pass = values_pass && std::fabs(output[i] - expected[i]) < 1e-6f;
+        std::cout << "XOR case " << i << ": " << output[i]
+                  << " (expected " << expected[i] << ")\n";
+    }
+
+    const auto& stats = mlp.statistics();
+    const bool ordered_pass = stats.layers_completed == 2 &&
+                              stats.total_cycles > 0 &&
+                              stats.total_stall_cycles > 0;
+    std::cout << "cycles: " << stats.total_cycles << '\n';
+    std::cout << "credit/tag stall cycles: " << stats.total_stall_cycles << '\n';
+    std::cout << "Numerical result: " << (values_pass ? "PASS" : "FAIL") << '\n';
+    std::cout << "Transaction-ordered execution: "
+              << (ordered_pass ? "PASS" : "FAIL") << '\n';
+    return values_pass && ordered_pass ? 0 : 1;
+}

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -18,7 +18,9 @@
 #include <sw/kpu/timing/livelock_detector.hpp>
 
 #include <algorithm>
+#include <cstring>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -53,8 +55,16 @@ public:
     struct MatMulComputeSpec {
         std::vector<TileID> a_tiles;
         std::vector<TileID> b_tiles;
+        // Inputs produced by an earlier compute may remain in the compute
+        // fabric and feed this operation without a drain/reload round trip.
+        std::vector<TileID> resident_tiles;
         std::vector<float> bias;
         FunctionalActivation activation = FunctionalActivation::NONE;
+    };
+    struct FunctionalComputeSpec {
+        std::vector<TileID> input_tiles;
+        std::vector<TileID> resident_tiles;
+        std::function<TilePayload(const std::vector<TilePayload>&)> operation;
     };
     /**
      * @brief Executor configuration
@@ -275,6 +285,8 @@ public:
      */
     void schedule_matmul_compute(const TileDescriptor& tile,
                                  const MatMulComputeSpec& spec);
+    void schedule_functional_compute(const TileDescriptor& tile,
+                                     const FunctionalComputeSpec& spec);
 
     // ========================================================================
     // Functional Payload API
@@ -284,22 +296,41 @@ public:
         if (!payload.valid()) {
             throw std::invalid_argument("Tile payload dimensions do not match value count");
         }
-        tile_payloads_[tile_id] = std::move(payload);
+        functional_payloads_enabled_ = true;
+        write_payload(MemoryLevel::DRAM, tile_id, std::move(payload));
     }
 
     [[nodiscard]] bool has_tile_payload(const TileID& tile_id) const {
-        return tile_payloads_.find(tile_id) != tile_payloads_.end();
+        return find_payload(tile_id) != nullptr;
     }
 
     [[nodiscard]] const TilePayload& tile_payload(const TileID& tile_id) const {
-        auto it = tile_payloads_.find(tile_id);
-        if (it == tile_payloads_.end()) {
+        const auto* payload = find_payload(tile_id);
+        if (payload == nullptr) {
             throw std::out_of_range("No numeric payload for " + tile_id.to_string());
         }
-        return it->second;
+        return *payload;
     }
 
-    void clear_tile_payloads() { tile_payloads_.clear(); }
+    [[nodiscard]] bool has_tile_payload_at(MemoryLevel level, const TileID& tile_id) const {
+        return payload_store(level).find(tile_id) != payload_store(level).end();
+    }
+
+    [[nodiscard]] const TilePayload& tile_payload_at(MemoryLevel level,
+                                                      const TileID& tile_id) const {
+        const auto& store = payload_store(level);
+        auto it = store.find(tile_id);
+        if (it == store.end()) {
+            throw std::out_of_range(std::string("No payload at ") + to_string(level) +
+                                    " for " + tile_id.to_string());
+        }
+        return it->second.payload;
+    }
+
+    void clear_tile_payloads() {
+        dram_payloads_.clear(); l3_payloads_.clear(); l2_payloads_.clear();
+        l1_payloads_.clear(); compute_payloads_.clear();
+    }
 
     // ========================================================================
     // Simulation Control
@@ -401,7 +432,9 @@ private:
     struct PendingCompute {
         TileDescriptor tile;         ///< Result tile (C)
         std::vector<std::pair<TileID, size_t>> dependencies;
+        std::vector<std::pair<TileID, size_t>> resident_dependencies;
         std::unique_ptr<MatMulComputeSpec> matmul;
+        std::unique_ptr<FunctionalComputeSpec> functional;
         Cycle schedule_cycle;        ///< When scheduled
         Cycle complete_cycle;        ///< When computation will complete (set when started)
         bool started;                ///< Has computation started?
@@ -412,10 +445,18 @@ private:
     // a boolean "ever fed" flag lets a reused tile start a later compute early.
     std::unordered_map<TileID, size_t, TileIDHash> scheduled_feed_counts_;
     std::unordered_map<TileID, size_t, TileIDHash> completed_feed_counts_;
+    std::unordered_map<TileID, size_t, TileIDHash> scheduled_compute_counts_;
+    std::unordered_map<TileID, size_t, TileIDHash> completed_compute_counts_;
 
-    // Numeric values are orthogonal to location/credit metadata but advance
-    // through the same dependency and completion points.
-    std::unordered_map<TileID, TilePayload, TileIDHash> tile_payloads_;
+    struct StoredPayload {
+        TilePayload payload;
+        std::vector<std::byte> bytes;
+        uint32_t slot_id = 0;
+        Cycle arrival_cycle = 0;
+    };
+    using PayloadStore = std::unordered_map<TileID, StoredPayload, TileIDHash>;
+    PayloadStore dram_payloads_, l3_payloads_, l2_payloads_, l1_payloads_, compute_payloads_;
+    bool functional_payloads_enabled_ = false;
 
     // Component processes
     std::vector<std::unique_ptr<MemoryControllerProcess>> memory_controllers_;
@@ -470,6 +511,15 @@ private:
 
     [[nodiscard]] bool dependencies_satisfied(const PendingCompute& pc) const;
     void execute_matmul(const PendingCompute& pc);
+    void execute_functional(const PendingCompute& pc);
+    void apply_payload_event(const TimingEvent& event);
+    void write_payload(MemoryLevel level, const TileID& id, TilePayload payload,
+                       uint32_t slot_id = 0);
+    void copy_payload(MemoryLevel source, MemoryLevel destination, const TileID& id,
+                      uint32_t slot_id);
+    [[nodiscard]] const TilePayload* find_payload(const TileID& id) const;
+    [[nodiscard]] PayloadStore& payload_store(MemoryLevel level);
+    [[nodiscard]] const PayloadStore& payload_store(MemoryLevel level) const;
 };
 
 // ============================================================================
@@ -683,18 +733,63 @@ inline void ConcurrentTimingExecutor::schedule_matmul_compute(
     pc.started = false;
     pc.matmul = std::make_unique<MatMulComputeSpec>(spec);
 
+    auto is_resident = [&spec](const TileID& id) {
+        return std::find(spec.resident_tiles.begin(), spec.resident_tiles.end(), id) !=
+               spec.resident_tiles.end();
+    };
+
     for (const auto& id : spec.a_tiles) {
+        if (is_resident(id)) {
+            const size_t required = std::max<size_t>(1, scheduled_compute_counts_[id]);
+            pc.resident_dependencies.push_back({id, required});
+            continue;
+        }
         if (scheduled_feed_counts_[id] == 0) {
             throw std::invalid_argument("Matmul A tile has no scheduled feed: " + id.to_string());
         }
         pc.dependencies.push_back({id, scheduled_feed_counts_[id]});
     }
     for (const auto& id : spec.b_tiles) {
+        if (is_resident(id)) {
+            const size_t required = std::max<size_t>(1, scheduled_compute_counts_[id]);
+            pc.resident_dependencies.push_back({id, required});
+            continue;
+        }
         if (scheduled_feed_counts_[id] == 0) {
             throw std::invalid_argument("Matmul B tile has no scheduled feed: " + id.to_string());
         }
         pc.dependencies.push_back({id, scheduled_feed_counts_[id]});
     }
+    ++scheduled_compute_counts_[tile.tile_id];
+    pending_computes_.push_back(std::move(pc));
+}
+
+inline void ConcurrentTimingExecutor::schedule_functional_compute(
+    const TileDescriptor& tile, const FunctionalComputeSpec& spec) {
+    if (spec.input_tiles.empty() || !spec.operation) {
+        throw std::invalid_argument("Functional compute requires inputs and an operation");
+    }
+    PendingCompute pc;
+    pc.tile = tile;
+    pc.schedule_cycle = current_cycle_;
+    pc.complete_cycle = 0;
+    pc.started = false;
+    pc.functional = std::make_unique<FunctionalComputeSpec>(spec);
+    for (const auto& id : spec.input_tiles) {
+        const bool resident = std::find(spec.resident_tiles.begin(), spec.resident_tiles.end(), id) !=
+                              spec.resident_tiles.end();
+        if (resident) {
+            pc.resident_dependencies.push_back(
+                {id, std::max<size_t>(1, scheduled_compute_counts_[id])});
+        } else {
+            if (scheduled_feed_counts_[id] == 0) {
+                throw std::invalid_argument("Functional input has no scheduled feed: " +
+                                            id.to_string());
+            }
+            pc.dependencies.push_back({id, scheduled_feed_counts_[id]});
+        }
+    }
+    ++scheduled_compute_counts_[tile.tile_id];
     pending_computes_.push_back(std::move(pc));
 }
 
@@ -764,7 +859,10 @@ inline bool ConcurrentTimingExecutor::step() {
         if (it->started && current_cycle_ >= it->complete_cycle) {
             if (it->matmul) {
                 execute_matmul(*it);
+            } else if (it->functional) {
+                execute_functional(*it);
             }
+            ++completed_compute_counts_[it->tile.tile_id];
             // Compute completed - result tile is now ready for DRAIN
             uint32_t slot = next_compute_slot_++;
             compute_result_tag_cam_.insert(it->tile.tile_id, slot, current_cycle_);
@@ -791,18 +889,21 @@ inline bool ConcurrentTimingExecutor::step() {
     // 1. Tick Memory Controllers FIRST (process DRAM commands, generate completions)
     for (auto& mc : memory_controllers_) {
         auto mc_events = mc->tick(current_cycle_);
+        for (const auto& event : mc_events) apply_payload_event(event);
         events_.insert(events_.end(), mc_events.begin(), mc_events.end());
     }
 
     // 2. Tick DMA Engines (poll MC completions, submit new requests)
     for (auto& dma : dma_engines_) {
         auto dma_events = dma->tick(current_cycle_);
+        for (const auto& event : dma_events) apply_payload_event(event);
         events_.insert(events_.end(), dma_events.begin(), dma_events.end());
     }
 
     // 3. Tick BlockMovers
     for (auto& mover : block_movers_) {
         auto mover_events = mover->tick(current_cycle_);
+        for (const auto& event : mover_events) apply_payload_event(event);
         events_.insert(events_.end(), mover_events.begin(), mover_events.end());
     }
 
@@ -811,6 +912,7 @@ inline bool ConcurrentTimingExecutor::step() {
         auto str_events = streamer->tick(current_cycle_);
         // Track tiles that have been fed to compute
         for (const auto& event : str_events) {
+            apply_payload_event(event);
             if (event.type == EventType::TILE_FED_TO_COMPUTE) {
                 ++completed_feed_counts_[event.tile_id];
             }
@@ -823,6 +925,7 @@ inline bool ConcurrentTimingExecutor::step() {
         auto str_events = streamer->tick(current_cycle_);
         // Track tiles that have been fed to compute
         for (const auto& event : str_events) {
+            apply_payload_event(event);
             if (event.type == EventType::TILE_FED_TO_COMPUTE) {
                 ++completed_feed_counts_[event.tile_id];
             }
@@ -879,6 +982,8 @@ inline void ConcurrentTimingExecutor::reset() {
     pending_computes_.clear();
     scheduled_feed_counts_.clear();
     completed_feed_counts_.clear();
+    scheduled_compute_counts_.clear();
+    completed_compute_counts_.clear();
 
     for (auto& mc : memory_controllers_) {
         mc->reset();
@@ -907,6 +1012,11 @@ inline bool ConcurrentTimingExecutor::dependencies_satisfied(const PendingComput
     for (const auto& [tile_id, required_count] : pc.dependencies) {
         auto it = completed_feed_counts_.find(tile_id);
         size_t completed = it == completed_feed_counts_.end() ? 0 : it->second;
+        if (completed < required_count) return false;
+    }
+    for (const auto& [tile_id, required_count] : pc.resident_dependencies) {
+        auto it = completed_compute_counts_.find(tile_id);
+        const size_t completed = it == completed_compute_counts_.end() ? 0 : it->second;
         if (completed < required_count) return false;
     }
     return true;
@@ -952,7 +1062,106 @@ inline void ConcurrentTimingExecutor::execute_matmul(const PendingCompute& pc) {
             if (spec.activation == FunctionalActivation::RELU && value < 0.0f) value = 0.0f;
         }
     }
-    tile_payloads_[pc.tile.tile_id] = std::move(output);
+    write_payload(MemoryLevel::COMPUTE, pc.tile.tile_id, std::move(output),
+                  next_compute_slot_);
+}
+
+inline void ConcurrentTimingExecutor::execute_functional(const PendingCompute& pc) {
+    std::vector<TilePayload> inputs;
+    inputs.reserve(pc.functional->input_tiles.size());
+    for (const auto& id : pc.functional->input_tiles) inputs.push_back(tile_payload(id));
+    TilePayload output = pc.functional->operation(inputs);
+    if (!output.valid()) throw std::runtime_error("Functional operation returned invalid payload");
+    write_payload(MemoryLevel::COMPUTE, pc.tile.tile_id, std::move(output), next_compute_slot_);
+}
+
+inline ConcurrentTimingExecutor::PayloadStore&
+ConcurrentTimingExecutor::payload_store(MemoryLevel level) {
+    switch (level) {
+        case MemoryLevel::DRAM: return dram_payloads_;
+        case MemoryLevel::L3: return l3_payloads_;
+        case MemoryLevel::L2: return l2_payloads_;
+        case MemoryLevel::L1: return l1_payloads_;
+        case MemoryLevel::COMPUTE: return compute_payloads_;
+    }
+    throw std::invalid_argument("Unknown memory level");
+}
+
+inline const ConcurrentTimingExecutor::PayloadStore&
+ConcurrentTimingExecutor::payload_store(MemoryLevel level) const {
+    return const_cast<ConcurrentTimingExecutor*>(this)->payload_store(level);
+}
+
+inline void ConcurrentTimingExecutor::write_payload(MemoryLevel level, const TileID& id,
+                                                     TilePayload payload, uint32_t slot_id) {
+    if (!payload.valid()) throw std::invalid_argument("Invalid tile payload");
+    StoredPayload stored;
+    stored.bytes.resize(payload.values.size() * sizeof(float));
+    std::memcpy(stored.bytes.data(), payload.values.data(), stored.bytes.size());
+    stored.payload = std::move(payload);
+    stored.slot_id = slot_id;
+    stored.arrival_cycle = current_cycle_;
+    payload_store(level)[id] = std::move(stored);
+}
+
+inline void ConcurrentTimingExecutor::copy_payload(MemoryLevel source, MemoryLevel destination,
+                                                    const TileID& id, uint32_t slot_id) {
+    const auto& sources = payload_store(source);
+    auto it = sources.find(id);
+    if (it == sources.end()) {
+        if (!functional_payloads_enabled_) return;
+        throw std::runtime_error(std::string("Payload transfer completed without source bytes at ") +
+                                 to_string(source) + " for " + id.to_string());
+    }
+    StoredPayload copy = it->second;
+    copy.slot_id = slot_id;
+    copy.arrival_cycle = current_cycle_;
+    payload_store(destination)[id] = std::move(copy);
+}
+
+inline const TilePayload* ConcurrentTimingExecutor::find_payload(const TileID& id) const {
+    for (MemoryLevel level : {MemoryLevel::COMPUTE, MemoryLevel::L1, MemoryLevel::L2,
+                              MemoryLevel::L3, MemoryLevel::DRAM}) {
+        const auto& store = payload_store(level);
+        auto it = store.find(id);
+        if (it != store.end()) return &it->second.payload;
+    }
+    return nullptr;
+}
+
+inline void ConcurrentTimingExecutor::apply_payload_event(const TimingEvent& event) {
+    switch (event.type) {
+        case EventType::TILE_ARRIVED_L3:
+            if (event.component_name.find("DMA") != std::string::npos) {
+                copy_payload(MemoryLevel::DRAM, MemoryLevel::L3, event.tile_id, event.slot_id);
+            }
+            break;
+        case EventType::BM_MOVE_COMPLETE:
+            copy_payload(MemoryLevel::L3, MemoryLevel::L2, event.tile_id, event.slot_id);
+            break;
+        case EventType::TILE_FED_TO_COMPUTE:
+            copy_payload(MemoryLevel::L2, MemoryLevel::L1, event.tile_id, event.component_id);
+            copy_payload(MemoryLevel::L1, MemoryLevel::COMPUTE, event.tile_id, event.component_id);
+            break;
+        case EventType::TILE_DRAINED:
+            copy_payload(MemoryLevel::COMPUTE, MemoryLevel::L1, event.tile_id, event.component_id);
+            copy_payload(MemoryLevel::L1, MemoryLevel::L2, event.tile_id, event.slot_id);
+            break;
+        case EventType::BM_WRITEBACK_COMPLETE:
+            copy_payload(MemoryLevel::L2, MemoryLevel::L3, event.tile_id, event.slot_id);
+            break;
+        case EventType::DMA_STORE_COMPLETE:
+            copy_payload(MemoryLevel::L3, MemoryLevel::DRAM, event.tile_id, event.slot_id);
+            break;
+        case EventType::CREDIT_RELEASED:
+            // Component processes update TagCAM ref-counts before emitting the
+            // event. Retire bytes only when the final reference disappeared.
+            if (!l3_tag_cam_.lookup(event.tile_id)) l3_payloads_.erase(event.tile_id);
+            if (!l2_tag_cam_.lookup(event.tile_id)) l2_payloads_.erase(event.tile_id);
+            break;
+        default:
+            break;
+    }
 }
 
 inline ConcurrentTimingExecutor::Statistics ConcurrentTimingExecutor::get_statistics() const {

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -17,10 +17,12 @@
 #include <sw/kpu/timing/streamer_process.hpp>
 #include <sw/kpu/timing/livelock_detector.hpp>
 
+#include <algorithm>
 #include <fstream>
 #include <memory>
-#include <set>
+#include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace sw::kpu::timing {
@@ -43,6 +45,17 @@ namespace sw::kpu::timing {
  */
 class ConcurrentTimingExecutor {
 public:
+    enum class FunctionalActivation {
+        NONE,
+        RELU
+    };
+
+    struct MatMulComputeSpec {
+        std::vector<TileID> a_tiles;
+        std::vector<TileID> b_tiles;
+        std::vector<float> bias;
+        FunctionalActivation activation = FunctionalActivation::NONE;
+    };
     /**
      * @brief Executor configuration
      */
@@ -253,6 +266,41 @@ public:
      */
     void schedule_compute(const TileDescriptor& tile);
 
+    /**
+     * @brief Schedule a value-producing tiled matmul under CSP ordering.
+     *
+     * Every listed A/B tile must complete the feed occurrence that precedes
+     * this call. The numeric result is produced at compute completion and is
+     * then made visible to DRAIN through the normal compute-result TagCAM.
+     */
+    void schedule_matmul_compute(const TileDescriptor& tile,
+                                 const MatMulComputeSpec& spec);
+
+    // ========================================================================
+    // Functional Payload API
+    // ========================================================================
+
+    void set_tile_payload(const TileID& tile_id, TilePayload payload) {
+        if (!payload.valid()) {
+            throw std::invalid_argument("Tile payload dimensions do not match value count");
+        }
+        tile_payloads_[tile_id] = std::move(payload);
+    }
+
+    [[nodiscard]] bool has_tile_payload(const TileID& tile_id) const {
+        return tile_payloads_.find(tile_id) != tile_payloads_.end();
+    }
+
+    [[nodiscard]] const TilePayload& tile_payload(const TileID& tile_id) const {
+        auto it = tile_payloads_.find(tile_id);
+        if (it == tile_payloads_.end()) {
+            throw std::out_of_range("No numeric payload for " + tile_id.to_string());
+        }
+        return it->second;
+    }
+
+    void clear_tile_payloads() { tile_payloads_.clear(); }
+
     // ========================================================================
     // Simulation Control
     // ========================================================================
@@ -352,15 +400,22 @@ private:
     // Pending compute operations (tile + dependency + state)
     struct PendingCompute {
         TileDescriptor tile;         ///< Result tile (C)
-        TileID dependency_tile;      ///< Last input tile that must be FED
+        std::vector<std::pair<TileID, size_t>> dependencies;
+        std::unique_ptr<MatMulComputeSpec> matmul;
         Cycle schedule_cycle;        ///< When scheduled
         Cycle complete_cycle;        ///< When computation will complete (set when started)
         bool started;                ///< Has computation started?
     };
     std::vector<PendingCompute> pending_computes_;
 
-    // Track tiles that have been fed to compute (for COMPUTE dependency checking)
-    std::set<TileID> fed_tiles_;
+    // Count scheduled and completed feed occurrences. Counts are required:
+    // a boolean "ever fed" flag lets a reused tile start a later compute early.
+    std::unordered_map<TileID, size_t, TileIDHash> scheduled_feed_counts_;
+    std::unordered_map<TileID, size_t, TileIDHash> completed_feed_counts_;
+
+    // Numeric values are orthogonal to location/credit metadata but advance
+    // through the same dependency and completion points.
+    std::unordered_map<TileID, TilePayload, TileIDHash> tile_payloads_;
 
     // Component processes
     std::vector<std::unique_ptr<MemoryControllerProcess>> memory_controllers_;
@@ -412,6 +467,9 @@ private:
      * @brief Count progress for livelock detection
      */
     [[nodiscard]] size_t count_completed_tiles() const;
+
+    [[nodiscard]] bool dependencies_satisfied(const PendingCompute& pc) const;
+    void execute_matmul(const PendingCompute& pc);
 };
 
 // ============================================================================
@@ -577,6 +635,7 @@ inline void ConcurrentTimingExecutor::schedule_writeback(const TileDescriptor& t
 }
 
 inline void ConcurrentTimingExecutor::schedule_feed(const TileDescriptor& tile, int streamer_id) {
+    ++scheduled_feed_counts_[tile.tile_id];
     // Determine if this is a row (A) or column (B) tile
     bool is_row = (tile.tile_id.matrix == isa::MatrixID::A);
     uint32_t streamer = (streamer_id >= 0)
@@ -603,11 +662,40 @@ inline void ConcurrentTimingExecutor::schedule_compute(
     // Schedule compute with explicit dependency
     PendingCompute pc;
     pc.tile = tile;
-    pc.dependency_tile = dependency_tile;
+    const size_t required = std::max<size_t>(1, scheduled_feed_counts_[dependency_tile]);
+    pc.dependencies.push_back({dependency_tile, required});
     pc.schedule_cycle = current_cycle_;
     pc.complete_cycle = 0;  // Set when started
     pc.started = false;
-    pending_computes_.push_back(pc);
+    pending_computes_.push_back(std::move(pc));
+}
+
+inline void ConcurrentTimingExecutor::schedule_matmul_compute(
+    const TileDescriptor& tile, const MatMulComputeSpec& spec) {
+    if (spec.a_tiles.empty() || spec.a_tiles.size() != spec.b_tiles.size()) {
+        throw std::invalid_argument("Matmul compute requires paired, non-empty A/B tiles");
+    }
+
+    PendingCompute pc;
+    pc.tile = tile;
+    pc.schedule_cycle = current_cycle_;
+    pc.complete_cycle = 0;
+    pc.started = false;
+    pc.matmul = std::make_unique<MatMulComputeSpec>(spec);
+
+    for (const auto& id : spec.a_tiles) {
+        if (scheduled_feed_counts_[id] == 0) {
+            throw std::invalid_argument("Matmul A tile has no scheduled feed: " + id.to_string());
+        }
+        pc.dependencies.push_back({id, scheduled_feed_counts_[id]});
+    }
+    for (const auto& id : spec.b_tiles) {
+        if (scheduled_feed_counts_[id] == 0) {
+            throw std::invalid_argument("Matmul B tile has no scheduled feed: " + id.to_string());
+        }
+        pc.dependencies.push_back({id, scheduled_feed_counts_[id]});
+    }
+    pending_computes_.push_back(std::move(pc));
 }
 
 inline void ConcurrentTimingExecutor::schedule_compute(const TileDescriptor& tile) {
@@ -656,8 +744,7 @@ inline bool ConcurrentTimingExecutor::step() {
     // Step 0a: Check pending computes for dependency satisfaction and start them
     for (auto& pc : pending_computes_) {
         if (!pc.started) {
-            // Check if dependency tile has been fed
-            if (fed_tiles_.count(pc.dependency_tile) > 0) {
+            if (dependencies_satisfied(pc)) {
                 // Dependency satisfied - start compute
                 pc.started = true;
                 pc.complete_cycle = current_cycle_ + config_.compute_latency;
@@ -675,6 +762,9 @@ inline bool ConcurrentTimingExecutor::step() {
     auto it = pending_computes_.begin();
     while (it != pending_computes_.end()) {
         if (it->started && current_cycle_ >= it->complete_cycle) {
+            if (it->matmul) {
+                execute_matmul(*it);
+            }
             // Compute completed - result tile is now ready for DRAIN
             uint32_t slot = next_compute_slot_++;
             compute_result_tag_cam_.insert(it->tile.tile_id, slot, current_cycle_);
@@ -722,7 +812,7 @@ inline bool ConcurrentTimingExecutor::step() {
         // Track tiles that have been fed to compute
         for (const auto& event : str_events) {
             if (event.type == EventType::TILE_FED_TO_COMPUTE) {
-                fed_tiles_.insert(event.tile_id);
+                ++completed_feed_counts_[event.tile_id];
             }
         }
         events_.insert(events_.end(), str_events.begin(), str_events.end());
@@ -734,7 +824,7 @@ inline bool ConcurrentTimingExecutor::step() {
         // Track tiles that have been fed to compute
         for (const auto& event : str_events) {
             if (event.type == EventType::TILE_FED_TO_COMPUTE) {
-                fed_tiles_.insert(event.tile_id);
+                ++completed_feed_counts_[event.tile_id];
             }
         }
         events_.insert(events_.end(), str_events.begin(), str_events.end());
@@ -748,6 +838,8 @@ inline bool ConcurrentTimingExecutor::step() {
 
 inline bool ConcurrentTimingExecutor::is_complete() const {
     // Complete when all queues are empty and no in-flight work
+
+    if (!pending_computes_.empty()) return false;
 
     // Check MCs (should be idle when DMA is complete)
     for (const auto& mc : memory_controllers_) {
@@ -785,7 +877,8 @@ inline void ConcurrentTimingExecutor::reset() {
     l2_tag_cam_.reset();
     compute_result_tag_cam_.reset();
     pending_computes_.clear();
-    fed_tiles_.clear();
+    scheduled_feed_counts_.clear();
+    completed_feed_counts_.clear();
 
     for (auto& mc : memory_controllers_) {
         mc->reset();
@@ -808,6 +901,58 @@ inline void ConcurrentTimingExecutor::reset() {
     }
 
     next_compute_slot_ = 0;
+}
+
+inline bool ConcurrentTimingExecutor::dependencies_satisfied(const PendingCompute& pc) const {
+    for (const auto& [tile_id, required_count] : pc.dependencies) {
+        auto it = completed_feed_counts_.find(tile_id);
+        size_t completed = it == completed_feed_counts_.end() ? 0 : it->second;
+        if (completed < required_count) return false;
+    }
+    return true;
+}
+
+inline void ConcurrentTimingExecutor::execute_matmul(const PendingCompute& pc) {
+    const auto& spec = *pc.matmul;
+    const auto& first_a = tile_payload(spec.a_tiles.front());
+    const auto& first_b = tile_payload(spec.b_tiles.front());
+    const Size m = first_a.rows;
+    const Size n = first_b.cols;
+
+    if (spec.bias.size() != 0 && spec.bias.size() != n) {
+        throw std::runtime_error("Matmul bias width does not match output tile");
+    }
+
+    TilePayload output;
+    output.rows = m;
+    output.cols = n;
+    output.values.assign(static_cast<size_t>(m) * n, 0.0f);
+
+    for (size_t tile_index = 0; tile_index < spec.a_tiles.size(); ++tile_index) {
+        const auto& a = tile_payload(spec.a_tiles[tile_index]);
+        const auto& b = tile_payload(spec.b_tiles[tile_index]);
+        if (!a.valid() || !b.valid() || a.rows != m || b.cols != n || a.cols != b.rows) {
+            throw std::runtime_error("Incompatible functional matmul tile payloads");
+        }
+        for (Size i = 0; i < m; ++i) {
+            for (Size k = 0; k < a.cols; ++k) {
+                const float av = a.values[static_cast<size_t>(i) * a.cols + k];
+                for (Size j = 0; j < n; ++j) {
+                    output.values[static_cast<size_t>(i) * n + j] +=
+                        av * b.values[static_cast<size_t>(k) * n + j];
+                }
+            }
+        }
+    }
+
+    for (Size i = 0; i < m; ++i) {
+        for (Size j = 0; j < n; ++j) {
+            float& value = output.values[static_cast<size_t>(i) * n + j];
+            if (!spec.bias.empty()) value += spec.bias[j];
+            if (spec.activation == FunctionalActivation::RELU && value < 0.0f) value = 0.0f;
+        }
+    }
+    tile_payloads_[pc.tile.tile_id] = std::move(output);
 }
 
 inline ConcurrentTimingExecutor::Statistics ConcurrentTimingExecutor::get_statistics() const {

--- a/include/sw/kpu/timing/dma_engine_process.hpp
+++ b/include/sw/kpu/timing/dma_engine_process.hpp
@@ -291,6 +291,9 @@ private:
                             completed->tile.tile_id,
                             name()
                         ));
+                        events.back().slot_id = req.slot_id;
+                        events.back().matrix_base_address = completed->tile.matrix_base_address;
+                        events.back().dram_address = completed->tile.dram_address;
                     } else {
                         // Store complete: tile written to DRAM
                         total_bytes_stored_ += completed->tile.size_bytes;
@@ -341,6 +344,9 @@ private:
                     req.tile.tile_id,
                     name()
                 ));
+                events.back().slot_id = entry->slot_id;
+                events.back().matrix_base_address = req.tile.matrix_base_address;
+                events.back().dram_address = req.tile.dram_address;
 
                 req.state = RequestState::COMPLETED;
                 continue;

--- a/include/sw/kpu/timing/functional_domain_flow.hpp
+++ b/include/sw/kpu/timing/functional_domain_flow.hpp
@@ -96,11 +96,17 @@ public:
             executor_.step();
             const auto& events = executor_.events();
             for (; event_cursor < events.size(); ++event_cursor) {
+                // Each completion event retires at most ONE node: nodes are
+                // keyed only by (tile_id, operation), so a program that
+                // schedules the same tile+op more than once (e.g. repeated
+                // FEEDs of a reused tile) must consume one completion per
+                // event, not retire every matching node at once.
                 for (size_t i = 0; i < program.nodes().size(); ++i) {
                     if (!scheduled[i] || completed[i]) continue;
                     if (matches_completion(program.nodes()[i], events[event_cursor])) {
                         completed[i] = true;
                         ++completed_count;
+                        break;
                     }
                 }
             }

--- a/include/sw/kpu/timing/functional_domain_flow.hpp
+++ b/include/sw/kpu/timing/functional_domain_flow.hpp
@@ -1,0 +1,151 @@
+// ============================================================================
+// Event-driven functional Domain Flow execution on the CSP timing simulator
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace sw::kpu::timing {
+
+class FunctionalDomainFlowProgram {
+public:
+    enum class Operation {
+        LOAD, MOVE, FEED, MATMUL, COMPUTE, DRAIN, WRITEBACK, STORE, BARRIER
+    };
+
+    struct Node {
+        Operation operation = Operation::BARRIER;
+        TileDescriptor tile;
+        ConcurrentTimingExecutor::MatMulComputeSpec matmul;
+        ConcurrentTimingExecutor::FunctionalComputeSpec compute;
+        std::vector<size_t> predecessors;
+
+        Node() = default;
+        Node(Operation op, TileDescriptor descriptor,
+             ConcurrentTimingExecutor::MatMulComputeSpec matmul_spec,
+             std::vector<size_t> dependencies)
+            : operation(op), tile(std::move(descriptor)), matmul(std::move(matmul_spec)),
+              predecessors(std::move(dependencies)) {}
+    };
+
+    size_t add(Node node) {
+        for (size_t predecessor : node.predecessors) {
+            if (predecessor >= nodes_.size()) {
+                throw std::invalid_argument("Domain Flow predecessor must already exist");
+            }
+        }
+        nodes_.push_back(std::move(node));
+        return nodes_.size() - 1;
+    }
+
+    [[nodiscard]] const std::vector<Node>& nodes() const { return nodes_; }
+    [[nodiscard]] bool empty() const { return nodes_.empty(); }
+
+private:
+    std::vector<Node> nodes_;
+};
+
+/**
+ * Dispatches every ready node in a Domain Flow DAG and marks it complete only
+ * when its corresponding CSP completion event occurs. Independent branches
+ * remain concurrent; dependency edges provide the global orchestration.
+ */
+class FunctionalDomainFlowExecutor {
+public:
+    explicit FunctionalDomainFlowExecutor(ConcurrentTimingExecutor::Config config = {})
+        : executor_(std::move(config)) {}
+
+    void set_tile_payload(const TileID& id, TilePayload payload) {
+        executor_.set_tile_payload(id, std::move(payload));
+    }
+
+    bool run(const FunctionalDomainFlowProgram& program) {
+        if (program.empty()) return true;
+        std::vector<bool> scheduled(program.nodes().size(), false);
+        std::vector<bool> completed(program.nodes().size(), false);
+        size_t completed_count = 0;
+        size_t event_cursor = executor_.events().size();
+
+        while (completed_count < program.nodes().size() &&
+               executor_.current_cycle() < executor_.config().max_cycles) {
+            for (size_t i = 0; i < program.nodes().size(); ++i) {
+                if (scheduled[i]) continue;
+                const auto& node = program.nodes()[i];
+                const bool ready = std::all_of(node.predecessors.begin(), node.predecessors.end(),
+                    [&completed](size_t predecessor) { return completed[predecessor]; });
+                if (!ready) continue;
+                scheduled[i] = true;
+                if (node.operation == FunctionalDomainFlowProgram::Operation::BARRIER) {
+                    completed[i] = true;
+                    ++completed_count;
+                } else {
+                    dispatch(node);
+                }
+            }
+
+            if (completed_count == program.nodes().size()) break;
+            executor_.step();
+            const auto& events = executor_.events();
+            for (; event_cursor < events.size(); ++event_cursor) {
+                for (size_t i = 0; i < program.nodes().size(); ++i) {
+                    if (!scheduled[i] || completed[i]) continue;
+                    if (matches_completion(program.nodes()[i], events[event_cursor])) {
+                        completed[i] = true;
+                        ++completed_count;
+                    }
+                }
+            }
+        }
+        return completed_count == program.nodes().size() && executor_.is_complete();
+    }
+
+    [[nodiscard]] ConcurrentTimingExecutor& executor() { return executor_; }
+    [[nodiscard]] const ConcurrentTimingExecutor& executor() const { return executor_; }
+
+private:
+    ConcurrentTimingExecutor executor_;
+
+    void dispatch(const FunctionalDomainFlowProgram::Node& node) {
+        using Op = FunctionalDomainFlowProgram::Operation;
+        switch (node.operation) {
+            case Op::LOAD: executor_.schedule_load(node.tile); break;
+            case Op::MOVE: executor_.schedule_move(node.tile); break;
+            case Op::FEED: executor_.schedule_feed(node.tile); break;
+            case Op::MATMUL: executor_.schedule_matmul_compute(node.tile, node.matmul); break;
+            case Op::COMPUTE: executor_.schedule_functional_compute(node.tile, node.compute); break;
+            case Op::DRAIN: executor_.schedule_drain(node.tile); break;
+            case Op::WRITEBACK: executor_.schedule_writeback(node.tile); break;
+            case Op::STORE: executor_.schedule_store(node.tile); break;
+            case Op::BARRIER: break;
+        }
+    }
+
+    [[nodiscard]] static bool matches_completion(const FunctionalDomainFlowProgram::Node& node,
+                                                  const TimingEvent& event) {
+        if (event.tile_id != node.tile.tile_id) return false;
+        using Op = FunctionalDomainFlowProgram::Operation;
+        switch (node.operation) {
+            case Op::LOAD: return event.type == EventType::TILE_ARRIVED_L3;
+            case Op::MOVE: return event.type == EventType::BM_MOVE_COMPLETE;
+            case Op::FEED: return event.type == EventType::TILE_FED_TO_COMPUTE;
+            case Op::MATMUL:
+            case Op::COMPUTE: return event.type == EventType::COMPUTE_COMPLETE;
+            case Op::DRAIN: return event.type == EventType::TILE_DRAINED;
+            case Op::WRITEBACK: return event.type == EventType::BM_WRITEBACK_COMPLETE;
+            case Op::STORE: return event.type == EventType::DMA_STORE_COMPLETE;
+            case Op::BARRIER: return false;
+        }
+        return false;
+    }
+};
+
+} // namespace sw::kpu::timing

--- a/include/sw/kpu/timing/functional_mlp_executor.hpp
+++ b/include/sw/kpu/timing/functional_mlp_executor.hpp
@@ -1,0 +1,152 @@
+// ============================================================================
+// Functional MLP execution on the CSP concurrent timing model
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sw::kpu::timing {
+
+/**
+ * @brief Narrow functional/transactional vertical slice for MLP inference.
+ *
+ * Each layer executes matmul+bias+activation through the real CSP data path:
+ * DMA -> L3 -> BlockMover -> L2 -> Streamer -> Compute -> Drain -> Store.
+ * Numeric results become visible only at the modeled compute completion point.
+ */
+class FunctionalMLPExecutor {
+public:
+    using FunctionalActivation = ConcurrentTimingExecutor::FunctionalActivation;
+
+    struct Layer {
+        Size input_dim = 0;
+        Size output_dim = 0;
+        std::vector<float> weights;
+        std::vector<float> bias;
+        FunctionalActivation activation = FunctionalActivation::NONE;
+        std::string name;
+    };
+
+    struct Statistics {
+        Cycle total_cycles = 0;
+        Cycle total_stall_cycles = 0;
+        size_t layers_completed = 0;
+    };
+
+    explicit FunctionalMLPExecutor(ConcurrentTimingExecutor::Config config = {})
+        : config_(std::move(config)) {}
+
+    void add_layer(Size input_dim, Size output_dim,
+                   std::vector<float> weights,
+                   std::vector<float> bias = {},
+                   FunctionalActivation activation = FunctionalActivation::NONE,
+                   std::string name = {}) {
+        if (input_dim == 0 || output_dim == 0) {
+            throw std::invalid_argument("MLP layer dimensions must be non-zero");
+        }
+        if (!layers_.empty() && layers_.back().output_dim != input_dim) {
+            throw std::invalid_argument("MLP layer dimensions are not composable");
+        }
+        if (weights.size() != static_cast<size_t>(input_dim) * output_dim) {
+            throw std::invalid_argument("MLP weight count does not match layer dimensions");
+        }
+        if (!bias.empty() && bias.size() != output_dim) {
+            throw std::invalid_argument("MLP bias count does not match output dimension");
+        }
+        layers_.push_back(Layer{input_dim, output_dim, std::move(weights),
+                                std::move(bias), activation, std::move(name)});
+    }
+
+    [[nodiscard]] std::vector<float> forward(const std::vector<float>& input,
+                                             Size batch_size) {
+        if (layers_.empty()) throw std::runtime_error("MLP has no layers");
+        if (input.size() != static_cast<size_t>(batch_size) * layers_.front().input_dim) {
+            throw std::invalid_argument("MLP input count does not match batch and input dimension");
+        }
+
+        stats_ = {};
+        std::vector<float> activation = input;
+        for (size_t layer_index = 0; layer_index < layers_.size(); ++layer_index) {
+            activation = execute_layer(activation, batch_size, layers_[layer_index], layer_index);
+            ++stats_.layers_completed;
+        }
+        return activation;
+    }
+
+    [[nodiscard]] const Statistics& statistics() const { return stats_; }
+    [[nodiscard]] const std::vector<Layer>& layers() const { return layers_; }
+
+private:
+    ConcurrentTimingExecutor::Config config_;
+    std::vector<Layer> layers_;
+    Statistics stats_;
+
+    [[nodiscard]] static TileDescriptor make_tile(isa::MatrixID matrix,
+                                                  Size rows, Size cols,
+                                                  Address address) {
+        TileDescriptor tile;
+        tile.tile_id = {matrix, 0, 0, 0};
+        tile.dram_address = address;
+        tile.matrix_base_address = address;
+        tile.height = rows;
+        tile.width = cols;
+        tile.element_size = sizeof(float);
+        tile.size_bytes = rows * cols * sizeof(float);
+        return tile;
+    }
+
+    [[nodiscard]] std::vector<float> execute_layer(const std::vector<float>& input,
+                                                   Size batch_size,
+                                                   const Layer& layer,
+                                                   size_t layer_index) {
+        ConcurrentTimingExecutor executor(config_);
+        const Address base = 0x100000 + static_cast<Address>(layer_index) * 0x100000;
+        auto a = make_tile(isa::MatrixID::A, batch_size, layer.input_dim, base);
+        auto b = make_tile(isa::MatrixID::B, layer.input_dim, layer.output_dim, base + 0x40000);
+        auto c = make_tile(isa::MatrixID::C, batch_size, layer.output_dim, base + 0x80000);
+
+        executor.set_tile_payload(a.tile_id, TilePayload{batch_size, layer.input_dim, input});
+        executor.set_tile_payload(b.tile_id, TilePayload{layer.input_dim, layer.output_dim,
+                                                         layer.weights});
+
+        executor.schedule_load(a);
+        executor.schedule_load(b);
+        executor.schedule_move(a);
+        executor.schedule_move(b);
+        executor.schedule_feed(a);
+        executor.schedule_feed(b);
+
+        ConcurrentTimingExecutor::MatMulComputeSpec compute;
+        compute.a_tiles = {a.tile_id};
+        compute.b_tiles = {b.tile_id};
+        compute.bias = layer.bias;
+        compute.activation = layer.activation;
+        executor.schedule_matmul_compute(c, compute);
+        executor.schedule_drain(c);
+        executor.schedule_writeback(c);
+        executor.schedule_store(c);
+
+        if (!executor.run()) {
+            throw std::runtime_error("Functional CSP execution failed for MLP layer " +
+                                     std::to_string(layer_index));
+        }
+
+        const auto timing = executor.get_statistics();
+        stats_.total_cycles += timing.total_cycles;
+        stats_.total_stall_cycles += timing.dma_credit_stalls + timing.bm_tag_stalls +
+                                     timing.bm_credit_stalls + timing.str_tag_stalls +
+                                     timing.str_credit_stalls;
+        return executor.tile_payload(c.tile_id).values;
+    }
+};
+
+} // namespace sw::kpu::timing

--- a/include/sw/kpu/timing/functional_mlp_executor.hpp
+++ b/include/sw/kpu/timing/functional_mlp_executor.hpp
@@ -69,6 +69,9 @@ public:
     [[nodiscard]] std::vector<float> forward(const std::vector<float>& input,
                                              Size batch_size) {
         if (layers_.empty()) throw std::runtime_error("MLP has no layers");
+        if (batch_size == 0) {
+            throw std::invalid_argument("MLP batch_size must be non-zero");
+        }
         if (input.size() != static_cast<size_t>(batch_size) * layers_.front().input_dim) {
             throw std::invalid_argument("MLP input count does not match batch and input dimension");
         }

--- a/include/sw/kpu/timing/functional_mlp_executor.hpp
+++ b/include/sw/kpu/timing/functional_mlp_executor.hpp
@@ -19,9 +19,9 @@ namespace sw::kpu::timing {
 /**
  * @brief Narrow functional/transactional vertical slice for MLP inference.
  *
- * Each layer executes matmul+bias+activation through the real CSP data path:
- * DMA -> L3 -> BlockMover -> L2 -> Streamer -> Compute -> Drain -> Store.
- * Numeric results become visible only at the modeled compute completion point.
+ * Inputs and weights traverse the real CSP data path. Intermediate activations
+ * remain in compute storage and are consumed directly by the next layer; only
+ * the final result drains through L2/L3 and stores to DRAM.
  */
 class FunctionalMLPExecutor {
 public:
@@ -74,27 +74,72 @@ public:
         }
 
         stats_ = {};
-        std::vector<float> activation = input;
+        ConcurrentTimingExecutor executor(config_);
+        const Address base = 0x100000;
+        auto current = make_tile(isa::MatrixID::A, batch_size,
+                                 layers_.front().input_dim, base, 0);
+        executor.set_tile_payload(current.tile_id,
+                                  TilePayload{batch_size, layers_.front().input_dim, input});
+        executor.schedule_load(current);
+        executor.schedule_move(current);
+        executor.schedule_feed(current);
+
         for (size_t layer_index = 0; layer_index < layers_.size(); ++layer_index) {
-            activation = execute_layer(activation, batch_size, layers_[layer_index], layer_index);
-            ++stats_.layers_completed;
+            const auto& layer = layers_[layer_index];
+            const Address layer_base = base + static_cast<Address>(layer_index) * 0x100000;
+            auto weights = make_tile(isa::MatrixID::B, layer.input_dim, layer.output_dim,
+                                     layer_base + 0x40000, static_cast<Size>(layer_index));
+            auto output = make_tile(isa::MatrixID::C, batch_size, layer.output_dim,
+                                    layer_base + 0x80000, static_cast<Size>(layer_index));
+
+            executor.set_tile_payload(weights.tile_id,
+                                      TilePayload{layer.input_dim, layer.output_dim,
+                                                  layer.weights});
+            executor.schedule_load(weights);
+            executor.schedule_move(weights);
+            executor.schedule_feed(weights);
+
+            ConcurrentTimingExecutor::MatMulComputeSpec compute;
+            compute.a_tiles = {current.tile_id};
+            compute.b_tiles = {weights.tile_id};
+            if (layer_index > 0) compute.resident_tiles = {current.tile_id};
+            compute.bias = layer.bias;
+            compute.activation = layer.activation;
+            executor.schedule_matmul_compute(output, compute);
+            current = output;
         }
-        return activation;
+
+        executor.schedule_drain(current);
+        executor.schedule_writeback(current);
+        executor.schedule_store(current);
+        if (!executor.run()) throw std::runtime_error("Functional CSP MLP execution failed");
+
+        const auto timing = executor.get_statistics();
+        stats_.total_cycles = timing.total_cycles;
+        stats_.total_stall_cycles = timing.dma_credit_stalls + timing.bm_tag_stalls +
+                                    timing.bm_credit_stalls + timing.str_tag_stalls +
+                                    timing.str_credit_stalls;
+        stats_.layers_completed = layers_.size();
+        events_ = executor.events();
+        return executor.tile_payload_at(MemoryLevel::DRAM, current.tile_id).values;
     }
 
     [[nodiscard]] const Statistics& statistics() const { return stats_; }
     [[nodiscard]] const std::vector<Layer>& layers() const { return layers_; }
+    [[nodiscard]] const std::vector<TimingEvent>& events() const { return events_; }
 
 private:
     ConcurrentTimingExecutor::Config config_;
     std::vector<Layer> layers_;
     Statistics stats_;
+    std::vector<TimingEvent> events_;
 
     [[nodiscard]] static TileDescriptor make_tile(isa::MatrixID matrix,
                                                   Size rows, Size cols,
-                                                  Address address) {
+                                                  Address address,
+                                                  Size layer_index) {
         TileDescriptor tile;
-        tile.tile_id = {matrix, 0, 0, 0};
+        tile.tile_id = {matrix, layer_index, 0, 0};
         tile.dram_address = address;
         tile.matrix_base_address = address;
         tile.height = rows;
@@ -104,49 +149,6 @@ private:
         return tile;
     }
 
-    [[nodiscard]] std::vector<float> execute_layer(const std::vector<float>& input,
-                                                   Size batch_size,
-                                                   const Layer& layer,
-                                                   size_t layer_index) {
-        ConcurrentTimingExecutor executor(config_);
-        const Address base = 0x100000 + static_cast<Address>(layer_index) * 0x100000;
-        auto a = make_tile(isa::MatrixID::A, batch_size, layer.input_dim, base);
-        auto b = make_tile(isa::MatrixID::B, layer.input_dim, layer.output_dim, base + 0x40000);
-        auto c = make_tile(isa::MatrixID::C, batch_size, layer.output_dim, base + 0x80000);
-
-        executor.set_tile_payload(a.tile_id, TilePayload{batch_size, layer.input_dim, input});
-        executor.set_tile_payload(b.tile_id, TilePayload{layer.input_dim, layer.output_dim,
-                                                         layer.weights});
-
-        executor.schedule_load(a);
-        executor.schedule_load(b);
-        executor.schedule_move(a);
-        executor.schedule_move(b);
-        executor.schedule_feed(a);
-        executor.schedule_feed(b);
-
-        ConcurrentTimingExecutor::MatMulComputeSpec compute;
-        compute.a_tiles = {a.tile_id};
-        compute.b_tiles = {b.tile_id};
-        compute.bias = layer.bias;
-        compute.activation = layer.activation;
-        executor.schedule_matmul_compute(c, compute);
-        executor.schedule_drain(c);
-        executor.schedule_writeback(c);
-        executor.schedule_store(c);
-
-        if (!executor.run()) {
-            throw std::runtime_error("Functional CSP execution failed for MLP layer " +
-                                     std::to_string(layer_index));
-        }
-
-        const auto timing = executor.get_statistics();
-        stats_.total_cycles += timing.total_cycles;
-        stats_.total_stall_cycles += timing.dma_credit_stalls + timing.bm_tag_stalls +
-                                     timing.bm_credit_stalls + timing.str_tag_stalls +
-                                     timing.str_credit_stalls;
-        return executor.tile_payload(c.tile_id).values;
-    }
 };
 
 } // namespace sw::kpu::timing

--- a/include/sw/kpu/timing/streamer_process.hpp
+++ b/include/sw/kpu/timing/streamer_process.hpp
@@ -269,6 +269,7 @@ private:
                     in_flight_->tile.tile_id,
                     name()
                 ));
+                events.back().slot_id = in_flight_l2_slot_;
 
                 if (credit_released) {
                     events.push_back(TimingEvent(

--- a/include/sw/kpu/timing/tile_descriptor.hpp
+++ b/include/sw/kpu/timing/tile_descriptor.hpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <functional>
 #include <tuple>
+#include <vector>
 
 namespace sw::kpu::timing {
 
@@ -150,6 +151,23 @@ struct TileDescriptor {
             s += hex;
         }
         return s;
+    }
+};
+
+/**
+ * @brief Numeric contents associated with a tile in the functional timing model.
+ *
+ * Payloads live in the executor rather than in TileDescriptor so descriptors
+ * remain cheap scheduling messages while values have one authoritative home.
+ */
+struct TilePayload {
+    Size rows = 0;
+    Size cols = 0;
+    std::vector<float> values;
+
+    [[nodiscard]] bool valid() const {
+        return rows > 0 && cols > 0 && values.size() ==
+               static_cast<std::size_t>(rows) * static_cast<std::size_t>(cols);
     }
 };
 

--- a/tests/timing/test_concurrent_timing_executor.cpp
+++ b/tests/timing/test_concurrent_timing_executor.cpp
@@ -13,6 +13,7 @@
 
 #include <sw/kpu/timing/concurrent_timing_executor.hpp>
 #include <sw/kpu/timing/functional_mlp_executor.hpp>
+#include <sw/kpu/timing/functional_domain_flow.hpp>
 
 using namespace sw::kpu::timing;
 using namespace sw::kpu::isa;
@@ -275,6 +276,84 @@ TEST_CASE("Functional CSP executor produces XOR MLP values under backpressure",
     REQUIRE(mlp.statistics().layers_completed == 2);
     REQUIRE(mlp.statistics().total_cycles > 0);
     REQUIRE(mlp.statistics().total_stall_cycles > 0);
+    REQUIRE(count_events(mlp.events(), EventType::COMPUTE_COMPLETE) == 2);
+    REQUIRE(count_events(mlp.events(), EventType::TILE_DRAINED) == 1);
+    REQUIRE(count_events(mlp.events(), EventType::DMA_STORE_COMPLETE) == 1);
+}
+
+TEST_CASE("Functional payload bytes cross every hierarchy boundary only on CSP completion",
+          "[timing][executor][functional][hierarchy]") {
+    ConcurrentTimingExecutor executor(default_config());
+    auto a = make_tile(MatrixID::A, 3, 0, 0, 4);
+    a.height = 1; a.width = 1;
+    executor.set_tile_payload(a.tile_id, TilePayload{1, 1, {7.0f}});
+    executor.schedule_load(a);
+    executor.schedule_move(a);
+    executor.schedule_feed(a);
+    size_t cursor = 0;
+    bool saw_l3 = false, saw_l2 = false, saw_l1 = false, saw_compute = false;
+    while (!executor.is_complete()) {
+        executor.step();
+        for (; cursor < executor.events().size(); ++cursor) {
+            const auto& event = executor.events()[cursor];
+            if (event.tile_id != a.tile_id) continue;
+            if (event.type == EventType::TILE_ARRIVED_L3) {
+                saw_l3 = executor.has_tile_payload_at(MemoryLevel::L3, a.tile_id);
+            } else if (event.type == EventType::BM_MOVE_COMPLETE) {
+                saw_l2 = executor.has_tile_payload_at(MemoryLevel::L2, a.tile_id);
+            } else if (event.type == EventType::TILE_FED_TO_COMPUTE) {
+                saw_l1 = executor.has_tile_payload_at(MemoryLevel::L1, a.tile_id);
+                saw_compute = executor.has_tile_payload_at(MemoryLevel::COMPUTE, a.tile_id);
+            }
+        }
+    }
+    REQUIRE(saw_l3); REQUIRE(saw_l2); REQUIRE(saw_l1); REQUIRE(saw_compute);
+    REQUIRE(executor.tile_payload_at(MemoryLevel::COMPUTE, a.tile_id).values[0] ==
+            Catch::Approx(7.0f));
+}
+
+TEST_CASE("Functional Domain Flow executes an arbitrary branched DAG",
+          "[timing][executor][functional][domain-flow]") {
+    FunctionalDomainFlowExecutor runner(default_config());
+    auto a = make_tile(MatrixID::A, 7, 0, 0, 4); a.height = 1; a.width = 1;
+    auto b = make_tile(MatrixID::B, 7, 0, 0, 4); b.height = 1; b.width = 1;
+    auto c = make_tile(MatrixID::C, 7, 0, 0, 4); c.height = 1; c.width = 1;
+    auto d = make_tile(MatrixID::C, 8, 0, 0, 4); d.height = 1; d.width = 1;
+    runner.set_tile_payload(a.tile_id, TilePayload{1, 1, {2.0f}});
+    runner.set_tile_payload(b.tile_id, TilePayload{1, 1, {4.0f}});
+
+    using Program = FunctionalDomainFlowProgram;
+    Program program;
+    const size_t load_a = program.add({Program::Operation::LOAD, a, {}, {}});
+    const size_t load_b = program.add({Program::Operation::LOAD, b, {}, {}});
+    const size_t move_a = program.add({Program::Operation::MOVE, a, {}, {load_a}});
+    const size_t move_b = program.add({Program::Operation::MOVE, b, {}, {load_b}});
+    const size_t feed_a = program.add({Program::Operation::FEED, a, {}, {move_a}});
+    const size_t feed_b = program.add({Program::Operation::FEED, b, {}, {move_b}});
+    ConcurrentTimingExecutor::MatMulComputeSpec matmul;
+    matmul.a_tiles = {a.tile_id}; matmul.b_tiles = {b.tile_id};
+    const size_t compute = program.add({Program::Operation::MATMUL, c, matmul,
+                                        {feed_a, feed_b}});
+    Program::Node custom;
+    custom.operation = Program::Operation::COMPUTE;
+    custom.tile = d;
+    custom.predecessors = {compute};
+    custom.compute.input_tiles = {c.tile_id};
+    custom.compute.resident_tiles = {c.tile_id};
+    custom.compute.operation = [](const std::vector<TilePayload>& inputs) {
+        TilePayload result = inputs.at(0);
+        for (float& value : result.values) value += 1.0f;
+        return result;
+    };
+    const size_t transformed = program.add(std::move(custom));
+    const size_t drain = program.add({Program::Operation::DRAIN, d, {}, {transformed}});
+    const size_t writeback = program.add({Program::Operation::WRITEBACK, d, {}, {drain}});
+    program.add({Program::Operation::STORE, d, {}, {writeback}});
+
+    REQUIRE(runner.run(program));
+    REQUIRE(runner.executor().tile_payload_at(MemoryLevel::DRAM, d.tile_id).values[0] ==
+            Catch::Approx(9.0f));
+    REQUIRE(count_events(runner.executor().events(), EventType::DMA_LOAD_COMPLETE) == 2);
 }
 
 TEST_CASE("Repeated tile feeds cannot satisfy a later functional compute early",

--- a/tests/timing/test_concurrent_timing_executor.cpp
+++ b/tests/timing/test_concurrent_timing_executor.cpp
@@ -7,10 +7,12 @@
 // ============================================================================
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include <filesystem>
 
 #include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/functional_mlp_executor.hpp>
 
 using namespace sw::kpu::timing;
 using namespace sw::kpu::isa;
@@ -232,6 +234,101 @@ TEST_CASE("ConcurrentTimingExecutor drain and writeback", "[timing][executor]") 
     REQUIRE(count_events(events, EventType::TILE_DRAINED) == 1);
     REQUIRE(count_events(events, EventType::BM_WRITEBACK_COMPLETE) == 1);
     REQUIRE(count_events(events, EventType::DMA_STORE_COMPLETE) == 1);
+}
+
+TEST_CASE("Functional CSP executor produces XOR MLP values under backpressure",
+          "[timing][executor][functional][mlp]") {
+    const std::vector<float> input = {
+        0.0f, 0.0f,
+        0.0f, 1.0f,
+        1.0f, 0.0f,
+        1.0f, 1.0f
+    };
+    const std::vector<float> w1 = {
+         1.0f,  1.0f, -1.0f, -1.0f,
+         1.0f,  1.0f, -1.0f, -1.0f
+    };
+    const std::vector<float> b1 = {-0.5f, -1.5f, 0.5f, 1.5f};
+    const std::vector<float> w2 = {2.0f, -6.0f, 0.0f, 0.0f};
+    const std::vector<float> b2 = {0.0f};
+
+    auto config = default_config();
+    config.l3_buffer_count = 1;
+    config.l2_bank_count = 1;
+    config.num_block_movers = 1;
+    config.compute_latency = 8;
+    config.max_cycles = 100000;
+
+    FunctionalMLPExecutor mlp(config);
+    mlp.add_layer(2, 4, w1, b1, ConcurrentTimingExecutor::FunctionalActivation::RELU,
+                  "hidden");
+    mlp.add_layer(4, 1, w2, b2, ConcurrentTimingExecutor::FunctionalActivation::NONE,
+                  "output");
+    auto output = mlp.forward(input, 4);
+
+    REQUIRE(output.size() == 4);
+    REQUIRE(output[0] == Catch::Approx(0.0f));
+    REQUIRE(output[1] == Catch::Approx(1.0f));
+    REQUIRE(output[2] == Catch::Approx(1.0f));
+    REQUIRE(output[3] == Catch::Approx(0.0f));
+
+    REQUIRE(mlp.statistics().layers_completed == 2);
+    REQUIRE(mlp.statistics().total_cycles > 0);
+    REQUIRE(mlp.statistics().total_stall_cycles > 0);
+}
+
+TEST_CASE("Repeated tile feeds cannot satisfy a later functional compute early",
+          "[timing][executor][functional][dependency]") {
+    auto config = default_config();
+    config.compute_latency = 4;
+    ConcurrentTimingExecutor executor(config);
+
+    auto a = make_tile(MatrixID::A, 0, 0, 0, 4);
+    a.height = 1; a.width = 1;
+    auto b = make_tile(MatrixID::B, 0, 0, 0, 4);
+    b.height = 1; b.width = 1;
+    auto c0 = make_tile(MatrixID::C, 0, 0, 0, 4);
+    c0.height = 1; c0.width = 1;
+    auto c1 = make_tile(MatrixID::C, 0, 1, 0, 4);
+    c1.height = 1; c1.width = 1;
+
+    executor.set_tile_payload(a.tile_id, TilePayload{1, 1, {2.0f}});
+    executor.set_tile_payload(b.tile_id, TilePayload{1, 1, {3.0f}});
+
+    ConcurrentTimingExecutor::MatMulComputeSpec compute;
+    compute.a_tiles = {a.tile_id};
+    compute.b_tiles = {b.tile_id};
+
+    for (auto* c : {&c0, &c1}) {
+        executor.schedule_load(a);
+        executor.schedule_load(b);
+        executor.schedule_move(a);
+        executor.schedule_move(b);
+        executor.schedule_feed(a);
+        executor.schedule_feed(b);
+        executor.schedule_matmul_compute(*c, compute);
+        executor.schedule_drain(*c);
+        executor.schedule_writeback(*c);
+        executor.schedule_store(*c);
+    }
+
+    REQUIRE(executor.run());
+    REQUIRE(executor.tile_payload(c0.tile_id).values[0] == Catch::Approx(6.0f));
+    REQUIRE(executor.tile_payload(c1.tile_id).values[0] == Catch::Approx(6.0f));
+
+    Cycle second_b_feed = 0;
+    Cycle second_compute_start = 0;
+    size_t b_feeds = 0;
+    for (const auto& event : executor.events()) {
+        if (event.type == EventType::TILE_FED_TO_COMPUTE && event.tile_id == b.tile_id) {
+            if (++b_feeds == 2) second_b_feed = event.cycle;
+        }
+        if (event.type == EventType::COMPUTE_START && event.tile_id == c1.tile_id) {
+            second_compute_start = event.cycle;
+        }
+    }
+    REQUIRE(b_feeds == 2);
+    REQUIRE(second_compute_start >= second_b_feed);
 }
 
 // ============================================================================


### PR DESCRIPTION
## What changed

- Replaced the single functional backing map with distinct serialized byte stores for DRAM, L3, L2, L1, and compute.
- Bound every byte copy and retirement to real DMA, BlockMover, Streamer, compute, TagCAM, and credit events.
- Added event slot/address metadata needed to identify physical transfer endpoints.
- Added counted feed and resident-compute dependencies so reused tiles cannot start later operations early.
- Added value-producing tiled matmul with optional bias/ReLU and generic functional tile transforms.
- Added an event-driven `FunctionalDomainFlowProgram` DAG runner. Independent branches dispatch concurrently; nodes complete only on matching CSP completion events.
- Refactored `FunctionalMLPExecutor` to one persistent executor. Intermediate activations remain in compute storage; only the final output drains and stores.
- Added hierarchy, ordering, arbitrary branched-DAG, custom-operator, and on-chip-residency tests.

## Why

The prior behavioral path produced values and the CSP path modeled timing, but they were separate. A successful MLP therefore did not prove that values were computed under transactional ordering and backpressure.

This PR makes the value path advance through the same completion events as the timing path. Missing source bytes at a claimed transfer completion are now a hard functional error.

## End-to-end path

```text
DRAM bytes --DMA complete--> L3 bytes --BlockMover complete--> L2 bytes
          --Streamer complete--> L1 bytes --> compute bytes
          --next compute node (resident, no spill)--> compute bytes
          --final drain--> L1/L2 --writeback--> L3 --store--> DRAM
```

## Validation

- macOS AppleClang: standalone Werror compile and run passed.
- macOS AppleClang ASan+UBSan: unified XOR MLP passed.
- Ubuntu 24.04 x86_64 GCC 13.3: all functional tests passed (24 assertions / 4 cases).
- Full Ubuntu GCC suite: 96/97 passed; only the pre-existing wall-clock EDDO performance threshold failed under amd64-on-arm64 emulation. `test_concurrent_timing_executor` and `unified_xor_mlp` passed.
- Earlier commit validation also passed native macOS 97/97, GCC/Clang Linux focused Werror builds, and Clang Linux non-flaky suite.

Current constrained XOR result:

```text
cycles: 225
credit/tag stall cycles: 576
Numerical result: PASS
Transaction-ordered execution: PASS
```

The previous layer-by-layer implementation reported 340 cycles. Persistent on-chip activation chaining reduces the modeled run to 225 cycles and emits one drain/store path for the two-layer network.

## Remaining work

The architectural boundaries identified in the first draft are closed. Future work is operator-library breadth and compiler lowering from the existing `TileDataFlowGraph`; those add kernels/frontends without introducing another simulator or changing the unified memory/ordering model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added functional/transactional MLP execution with dense layers, optional bias, and ReLU.
  * Introduced tile payload support and event-driven, dependency-aware DAG execution with custom operations.
  * Added a new unified XOR MLP scheduling example with output and timing/statistics validation.
* **Bug Fixes**
  * Improved timing event metadata and strengthened feed/payload completion tracking for correct ordering and retirement.
* **Tests**
  * Added functional MLP, payload propagation, branched DAG execution, and dependency-ordering coverage.
* **Documentation**
  * Added a functional CSP/MLP vertical-slice guide, execution model, and run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->