### PR TITLE
feat: resource-envelope-aware schedule generation; BLOCKED_AB livelock-safe by construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CSP timing: resource-envelope-aware schedule generation (#67).**
+  `MatMulScheduleGenerator::Config` gains a resource envelope
+  (`l3_buffer_count`/`l2_bank_count`, defaults matching the executor) and a
+  derived per-matrix burst bound (`max_burst_tiles()` = a quarter of the
+  smaller pool). BLOCKED_AB is now livelock-safe **by construction**: an
+  outer K-block loop bounds each A/B burst to the envelope share, so the
+  tile working set provably fits the credit pools - the classic
+  blocked-linear-algebra discipline of deriving block sizes from the memory
+  hierarchy. A capacity-aware `is_livelock_safe(schedule, l3, l2)` overload
+  checks the constructive residency bound (in operations: 2 ops per
+  resident tile) instead of the fixed interleaving heuristic; `run_matmul`
+  generates against and reports the envelope it executes with. Provenance
+  of the original design gap (executor-side partitioned credits designed,
+  built, never wired; safety burden silently moved to schedule ordering)
+  is documented in #67.
+
 - **CSP timing: multi-tile execution regression suite (#64).**
   `tests/timing/test_multi_tile_execution.cpp` executes generated matmul
   schedules end-to-end through `ConcurrentTimingExecutor` across all four

--- a/docs/sessions/2026-07-11_v0.9_envelope_aware_blocked_schedule.md
+++ b/docs/sessions/2026-07-11_v0.9_envelope_aware_blocked_schedule.md
@@ -1,0 +1,107 @@
+# v0.9 Resource-Envelope-Aware Schedule Generation Decision Log
+
+**Date:** 2026-07-11
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 99/99 suites passing (new: envelope generator sections, constrained-envelope execution)
+**Issue:** #67
+
+## 1. Summary
+
+Made schedule generation resource-aware. Previously the generators were
+capacity-blind and BLOCKED_AB shipped knowingly livelock-prone ("can
+livelock" in its own enum doc), with safety expressed as a post-hoc
+heuristic flag. The generator Config now carries the resource envelope, and
+BLOCKED_AB derives its burst length from it via an outer K-block loop -
+livelock-safety becomes a constructive property of every emitted schedule,
+checked by a capacity-aware `is_livelock_safe(schedule, l3, l2)` invariant.
+
+Provenance of the gap (documented in #67): the original design placed
+safety in the executor (partitioned credits, bounded lookahead,
+compute-driven pull); Phase 1 built `PartitionedCreditPool`; Phase 3
+shipped the executor without wiring it; Phase 4 compensated at the schedule
+layer with an interleaving heuristic and normalized BLOCKED_AB as a
+livelock-prone stress fixture. The a-priori requirement - working set
+derived from loop structure, verified against capacity - existed nowhere.
+
+## 2. Scope
+
+| Item | Status | Verification |
+|------|--------|--------------|
+| Resource envelope in generator Config | Done | defaults match executor (32/64) |
+| `max_burst_tiles()` derivation | Done | min(l3,l2)/4, clamped >= 1 |
+| Constructive BLOCKED_AB (K-block outer loop) | Done | max_consec <= 2x share across envelopes |
+| Capacity-aware `is_livelock_safe(schedule, l3, l2)` | Done | ops-vs-tiles accounting (2 ops/resident tile) |
+| run_matmul generates against executor envelope | Done | reports envelope in livelock analysis |
+| Generator tests (constrained/large/degenerate envelopes) | Done | test_schedule_generators |
+| Constrained-envelope execution regression | Done | BLOCKED_AB 128^3 @ L3=8: SUCCESS |
+
+Files modified:
+- `include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp` (implementation)
+- `include/sw/kpu/timing/schedule/schedule_validator.hpp` (implementation)
+- `examples/schedule/run_matmul.cpp` (envelope wiring + reporting)
+- `tests/timing/test_schedule_generators.cpp` (new envelope test case)
+- `tests/timing/test_multi_tile_execution.cpp` (constrained-envelope regression)
+- `CHANGELOG.md`
+- `docs/sessions/2026-07-11_v0.9_envelope_aware_blocked_schedule.md` (this log)
+
+## 3. Technical Decisions
+
+**Decision 1: Quarter-pool burst bound**
+- **Choice:** per-matrix burst = `min(l3_buffer_count, l2_bank_count) / 4`,
+  clamped to >= 1.
+- **Rationale:** an A burst and a B burst must be concurrently resident
+  (half the pool), leaving the other half as headroom for in-flight drains,
+  C writebacks, and cross-iteration overlap under the executor's greedy
+  prefetch. Conservative by design; the margin is tunable later without
+  changing the structure.
+- **Alternatives:** half-pool bound (no headroom for C traffic);
+  exact working-set simulation at generation time (heavier, and
+  `validate_livelock_safety`'s credit simulation already exists for
+  post-hoc checking).
+
+**Decision 2: Fix generation, not the flag**
+- **Choice:** BLOCKED_AB generates safe schedules; the capacity-aware
+  `is_livelock_safe` overload verifies the constructive bound. The
+  capacity-blind heuristic overload remains for callers without an
+  envelope.
+- **Rationale:** per #67, "emit and hope, then flag" inverts the blocked-LA
+  discipline. The flag is now an invariant check.
+
+**Decision 3: Ops-vs-tiles accounting in the safety check**
+- **Choice:** compare `max_consecutive` (operations) against `2 x share`
+  (tiles), since a resident tile contributes LOAD + MOVE to a burst.
+- **Rationale:** `ScheduleAnalysis` counts operations; the residency bound
+  is in tiles. Comparing tile-share to op-count directly would falsely
+  flag every blocked schedule. Caught during implementation before it
+  became a bug.
+
+## 4. Issues Encountered
+
+1. Missing `schedule_validator.hpp` include in test_schedule_generators
+   (compile error under -Werror). Fixed.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session. (The near-miss in Decision 3 -
+comparing an operation count to a tile bound - was caught before commit.)
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                                  # 99/99 pass
+./build/examples/schedule/run_matmul -M 128 -N 128 -K 128 \
+  --strategy blocked --l3-buffers 8                     # livelock-safe YES, SUCCESS
+./build/examples/schedule/run_matmul -M 128 -N 128 -K 128 \
+  --strategy blocked                                    # SUCCESS, 8041 cycles
+```
+
+## 7. Next Steps
+
+- Wire `PartitionedCreditPool` into `ConcurrentTimingExecutor` per the
+  original design (defense-in-depth for hand-written schedules) - noted
+  as follow-up in #67.
+- Extend the envelope to the conv2d/softmax/norm generators.
+- Consider having `ScheduleExecutor` warn when a schedule's generation
+  envelope differs from the executor's configuration.

--- a/examples/schedule/run_matmul.cpp
+++ b/examples/schedule/run_matmul.cpp
@@ -165,6 +165,11 @@ int main(int argc, char* argv[]) {
     config.Tk = static_cast<Size>(Tk);
     config.strategy = strategy;
 
+    // Generate against the same resource envelope the executor runs with,
+    // so blocked strategies derive burst lengths that provably fit (#67)
+    config.l3_buffer_count = static_cast<Size>(l3_buffers);
+    config.l2_bank_count = 64;
+
     // Set matrix base addresses in DRAM (for trace display)
     // A matrix at 0x0000'1000, B at 0x0010'0000, C at 0x0020'0000
     config.a_base = 0x00001000;
@@ -193,7 +198,8 @@ int main(int argc, char* argv[]) {
     std::cout << "  Max consecutive A ops: " << analysis.max_consecutive_a << "\n";
     std::cout << "  Max consecutive B ops: " << analysis.max_consecutive_b << "\n";
     std::cout << "  Interleaved: " << (analysis.is_interleaved ? "YES" : "NO") << "\n";
-    std::cout << "  Livelock-safe: " << (is_livelock_safe(schedule) ? "YES" : "NO") << "\n";
+    std::cout << "  Livelock-safe (envelope L3=" << l3_buffers << ", L2=64): "
+              << (is_livelock_safe(schedule, l3_buffers, 64) ? "YES" : "NO") << "\n";
 
     // ========================================
     // Validate schedule (optional)

--- a/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
@@ -25,11 +25,13 @@ namespace sw::kpu::timing::schedule {
  * - OUTPUT_STATIONARY: C tiles stay in accumulators, A and B stream through
  * - INTERLEAVED_AB: A-B-A-B ordering for balanced buffer usage (livelock-safe)
  * - PREFETCH_NEXT: Overlap next tile load with current compute
- * - BLOCKED_AB: All A tiles then all B tiles (livelock-prone with limited credits)
+ * - BLOCKED_AB: A bursts then B bursts, blocked over K with burst lengths
+ *   derived from the resource envelope (livelock-safe by construction)
  *
- * The default INTERLEAVED_AB strategy ensures livelock-free execution by
- * alternating between A and B tile operations, preventing either matrix
- * type from monopolizing buffer resources.
+ * All strategies are generated against the Config resource envelope
+ * (l3_buffer_count/l2_bank_count): burst lengths are bounded so the tile
+ * working set provably fits the credit pools and neither matrix can
+ * monopolize the buffers the other needs (issue #67).
  *
  * Usage:
  * ```cpp
@@ -51,7 +53,9 @@ public:
         OUTPUT_STATIONARY,  ///< C stays in accumulators
         INTERLEAVED_AB,     ///< A-B-A-B ordering (livelock-safe) - DEFAULT
         PREFETCH_NEXT,      ///< Overlap load with compute
-        BLOCKED_AB          ///< All A then all B (can livelock)
+        BLOCKED_AB          ///< A/B bursts blocked over K, burst length bounded
+                            ///< by the resource envelope (livelock-safe by
+                            ///< construction)
     };
 
     /**
@@ -74,10 +78,36 @@ public:
         // Scheduling strategy
         Strategy strategy = Strategy::INTERLEAVED_AB;
 
+        // Resource envelope: the buffer capacities this schedule is generated
+        // against. Blocked strategies derive their burst lengths from these so
+        // the tile working set provably fits the credit pools (issue #67) -
+        // the classic blocked-linear-algebra discipline of sizing blocks to
+        // the memory hierarchy. Defaults match ConcurrentTimingExecutor::Config.
+        Size l3_buffer_count = 32;   ///< L3 credit pool the schedule targets
+        Size l2_bank_count = 64;     ///< L2 credit pool the schedule targets
+
         // Address generation (base addresses in DRAM)
         Address a_base = 0;
         Address b_base = 0;
         Address c_base = 0;
+
+        /**
+         * @brief Per-matrix burst bound derived from the resource envelope
+         *
+         * A burst of L same-matrix tiles can occupy up to L buffers
+         * concurrently. Bounding each matrix's burst to a quarter of the
+         * L3 pool (and of the L2 pool) guarantees an A-burst and a B-burst
+         * can be resident simultaneously with half the pool left as headroom
+         * for in-flight drains, C writebacks, and cross-iteration overlap -
+         * so neither matrix can monopolize the credits that the other needs
+         * to make forward progress.
+         */
+        [[nodiscard]] Size max_burst_tiles() const {
+            Size l3_share = l3_buffer_count / 4;
+            Size l2_share = l2_bank_count / 4;
+            Size share = l3_share < l2_share ? l3_share : l2_share;
+            return share > 0 ? share : 1;
+        }
 
         /**
          * @brief Calculate tile size in bytes
@@ -368,39 +398,55 @@ private:
     }
 
     /**
-     * @brief Generate blocked A-B schedule (can cause livelock)
+     * @brief Generate blocked A-B schedule (livelock-safe by construction)
      *
-     * Loads all A tiles for a row, then all B tiles for a column.
-     * WARNING: This can cause livelock if buffer space is limited!
-     * Emits all operations; execution layer handles deduplication.
+     * Classic blocked-linear-algebra structure: an outer K-block loop
+     * sequences tile residency so the working set provably fits the
+     * resource envelope (issue #67). Within each K block, an A burst is
+     * followed by a B burst; the burst length is bounded by
+     * Config::max_burst_tiles(), which is derived from the L3/L2 credit
+     * pools. An A burst and a B burst can therefore always be resident
+     * simultaneously - neither matrix can monopolize the credits the other
+     * needs, so livelock-safety is a constructive property of the schedule
+     * rather than an empirical hope.
+     *
+     * With a large envelope the block degenerates to the full K loop
+     * (identical to the historical behavior); with a constrained envelope
+     * the K loop is chunked.
      */
     void generate_blocked_ab(ScheduleResult& result) {
         Size m_tiles = config_.m_tiles();
         Size n_tiles = config_.n_tiles();
         Size k_tiles = config_.k_tiles();
+        Size burst = config_.max_burst_tiles();
 
         for (Size ti = 0; ti < m_tiles; ++ti) {
             for (Size tj = 0; tj < n_tiles; ++tj) {
-                // Load ALL A tiles for this row first
-                for (Size tk = 0; tk < k_tiles; ++tk) {
-                    auto a_tile = make_tile(isa::MatrixID::A, ti, 0, tk);
-                    result.operations.push_back(ScheduleOperation::load(a_tile));
-                    result.operations.push_back(ScheduleOperation::move(a_tile));
-                }
+                // Outer K-block loop: each block's bursts fit the envelope
+                for (Size kb = 0; kb < k_tiles; kb += burst) {
+                    Size kend = kb + burst < k_tiles ? kb + burst : k_tiles;
 
-                // Then load ALL B tiles for this column
-                for (Size tk = 0; tk < k_tiles; ++tk) {
-                    auto b_tile = make_tile(isa::MatrixID::B, 0, tj, tk);
-                    result.operations.push_back(ScheduleOperation::load(b_tile));
-                    result.operations.push_back(ScheduleOperation::move(b_tile, true));
-                }
+                    // A burst for this K block (bounded by the envelope)
+                    for (Size tk = kb; tk < kend; ++tk) {
+                        auto a_tile = make_tile(isa::MatrixID::A, ti, 0, tk);
+                        result.operations.push_back(ScheduleOperation::load(a_tile));
+                        result.operations.push_back(ScheduleOperation::move(a_tile));
+                    }
 
-                // Feed tiles
-                for (Size tk = 0; tk < k_tiles; ++tk) {
-                    auto a_tile = make_tile(isa::MatrixID::A, ti, 0, tk);
-                    auto b_tile = make_tile(isa::MatrixID::B, 0, tj, tk);
-                    result.operations.push_back(ScheduleOperation::feed(a_tile));
-                    result.operations.push_back(ScheduleOperation::feed(b_tile));
+                    // B burst for this K block
+                    for (Size tk = kb; tk < kend; ++tk) {
+                        auto b_tile = make_tile(isa::MatrixID::B, 0, tj, tk);
+                        result.operations.push_back(ScheduleOperation::load(b_tile));
+                        result.operations.push_back(ScheduleOperation::move(b_tile, true));
+                    }
+
+                    // Feed this K block's tiles (consumes their residency)
+                    for (Size tk = kb; tk < kend; ++tk) {
+                        auto a_tile = make_tile(isa::MatrixID::A, ti, 0, tk);
+                        auto b_tile = make_tile(isa::MatrixID::B, 0, tj, tk);
+                        result.operations.push_back(ScheduleOperation::feed(a_tile));
+                        result.operations.push_back(ScheduleOperation::feed(b_tile));
+                    }
                 }
 
                 // Signal compute complete, then drain and store C

--- a/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
@@ -28,10 +28,12 @@ namespace sw::kpu::timing::schedule {
  * - BLOCKED_AB: A bursts then B bursts, blocked over K with burst lengths
  *   derived from the resource envelope (livelock-safe by construction)
  *
- * All strategies are generated against the Config resource envelope
- * (l3_buffer_count/l2_bank_count): burst lengths are bounded so the tile
- * working set provably fits the credit pools and neither matrix can
- * monopolize the buffers the other needs (issue #67).
+ * The Config carries a resource envelope (l3_buffer_count/l2_bank_count).
+ * BLOCKED_AB derives its burst lengths from it so the tile working set
+ * provably fits the credit pools (issue #67); INTERLEAVED_AB and
+ * OUTPUT_STATIONARY are envelope-safe by their op-level interleaving.
+ * Extending envelope-derived blocking to the remaining strategies and
+ * generators is follow-up work tracked in #67.
  *
  * Usage:
  * ```cpp
@@ -95,18 +97,13 @@ public:
          * @brief Per-matrix burst bound derived from the resource envelope
          *
          * A burst of L same-matrix tiles can occupy up to L buffers
-         * concurrently. Bounding each matrix's burst to a quarter of the
-         * L3 pool (and of the L2 pool) guarantees an A-burst and a B-burst
-         * can be resident simultaneously with half the pool left as headroom
-         * for in-flight drains, C writebacks, and cross-iteration overlap -
-         * so neither matrix can monopolize the credits that the other needs
-         * to make forward progress.
+         * concurrently; bounding L keeps an A-burst and a B-burst
+         * simultaneously resident so neither matrix can monopolize the
+         * credits the other needs. Delegates to per_matrix_burst_share() -
+         * the canonical formula shared with is_livelock_safe().
          */
         [[nodiscard]] Size max_burst_tiles() const {
-            Size l3_share = l3_buffer_count / 4;
-            Size l2_share = l2_bank_count / 4;
-            Size share = l3_share < l2_share ? l3_share : l2_share;
-            return share > 0 ? share : 1;
+            return per_matrix_burst_share(l3_buffer_count, l2_bank_count);
         }
 
         /**

--- a/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
@@ -17,6 +17,28 @@
 namespace sw::kpu::timing::schedule {
 
 // ============================================================================
+// Resource Envelope
+// ============================================================================
+
+/**
+ * @brief Per-matrix burst share for a resource envelope (issue #67)
+ *
+ * The canonical formula tying envelope-aware schedule generation to the
+ * capacity-aware livelock check: each matrix may burst at most a quarter of
+ * the smaller credit pool, so an A burst and a B burst can always be
+ * resident simultaneously with half the pool left as headroom for in-flight
+ * drains, C writebacks, and prefetch overlap. Generators bound their bursts
+ * with this; is_livelock_safe(schedule, l3, l2) verifies against it. Keep
+ * both sides on this single definition.
+ */
+[[nodiscard]] inline Size per_matrix_burst_share(Size l3_credits, Size l2_credits) {
+    Size l3_share = l3_credits / 4;
+    Size l2_share = l2_credits / 4;
+    Size share = l3_share < l2_share ? l3_share : l2_share;
+    return share > 0 ? share : 1;
+}
+
+// ============================================================================
 // Schedule Operation Types
 // ============================================================================
 

--- a/include/sw/kpu/timing/schedule/schedule_validator.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_validator.hpp
@@ -599,11 +599,41 @@ inline ValidationResult validate_livelock_safety(
 }
 
 /**
- * @brief Quick check if schedule is livelock-safe
+ * @brief Quick check if schedule is livelock-safe (capacity-blind heuristic)
+ *
+ * Uses the fixed interleaving threshold (max 3 consecutive same-matrix ops).
+ * Prefer the capacity-aware overload when the resource envelope is known:
+ * it checks the constructive property the generators guarantee.
  */
 inline bool is_livelock_safe(const ScheduleResult& schedule) {
     auto analysis = ScheduleAnalysis::analyze(schedule);
     return analysis.is_interleaved;
+}
+
+/**
+ * @brief Capacity-aware livelock-safety check (issue #67)
+ *
+ * Verifies the constructive residency bound the generators emit against:
+ * each matrix's longest burst must fit its share of the credit pools
+ * (a quarter of the smaller pool, so an A burst and a B burst can always
+ * be resident simultaneously with headroom for drains and C writebacks).
+ * This is an invariant check of the schedule's working set against the
+ * envelope - not a fixed-threshold heuristic.
+ */
+inline bool is_livelock_safe(const ScheduleResult& schedule,
+                             size_t l3_credits,
+                             size_t l2_credits) {
+    auto analysis = ScheduleAnalysis::analyze(schedule);
+    size_t l3_share = l3_credits / 4;
+    size_t l2_share = l2_credits / 4;
+    size_t share = l3_share < l2_share ? l3_share : l2_share;
+    if (share == 0) share = 1;
+    // ScheduleAnalysis counts consecutive OPERATIONS; a resident tile
+    // contributes at most two ops to a burst (LOAD + MOVE), so a burst of
+    // `share` tiles appears as up to 2*share consecutive same-matrix ops.
+    size_t share_ops = 2 * share;
+    return analysis.max_consecutive_a <= share_ops &&
+           analysis.max_consecutive_b <= share_ops;
 }
 
 } // namespace sw::kpu::timing::schedule

--- a/include/sw/kpu/timing/schedule/schedule_validator.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_validator.hpp
@@ -624,10 +624,8 @@ inline bool is_livelock_safe(const ScheduleResult& schedule,
                              size_t l3_credits,
                              size_t l2_credits) {
     auto analysis = ScheduleAnalysis::analyze(schedule);
-    size_t l3_share = l3_credits / 4;
-    size_t l2_share = l2_credits / 4;
-    size_t share = l3_share < l2_share ? l3_share : l2_share;
-    if (share == 0) share = 1;
+    size_t share = per_matrix_burst_share(static_cast<Size>(l3_credits),
+                                          static_cast<Size>(l2_credits));
     // ScheduleAnalysis counts consecutive OPERATIONS; a resident tile
     // contributes at most two ops to a burst (LOAD + MOVE), so a burst of
     // `share` tiles appears as up to 2*share consecutive same-matrix ops.

--- a/tests/timing/test_multi_tile_execution.cpp
+++ b/tests/timing/test_multi_tile_execution.cpp
@@ -17,6 +17,7 @@
 #include <sw/kpu/timing/concurrent_timing_executor.hpp>
 #include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/schedule_executor.hpp>
+#include <sw/kpu/timing/schedule/schedule_validator.hpp>
 
 #include <string>
 
@@ -139,6 +140,38 @@ TEST_CASE("Multi-tile schedules execute to completion across strategies and size
             }
         }
     }
+}
+
+// ============================================================================
+// Envelope-aware blocked schedules under constrained buffers (issue #67)
+// ============================================================================
+
+TEST_CASE("BLOCKED_AB executes under a constrained resource envelope",
+          "[timing][executor][regression][envelope]") {
+    // A small envelope that the historical all-A-then-all-B ordering would
+    // stress: 8 L3 buffers / 16 L2 banks for an 8-K-slice problem. The
+    // generator must chunk the K loop so the working set fits.
+    auto exec_config = make_executor_config();
+    exec_config.l3_buffer_count = 8;
+    exec_config.l2_bank_count = 16;
+
+    auto gen_config = make_generator_config(
+        128, MatMulScheduleGenerator::Strategy::BLOCKED_AB);
+    gen_config.l3_buffer_count = 8;
+    gen_config.l2_bank_count = 16;
+
+    MatMulScheduleGenerator generator(gen_config);
+    auto schedule = generator.generate();
+    REQUIRE(schedule.valid);
+    REQUIRE(is_livelock_safe(schedule, 8, 16));
+
+    ConcurrentTimingExecutor executor(exec_config);
+    ScheduleExecutor sched_exec(executor);
+    auto result = sched_exec.execute(schedule);
+
+    INFO("cycles=" << result.total_cycles << " error=" << result.error_message);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
 }
 
 // ============================================================================

--- a/tests/timing/test_schedule_generators.cpp
+++ b/tests/timing/test_schedule_generators.cpp
@@ -11,6 +11,7 @@
 #include <sw/kpu/timing/schedule/schedule_generator_interface.hpp>
 #include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/schedule_executor.hpp>
+#include <sw/kpu/timing/schedule/schedule_validator.hpp>
 
 #include <set>
 
@@ -319,6 +320,73 @@ TEST_CASE("MatMulScheduleGenerator prefetch_next", "[timing][schedule][matmul]")
     size_t move_ops = result.count_ops(ScheduleOpType::MOVE);
     REQUIRE(load_ops == expected_k_tiles * 2 * expected_c_tiles);
     REQUIRE(load_ops == move_ops);
+}
+
+TEST_CASE("MatMulScheduleGenerator blocked_ab derives bursts from the resource envelope",
+          "[timing][schedule][matmul][envelope]") {
+    // 128^3 at 16^3 tiles: k_tiles = 8
+    MatMulScheduleGenerator::Config config;
+    config.M = 128;
+    config.N = 128;
+    config.K = 128;
+    config.Ti = 16;
+    config.Tj = 16;
+    config.Tk = 16;
+    config.strategy = MatMulScheduleGenerator::Strategy::BLOCKED_AB;
+
+    SECTION("constrained envelope chunks the K loop") {
+        // share = min(8/4, 16/4) = 2 tiles -> bursts of 2 tiles
+        // (= at most 4 consecutive same-matrix ops: 2 x (LOAD + MOVE))
+        config.l3_buffer_count = 8;
+        config.l2_bank_count = 16;
+        REQUIRE(config.max_burst_tiles() == 2);
+
+        MatMulScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        auto analysis = ScheduleAnalysis::analyze(schedule);
+        REQUIRE(analysis.max_consecutive_a <= 4);
+        REQUIRE(analysis.max_consecutive_b <= 4);
+        REQUIRE(is_livelock_safe(schedule, 8, 16));
+
+        // Blocking must not change total work: LOAD:MOVE:FEED stay 1:1:1
+        size_t loads = schedule.count_ops(ScheduleOpType::LOAD);
+        REQUIRE(loads == schedule.count_ops(ScheduleOpType::MOVE));
+        REQUIRE(loads == schedule.count_ops(ScheduleOpType::FEED));
+        REQUIRE(loads == 2u * 8u * 64u);  // 2 matrices x k_tiles x c_tiles
+    }
+
+    SECTION("large envelope degenerates to the full K loop") {
+        // share = min(32/4, 64/4) = 8 tiles >= k_tiles -> single block,
+        // identical structure to the historical all-A-then-all-B ordering
+        config.l3_buffer_count = 32;
+        config.l2_bank_count = 64;
+        REQUIRE(config.max_burst_tiles() == 8);
+
+        MatMulScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        auto analysis = ScheduleAnalysis::analyze(schedule);
+        REQUIRE(analysis.max_consecutive_a == 16);  // 8 tiles x (LOAD + MOVE)
+        REQUIRE(is_livelock_safe(schedule, 32, 64));
+    }
+
+    SECTION("degenerate envelope still makes progress") {
+        // share clamps to 1 tile
+        config.l3_buffer_count = 2;
+        config.l2_bank_count = 2;
+        REQUIRE(config.max_burst_tiles() == 1);
+
+        MatMulScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        auto analysis = ScheduleAnalysis::analyze(schedule);
+        REQUIRE(analysis.max_consecutive_a <= 2);
+        REQUIRE(is_livelock_safe(schedule, 2, 2));
+    }
 }
 
 TEST_CASE("MatMulScheduleGenerator address calculation", "[timing][schedule][matmul]") {


### PR DESCRIPTION
Fixes #67.

## Problem

Schedule generation was capacity-blind. The generator Config carried no resource envelope, so no strategy could enforce "working set ≤ buffer capacity" at generation time; BLOCKED_AB shipped knowingly livelock-prone ("can livelock" in its own enum doc), and safety was expressed as a post-hoc heuristic (`is_livelock_safe` = max 3 consecutive same-matrix ops). Proper blocked linear algebra derives block sizes **a priori** from the memory hierarchy — the schedule should be safe by construction, with validation as an invariant check. Full provenance of how the requirement was lost (executor-side partitioned credits designed and built but never wired; safety burden silently migrated to schedule ordering in Phase 4) is in #67.

## Changes

- **Resource envelope in the generator**: `MatMulScheduleGenerator::Config` gains `l3_buffer_count`/`l2_bank_count` (defaults match `ConcurrentTimingExecutor::Config`) and `max_burst_tiles()` — a per-matrix burst bound of a quarter of the smaller pool, so an A burst and a B burst are always concurrently resident with half the pool left as headroom for drains, C writebacks, and prefetch overlap.
- **Constructive BLOCKED_AB**: an outer K-block loop bounds each A/B burst to the envelope share. With a large envelope the block degenerates to the historical full-K ordering; with a constrained envelope the K loop chunks. Total work is unchanged (LOAD:MOVE:FEED stay 1:1:1).
- **Capacity-aware safety check**: `is_livelock_safe(schedule, l3_credits, l2_credits)` verifies the constructive residency bound — comparing consecutive *operations* against `2 × share` since each resident tile contributes LOAD+MOVE to a burst. The capacity-blind heuristic overload remains for callers without an envelope.
- **`run_matmul`** generates against the executor's envelope and reports it in the livelock analysis.

## Verification

- Full suite: **99/99 pass**, including new envelope sections (constrained/large/degenerate) and a constrained-envelope execution regression (BLOCKED_AB 128³ at L3=8/L2=16 → completes, livelock-safe YES).
- `run_matmul --strategy blocked --l3-buffers 8` at 128³: **livelock-safe YES, SUCCESS, 10435 cycles** (vs 8041 at L3=32 — the chunking cost is visible and honest).
- Session log: `docs/sessions/2026-07-11_v0.9_envelope_aware_blocked_schedule.md`.

## Follow-ups (tracked in #67)

- Wire `PartitionedCreditPool` into the executor per the original design (defense-in-depth for hand-written schedules).
- Extend the envelope to conv2d/softmax/norm generators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added resource-envelope-aware matrix multiplication schedule generation, deriving burst behavior from available L3 buffers and L2 banks.
  - Enhanced livelock safety validation with an explicit envelope-aware check and updated reporting for YES/NO safety results.
- **Bug Fixes**
  - Updated blocked scheduling behavior to be livelock-safe under constrained resource configurations.
- **Documentation**
  - Added a decision log and updated changelog notes describing the envelope-aware scheduling and safety approach.
- **Tests**
  - Added and extended tests to verify envelope-derived burst bounds, livelock-safety, and successful execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->