### PR TITLE
feat: DNN Milestone M1 - MLP baseline demo, benchmark, and writeup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DNN Milestone M1: MLP baseline demo + benchmark (#129).**
+  `examples/milestones/m1_mlp_baseline` packages the first rung of the DNN
+  milestone ladder: XOR 2-4-1 (exact expected outputs) and the canonical
+  MNIST-shape 784-128-64-10 MLP (deterministic synthetic weights,
+  host-oracle validated to 0.0 max abs error) executing with real values on
+  the CSP credit-dataflow pipeline. Benchmarks batch sweep 16/64/256
+  (752 -> 94 cycles/sample amortization) and pipeline sweep; `--trace-dir`
+  exports Chrome traces of the credit dataflow; registered as a CI test so
+  the milestone cannot regress. Writeup with measured numbers:
+  `docs/milestones/M1_mlp_baseline.md`. Supporting: FunctionalMLPExecutor
+  gains `set_trace_file()` and full per-component timing statistics.
+
 - **CSP timing: resource-envelope-aware schedule generation (#67).**
   `MatMulScheduleGenerator::Config` gains a resource envelope
   (`l3_buffer_count`/`l2_bank_count`, defaults matching the executor) and a

--- a/docs/milestones/M1_mlp_baseline.md
+++ b/docs/milestones/M1_mlp_baseline.md
@@ -66,10 +66,11 @@ streamers, 32 L3 buffers / 64 L2 banks; *minimal* = one of everything,
 
 ## What the numbers say
 
-- **Validation is exact.** Max absolute error is 0.0 across all runs: the
-  CSP compute path performs the same fp32 operations as the oracle, in
-  matching accumulation order — the value plane is bit-faithful, not
-  approximately right.
+- **Validation is exact on every tested output.** Max absolute error is
+  0.0 across all runs — every output element equals the host oracle's
+  bit-for-bit. (This establishes output equality, consistent with the CSP
+  compute performing equivalent fp32 arithmetic; internal operation order
+  is not separately instrumented.)
 - **Batch amortization is the headline curve:** 752 → 189 → 94
   cycles/sample from batch 16 → 64 → 256. Weight movement is paid once per
   layer regardless of batch, so larger batches amortize it — the expected

--- a/docs/milestones/M1_mlp_baseline.md
+++ b/docs/milestones/M1_mlp_baseline.md
@@ -1,0 +1,110 @@
+# DNN Milestone M1: MLP Baseline on the CSP Executor
+
+**Milestone:** M1 (issue #129) — first rung of the DNN milestone ladder
+(`docs/plans/csp_pattern_coverage_roadmap.md`, Section 6)
+**Date:** 2026-07-11
+**Demo:** `build/examples/milestones/m1_mlp_baseline`
+**Status:** Demonstrate ✓ Validate ✓ Benchmark ✓
+
+---
+
+## What this milestone shows
+
+Multi-layer perceptron inference executing **with real values on the
+credit-based dataflow pipeline** — not a host-side reference with a timing
+overlay, but actual floating-point tiles traversing
+DRAM → L3 → L2 → compute → L2 → L3 → DRAM under credit/tag-CAM flow
+control, with intermediate activations staying resident in compute storage
+between layers. Every output element is validated against an independent
+host oracle.
+
+Two networks:
+
+- **XOR 2-4-1** — the classic sanity network with hand-derived weights and
+  exact expected outputs. Small enough to read its entire credit-dataflow
+  trace event by event: the educational artifact.
+- **MNIST-shape 784-128-64-10** — the canonical MNIST MLP topology with
+  deterministic synthetic weights (fixed-seed LCG, reproducible on any
+  platform), validated elementwise against a host reference forward pass.
+  Real trained weights are a drop-in once a weight-loading path lands
+  (E5/E15 scope).
+
+## Reproduce
+
+```bash
+cmake --preset release && cmake --build --preset release --target m1_mlp_baseline
+./build/examples/milestones/m1_mlp_baseline                    # benchmark table
+./build/examples/milestones/m1_mlp_baseline --trace-dir traces # + Chrome traces
+```
+
+Traces open at https://ui.perfetto.dev — lanes show the memory controller,
+DMA, BlockMovers, and row/column streamers; the credit acquire/release and
+tile-arrival events make the dataflow protocol visible. The demo is also a
+CI test (`ctest -R m1_mlp_baseline`), so this milestone cannot silently
+regress.
+
+## Measured results
+
+Linux x86-64, gcc 13, release build, simulator commit at time of writing.
+Cycles are simulated KPU cycles (1 GHz reference clock). Stall columns are
+aggregate per-component-category cycles (a stalled component's wait cycles
+overlap other components' useful work — high stall counts with completed
+work indicate pipeline slack, not failure).
+
+| configuration | batch | cycles | cyc/sample | DMA stalls | BM stalls | STR stalls | max abs err | check |
+|---|---|---|---|---|---|---|---|---|
+| XOR 2-4-1 (minimal pipeline) | 4 | 235 | 58.8 | 0 | 286 | 175 | 0.0 | PASS |
+| XOR 2-4-1 (default pipeline) | 4 | 235 | 58.8 | 0 | 425 | 175 | 0.0 | PASS |
+| MNIST-shape (default pipeline) | 16 | 12,028 | 751.8 | 0 | 12,211 | 8,625 | 0.0 | PASS |
+| MNIST-shape (default pipeline) | 64 | 12,083 | 188.8 | 0 | 12,229 | 11,565 | 0.0 | PASS |
+| MNIST-shape (default pipeline) | 256 | 24,019 | 93.8 | 0 | 24,015 | 23,325 | 0.0 | PASS |
+| MNIST-shape (minimal pipeline) | 64 | 16,247 | 253.9 | 0 | 3,710 | 15,762 | 0.0 | PASS |
+
+Pipeline configurations: *default* = 1 MC, 1 DMA, 4 BlockMovers, 2+2
+streamers, 32 L3 buffers / 64 L2 banks; *minimal* = one of everything,
+4 L3 / 4 L2.
+
+## What the numbers say
+
+- **Validation is exact.** Max absolute error is 0.0 across all runs: the
+  CSP compute path performs the same fp32 operations as the oracle, in
+  matching accumulation order — the value plane is bit-faithful, not
+  approximately right.
+- **Batch amortization is the headline curve:** 752 → 189 → 94
+  cycles/sample from batch 16 → 64 → 256. Weight movement is paid once per
+  layer regardless of batch, so larger batches amortize it — the expected
+  bandwidth-vs-reuse behavior, now measurable on the KPU pipeline.
+- **Pipeline parallelism is visible:** the minimal pipeline pays ~34% more
+  cycles (16,247 vs 12,083 at batch 64), isolating the contribution of
+  parallel BlockMovers/streamers to overlap.
+- **Zero DMA credit stalls everywhere:** at this scale the pipeline is
+  never starved for L3 buffers; the BM/STR stall counts reflect components
+  idling while waiting for upstream tiles — slack, not contention. The
+  constrained-envelope stress story starts at M2 where working sets exceed
+  the pools.
+
+## Honest limitations (what M1 is not)
+
+- **Single tile per matrix.** Each layer's activation/weight matrix moves
+  as one tile (e.g., the 784×128 weight matrix is one 401 KB payload).
+  Functional behavior and movement ordering are real; the *tiled*
+  decomposition against 64 KB buffers — and the timing fidelity that comes
+  with it — is exactly what the E5 (GEMM family) and E10 (fused epilogue)
+  epics add. M1 numbers are a baseline, not a performance claim.
+- **Compute latency is envelope-level.** Per-tile compute cost does not yet
+  scale with the 784-deep reduction inside a single tile (K-scaling exists
+  at tile granularity, per #63); tiled M2+ milestones inherit the full
+  model.
+- **Synthetic weights** for the MNIST-shape network (deterministic, oracle-
+  validated). Classification-accuracy demos need the weight-loading path.
+
+## Milestone ledger
+
+| Tier | Evidence |
+|---|---|
+| Demonstrate | end-to-end CSP execution; Chrome traces via `--trace-dir` (XOR trace ~100 KB — readable; MNIST b64 ~46k events) |
+| Validate | elementwise oracle comparison, tolerance 1e-4, measured 0.0 |
+| Benchmark | table above: batch sweep 16/64/256, pipeline sweep, stall breakdown; regenerable with one command |
+
+Next rung: **M2 ResNet-18** (#130) — needs Wave 1 (conv2d family, pooling,
+GEMM completion) plus the CNN half of Wave 2 (BN fold, fused epilogue).

--- a/docs/sessions/2026-07-11_v0.9_m1_mlp_baseline_milestone.md
+++ b/docs/sessions/2026-07-11_v0.9_m1_mlp_baseline_milestone.md
@@ -1,0 +1,79 @@
+# v0.9 DNN Milestone M1 Packaging Decision Log
+
+**Date:** 2026-07-11
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 100/100 suites passing (new: m1_mlp_baseline CI test)
+**Issue:** #129 (milestone ladder rung M1)
+
+## 1. Summary
+
+Packaged M1 - the MLP baseline - as the first public-facing artifact of the
+DNN milestone ladder: a demo binary exercising all three DoD tiers
+(demonstrate via Chrome traces of the credit dataflow, validate via
+elementwise host-oracle comparison, benchmark via batch and pipeline
+sweeps), plus a writeup with measured numbers in docs/milestones/.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| `examples/milestones/m1_mlp_baseline` demo (XOR + MNIST-shape) | Done |
+| Host reference oracle + elementwise validation (0.0 max abs err) | Done |
+| Batch sweep 16/64/256 + pipeline sweep benchmark table | Done |
+| Chrome trace export (`--trace-dir`, verified valid Perfetto JSON) | Done |
+| CI test registration (`ctest -R m1_mlp_baseline`) | Done |
+| Writeup `docs/milestones/M1_mlp_baseline.md` with measured numbers | Done |
+| `FunctionalMLPExecutor::set_trace_file()` + full timing stats | Done |
+
+Files modified:
+- `include/sw/kpu/timing/functional_mlp_executor.hpp` (implementation)
+- `examples/milestones/m1_mlp_baseline.cpp` (new)
+- `examples/milestones/CMakeLists.txt` (new), `examples/CMakeLists.txt`
+- `docs/milestones/M1_mlp_baseline.md` (new)
+- `CHANGELOG.md`
+- `docs/sessions/2026-07-11_v0.9_m1_mlp_baseline_milestone.md` (this log)
+
+## 3. Technical Decisions
+
+**Decision 1: MNIST-shape with deterministic synthetic weights, not
+trained weights.** A fixed-seed LCG generates reproducible weights on any
+platform; validation is against a host oracle computing the same network.
+Rationale: M1's claim is "real values through the real pipeline, exactly
+right" - classification accuracy adds a weight-loading dependency (E5/E15
+scope) without strengthening that claim. Documented as an honest
+limitation.
+
+**Decision 2: trace export from inside forward().** The
+FunctionalMLPExecutor constructs its executor per-call; `set_trace_file()`
+makes forward() export before destruction rather than exposing the
+executor.
+
+**Decision 3: honest-limitations section in the writeup.** Single tile per
+matrix (401 KB weight tile vs 64 KB buffers), envelope-level compute
+latency, synthetic weights - stated explicitly so the baseline is credible
+to researchers rather than overclaiming.
+
+## 4. Issues Encountered
+
+None - the #66/#65 machinery carried the milestone without new defects.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                                   # 100/100 pass
+./build/examples/milestones/m1_mlp_baseline              # all PASS, 0.0 err
+./build/examples/milestones/m1_mlp_baseline --trace-dir traces
+```
+
+## 7. Next Steps
+
+- M2 ResNet-18 (#130): needs Wave 1 epics (conv2d #75, pooling #76, GEMM
+  completion #74) + BN fold (#78) and fused epilogue (#79).
+- Weight-loading path (E5/E15) upgrades M1's MNIST-shape run to real
+  trained weights and a classification-accuracy demo.

--- a/docs/sessions/2026-07-11_v0.9_m1_mlp_baseline_milestone.md
+++ b/docs/sessions/2026-07-11_v0.9_m1_mlp_baseline_milestone.md
@@ -37,22 +37,37 @@ Files modified:
 ## 3. Technical Decisions
 
 **Decision 1: MNIST-shape with deterministic synthetic weights, not
-trained weights.** A fixed-seed LCG generates reproducible weights on any
-platform; validation is against a host oracle computing the same network.
-Rationale: M1's claim is "real values through the real pipeline, exactly
-right" - classification accuracy adds a weight-loading dependency (E5/E15
-scope) without strengthening that claim. Documented as an honest
-limitation.
+trained weights.**
+- **Choice:** fixed-seed LCG weights, reproducible on any platform;
+  validation against a host oracle computing the same network.
+- **Alternatives considered:** (a) real trained MNIST weights - requires a
+  weight-loading path that is E5/E15 scope and would add a file-format
+  dependency to a baseline demo; (b) random weights via std::mt19937 -
+  reproducible only per-platform (distribution implementations differ
+  across standard libraries).
+- **Rationale:** M1's claim is "real values through the real pipeline,
+  exactly right"; classification accuracy does not strengthen that claim.
+  Documented as an honest limitation.
 
-**Decision 2: trace export from inside forward().** The
-FunctionalMLPExecutor constructs its executor per-call; `set_trace_file()`
-makes forward() export before destruction rather than exposing the
-executor.
+**Decision 2: trace export from inside forward().**
+- **Choice:** `set_trace_file()`; forward() exports before its
+  per-call executor is destroyed.
+- **Alternatives considered:** (a) expose the executor to callers - leaks
+  the executor's lifetime out of the class and invites use-after-scope;
+  (b) reconstruct a trace from the retained events_ copy - duplicates the
+  exporter's metadata logic (component naming, sort indices) outside the
+  executor.
+- **Rationale:** smallest surface that keeps the exporter authoritative.
 
-**Decision 3: honest-limitations section in the writeup.** Single tile per
-matrix (401 KB weight tile vs 64 KB buffers), envelope-level compute
-latency, synthetic weights - stated explicitly so the baseline is credible
-to researchers rather than overclaiming.
+**Decision 3: honest-limitations section in the writeup.**
+- **Choice:** state single-tile-per-matrix (401 KB weight tile vs 64 KB
+  buffers), envelope-level compute latency, and synthetic weights
+  explicitly.
+- **Alternatives considered:** omit and let the numbers speak - rejected;
+  researchers will find the single-tile abstraction immediately, and an
+  overclaimed baseline damages exactly the credibility the milestone
+  ladder is meant to build.
+- **Rationale:** credible baseline > impressive baseline.
 
 ## 4. Issues Encountered
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -55,6 +55,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/dataflow)
     add_subdirectory(dataflow)
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/milestones)
+    add_subdirectory(milestones)
+endif()
+
 if(KPU_BUILD_PYTHON_BINDINGS)
     # Python examples are handled by the Python package
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/python)

--- a/examples/milestones/CMakeLists.txt
+++ b/examples/milestones/CMakeLists.txt
@@ -1,0 +1,20 @@
+# ============================================================================
+# examples/milestones/CMakeLists.txt
+# DNN milestone demos (plan: docs/plans/csp_pattern_coverage_roadmap.md §6)
+#
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+# ============================================================================
+
+# M1: MLP baseline demo + benchmark (issue #129)
+add_executable(m1_mlp_baseline m1_mlp_baseline.cpp)
+target_link_libraries(m1_mlp_baseline PRIVATE kpu_simulator)
+set_target_properties(m1_mlp_baseline PROPERTIES
+    FOLDER "Examples/Milestones"
+)
+if(KPU_BUILD_TESTS)
+    add_test(NAME m1_mlp_baseline COMMAND m1_mlp_baseline)
+    set_tests_properties(m1_mlp_baseline PROPERTIES
+        LABELS "timing;mlp;milestone;v0.9"
+    )
+endif()

--- a/examples/milestones/m1_mlp_baseline.cpp
+++ b/examples/milestones/m1_mlp_baseline.cpp
@@ -1,0 +1,253 @@
+/**
+ * @file m1_mlp_baseline.cpp
+ * @brief DNN Milestone M1: MLP baseline demo + benchmark on the CSP executor.
+ *
+ * The first rung of the DNN milestone ladder (issue #129, plan Section 6):
+ * MLP inference with real values flowing through the credit-based dataflow
+ * pipeline (DRAM -> L3 -> L2 -> compute -> L2 -> L3 -> DRAM).
+ *
+ * Three-tier definition of done, all exercised here:
+ *  - Demonstrate: end-to-end CSP execution; --trace-dir exports Chrome
+ *    traces of the credit dataflow (view at https://ui.perfetto.dev)
+ *  - Validate: elementwise comparison against a host reference oracle
+ *    (exact expected outputs for XOR; computed oracle for the MNIST-shape
+ *    network with deterministic synthetic weights)
+ *  - Benchmark: cycles, cycles/sample, stall breakdown across batch sizes
+ *    and pipeline configurations
+ *
+ * Usage:
+ *   m1_mlp_baseline [--trace-dir DIR]
+ *
+ * Writeup: docs/milestones/M1_mlp_baseline.md
+ */
+
+#include <sw/kpu/timing/functional_mlp_executor.hpp>
+
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using sw::kpu::timing::ConcurrentTimingExecutor;
+using sw::kpu::timing::FunctionalMLPExecutor;
+using sw::kpu::timing::Size;
+using Activation = ConcurrentTimingExecutor::FunctionalActivation;
+
+namespace {
+
+// ============================================================================
+// Deterministic synthetic weights (fixed-seed LCG - reproducible everywhere)
+// ============================================================================
+
+class Lcg {
+public:
+    explicit Lcg(uint64_t seed) : state_(seed) {}
+    float next_weight() {
+        state_ = state_ * 6364136223846793005ULL + 1442695040888963407ULL;
+        // Map the top bits to [-0.1, 0.1] - small weights keep activations
+        // in a numerically comfortable range through three layers
+        auto bits = static_cast<uint32_t>(state_ >> 33);
+        return (static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * 0.1f;
+    }
+
+private:
+    uint64_t state_;
+};
+
+std::vector<float> synthetic(size_t count, uint64_t seed) {
+    Lcg lcg(seed);
+    std::vector<float> v(count);
+    for (auto& x : v) x = lcg.next_weight();
+    return v;
+}
+
+// ============================================================================
+// Host reference oracle: plain-loop forward pass over the same layer specs
+// ============================================================================
+
+std::vector<float> reference_forward(const std::vector<FunctionalMLPExecutor::Layer>& layers,
+                                     const std::vector<float>& input, Size batch) {
+    std::vector<float> current = input;
+    for (const auto& layer : layers) {
+        std::vector<float> next(static_cast<size_t>(batch) * layer.output_dim, 0.0f);
+        for (Size b = 0; b < batch; ++b) {
+            for (Size o = 0; o < layer.output_dim; ++o) {
+                float acc = layer.bias.empty() ? 0.0f : layer.bias[o];
+                for (Size i = 0; i < layer.input_dim; ++i) {
+                    acc += current[b * layer.input_dim + i] *
+                           layer.weights[i * layer.output_dim + o];
+                }
+                if (layer.activation == Activation::RELU && acc < 0.0f) acc = 0.0f;
+                next[b * layer.output_dim + o] = acc;
+            }
+        }
+        current = std::move(next);
+    }
+    return current;
+}
+
+// ============================================================================
+// Benchmark harness
+// ============================================================================
+
+struct RunResult {
+    std::string name;
+    Size batch = 0;
+    bool pass = false;
+    float max_abs_err = 0.0f;
+    FunctionalMLPExecutor::Statistics stats;
+};
+
+ConcurrentTimingExecutor::Config pipeline_config(bool minimal) {
+    ConcurrentTimingExecutor::Config config;
+    if (minimal) {
+        config.num_memory_controllers = 1;
+        config.num_dma_engines = 1;
+        config.num_block_movers = 1;
+        config.num_row_streamers = 1;
+        config.num_col_streamers = 1;
+        config.l3_buffer_count = 4;
+        config.l2_bank_count = 4;
+    }
+    // Defaults otherwise: 1 MC, 1 DMA, 4 BM, 2+2 streamers, 32 L3, 64 L2
+    config.max_cycles = 10'000'000;
+    return config;
+}
+
+RunResult run_mlp(const std::string& name,
+                  FunctionalMLPExecutor& mlp,
+                  const std::vector<float>& input, Size batch,
+                  const std::vector<float>& expected,
+                  const std::string& trace_file) {
+    if (!trace_file.empty()) mlp.set_trace_file(trace_file);
+
+    RunResult r;
+    r.name = name;
+    r.batch = batch;
+    const auto output = mlp.forward(input, batch);
+
+    r.pass = output.size() == expected.size();
+    for (size_t i = 0; i < output.size() && i < expected.size(); ++i) {
+        float err = std::fabs(output[i] - expected[i]);
+        if (err > r.max_abs_err) r.max_abs_err = err;
+    }
+    // MNIST-shape magnitudes stay O(1) with the synthetic weight scale, so a
+    // uniform absolute tolerance is appropriate for fp32 accumulation depths
+    // up to 784
+    r.pass = r.pass && r.max_abs_err < 1e-4f;
+    r.stats = mlp.statistics();
+    return r;
+}
+
+RunResult run_xor(bool minimal_pipeline, const std::string& trace_file) {
+    FunctionalMLPExecutor mlp(pipeline_config(minimal_pipeline));
+    mlp.add_layer(2, 4,
+        {1.0f, 1.0f, -1.0f, -1.0f,
+         1.0f, 1.0f, -1.0f, -1.0f},
+        {-0.5f, -1.5f, 0.5f, 1.5f},
+        Activation::RELU, "hidden");
+    mlp.add_layer(4, 1, {2.0f, -6.0f, 0.0f, 0.0f}, {0.0f},
+        Activation::NONE, "output");
+
+    const std::vector<float> input = {0, 0, 0, 1, 1, 0, 1, 1};
+    const std::vector<float> expected = {0.0f, 1.0f, 1.0f, 0.0f};
+    std::string name = std::string("XOR 2-4-1 ") +
+                       (minimal_pipeline ? "(minimal pipeline)" : "(default pipeline)");
+    return run_mlp(name, mlp, input, 4, expected, trace_file);
+}
+
+RunResult run_mnist_shape(Size batch, bool minimal_pipeline,
+                          const std::string& trace_file) {
+    // The canonical MNIST MLP shape: 784 -> 128 -> 64 -> 10, synthetic
+    // deterministic weights, oracle-validated. Real trained weights are a
+    // drop-in once a weight-loading path lands (E5/E15 scope).
+    FunctionalMLPExecutor mlp(pipeline_config(minimal_pipeline));
+    mlp.add_layer(784, 128, synthetic(784 * 128, 1), synthetic(128, 2),
+                  Activation::RELU, "fc1");
+    mlp.add_layer(128, 64, synthetic(128 * 64, 3), synthetic(64, 4),
+                  Activation::RELU, "fc2");
+    mlp.add_layer(64, 10, synthetic(64 * 10, 5), synthetic(10, 6),
+                  Activation::NONE, "logits");
+
+    const auto input = synthetic(static_cast<size_t>(batch) * 784, 7 + batch);
+    const auto expected = reference_forward(mlp.layers(), input, batch);
+
+    std::string name = "MNIST-shape 784-128-64-10 " +
+                       std::string(minimal_pipeline ? "(minimal pipeline)" : "(default pipeline)");
+    return run_mlp(name, mlp, input, batch, expected, trace_file);
+}
+
+void print_row(const RunResult& r) {
+    const auto& t = r.stats.timing;
+    double per_sample = r.batch > 0
+        ? static_cast<double>(r.stats.total_cycles) / r.batch : 0.0;
+    std::cout << "  " << std::left << std::setw(44) << r.name
+              << std::right
+              << std::setw(6) << r.batch
+              << std::setw(10) << r.stats.total_cycles
+              << std::setw(12) << std::fixed << std::setprecision(1) << per_sample
+              << std::setw(9) << t.dma_credit_stalls
+              << std::setw(9) << (t.bm_tag_stalls + t.bm_credit_stalls)
+              << std::setw(9) << (t.str_tag_stalls + t.str_credit_stalls)
+              << std::setw(12) << std::scientific << std::setprecision(1)
+              << r.max_abs_err
+              << std::setw(7) << (r.pass ? "PASS" : "FAIL") << "\n"
+              << std::defaultfloat;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    std::string trace_dir;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--trace-dir") == 0 && i + 1 < argc) {
+            trace_dir = argv[++i];
+        } else {
+            std::cout << "Usage: " << argv[0] << " [--trace-dir DIR]\n";
+            return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
+        }
+    }
+    auto trace = [&](const std::string& base) {
+        return trace_dir.empty() ? std::string{} : trace_dir + "/" + base + ".json";
+    };
+
+    std::cout << "\n"
+        "======================================================================\n"
+        "DNN Milestone M1: MLP baseline on the CSP concurrent timing executor\n"
+        "Values flow through the real credit-dataflow pipeline; results are\n"
+        "validated elementwise against a host reference oracle.\n"
+        "======================================================================\n\n";
+
+    std::vector<RunResult> results;
+    results.push_back(run_xor(true, trace("m1_xor_minimal")));
+    results.push_back(run_xor(false, trace("m1_xor_default")));
+    results.push_back(run_mnist_shape(16, false, trace("m1_mnist_b16")));
+    results.push_back(run_mnist_shape(64, false, trace("m1_mnist_b64")));
+    results.push_back(run_mnist_shape(256, false, trace("m1_mnist_b256")));
+    results.push_back(run_mnist_shape(64, true, trace("m1_mnist_b64_minimal")));
+
+    std::cout << "  " << std::left << std::setw(44) << "configuration"
+              << std::right << std::setw(6) << "batch"
+              << std::setw(10) << "cycles" << std::setw(12) << "cyc/sample"
+              << std::setw(9) << "dmaStl" << std::setw(9) << "bmStl"
+              << std::setw(9) << "strStl" << std::setw(12) << "maxAbsErr"
+              << std::setw(7) << "check" << "\n";
+    std::cout << "  " << std::string(116, '-') << "\n";
+
+    bool all_pass = true;
+    for (const auto& r : results) {
+        print_row(r);
+        all_pass = all_pass && r.pass;
+    }
+
+    std::cout << "\n  Validation: " << (all_pass ? "ALL PASS" : "FAILURES PRESENT")
+              << " (oracle: host reference forward pass, tolerance 1e-4)\n";
+    if (!trace_dir.empty()) {
+        std::cout << "  Chrome traces written to " << trace_dir
+                  << "/ - view at https://ui.perfetto.dev\n";
+    }
+    std::cout << "\n";
+    return all_pass ? 0 : 1;
+}

--- a/examples/milestones/m1_mlp_baseline.cpp
+++ b/examples/milestones/m1_mlp_baseline.cpp
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -207,6 +208,17 @@ int main(int argc, char* argv[]) {
         } else {
             std::cout << "Usage: " << argv[0] << " [--trace-dir DIR]\n";
             return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
+        }
+    }
+    if (!trace_dir.empty()) {
+        // The trace exporter opens the path directly; create the directory
+        // so a fresh checkout does not silently produce no files
+        std::error_code ec;
+        std::filesystem::create_directories(trace_dir, ec);
+        if (ec) {
+            std::cerr << "Cannot create trace directory '" << trace_dir
+                      << "': " << ec.message() << "\n";
+            return 1;
         }
     }
     auto trace = [&](const std::string& base) {

--- a/include/sw/kpu/timing/functional_mlp_executor.hpp
+++ b/include/sw/kpu/timing/functional_mlp_executor.hpp
@@ -40,10 +40,22 @@ public:
         Cycle total_cycles = 0;
         Cycle total_stall_cycles = 0;
         size_t layers_completed = 0;
+        /// Full per-component breakdown from the underlying executor
+        /// (stall categories, tile throughput, bytes, utilization)
+        ConcurrentTimingExecutor::Statistics timing;
     };
 
     explicit FunctionalMLPExecutor(ConcurrentTimingExecutor::Config config = {})
         : config_(std::move(config)) {}
+
+    /**
+     * @brief Export a Chrome trace of the next forward() to this path
+     *
+     * The executor lives only for the duration of forward(); setting a trace
+     * file makes forward() export the credit-dataflow trace before the
+     * executor is destroyed. View at https://ui.perfetto.dev
+     */
+    void set_trace_file(std::string path) { trace_path_ = std::move(path); }
 
     void add_layer(Size input_dim, Size output_dim,
                    std::vector<float> weights,
@@ -123,7 +135,11 @@ public:
                                     timing.bm_credit_stalls + timing.str_tag_stalls +
                                     timing.str_credit_stalls;
         stats_.layers_completed = layers_.size();
+        stats_.timing = timing;
         events_ = executor.events();
+        if (!trace_path_.empty()) {
+            executor.export_chrome_trace(trace_path_);
+        }
         return executor.tile_payload_at(MemoryLevel::DRAM, current.tile_id).values;
     }
 
@@ -136,6 +152,7 @@ private:
     std::vector<Layer> layers_;
     Statistics stats_;
     std::vector<TimingEvent> events_;
+    std::string trace_path_;
 
     [[nodiscard]] static TileDescriptor make_tile(isa::MatrixID matrix,
                                                   Size rows, Size cols,


### PR DESCRIPTION
Packages **DNN Milestone M1** (#129) — the first rung of the milestone ladder from `docs/plans/csp_pattern_coverage_roadmap.md` §6 — as a public-facing demo + benchmark + writeup.

## Deliverables

- **`examples/milestones/m1_mlp_baseline`** (new milestone demo family):
  - XOR 2-4-1 with exact expected outputs — the readable educational trace
  - MNIST-shape 784-128-64-10 with deterministic synthetic weights (fixed-seed LCG, reproducible anywhere), validated elementwise against a host oracle
  - batch sweep (16/64/256) + pipeline sweep (minimal vs default), stall breakdown per run
  - `--trace-dir` exports Chrome traces of the credit dataflow (verified valid Perfetto JSON)
  - registered as a CI test (`ctest -R m1_mlp_baseline`) so the milestone cannot silently regress
- **`docs/milestones/M1_mlp_baseline.md`** — writeup with measured numbers, interpretation, and an honest-limitations section (single tile per matrix, envelope-level compute latency, synthetic weights — the things E5/E10/E15 will fix).
- **`FunctionalMLPExecutor`**: `set_trace_file()` (executor is per-forward(), so the trace exports before destruction) and full per-component timing statistics.

## Measured results

| configuration | batch | cycles | cyc/sample | max abs err |
|---|---|---|---|---|
| XOR 2-4-1 | 4 | 235 | 58.8 | 0.0 |
| MNIST-shape (default) | 16 | 12,028 | 751.8 | 0.0 |
| MNIST-shape (default) | 64 | 12,083 | 188.8 | 0.0 |
| MNIST-shape (default) | 256 | 24,019 | 93.8 | 0.0 |
| MNIST-shape (minimal pipeline) | 64 | 16,247 | 253.9 | 0.0 |

Validation is **exact** (0.0 max abs error — the CSP value plane is bit-faithful to the oracle). The batch-amortization curve (752 → 94 cycles/sample) and the ~34% pipeline-parallelism delta are the headline benchmark stories.

## Verification

Full suite: 100/100 pass (new M1 test included). Session log: `docs/sessions/2026-07-11_v0.9_m1_mlp_baseline_milestone.md`.

Closes the packaging scope of #129 (the milestone issue itself can close on merge or stay open until real-trained-weight upgrade — maintainer's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the M1 MLP baseline demo with XOR and MNIST-shaped benchmark scenarios (including deterministic synthetic weights).
  * Added host-oracle validation with strict max-absolute-error checking and detailed performance/stall summaries.
  * Added optional Chrome/Perfetto trace export for each run.
  * Registered the milestone example for builds/tests (when test builds are enabled).

* **Documentation**
  * Added milestone and session decision-log documentation, including reproduction steps, trace notes, and measured benchmark results/limitations.
  * Updated the unreleased changelog entry for the M1 milestone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->