### PR TITLE
feat: wire PartitionedCreditPool into the CSP executor (per-matrix credits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CSP timing: per-matrix credit partitioning wired into the executor
+  (#89, Wave 0 of the pattern-coverage program).** `CreditPool` gains an
+  opt-in partition mode backed by `PartitionedCreditPool` (equal A/B/C
+  split, remainder to C): indexed `acquire/release/available(partition)`
+  overloads match `isa::MatrixID` values and behave identically to the
+  shared calls when unpartitioned, so all processes were converted once
+  and work in both modes; un-indexed calls throw in partition mode to
+  catch missed conversions. `ConcurrentTimingExecutor::Config` gains
+  `partition_l3_credits`/`partition_l2_credits` (default off - partitioning
+  intentionally forbids single-matrix workloads from filling the whole
+  pool); `run_matmul` gains `--partition-credits`. Restores the original
+  v0.9 design's structural livelock prevention: an adversarial A-load
+  flood can no longer starve B traffic (regression-tested both ways), and
+  the full strategy matrix passes partitioned - measurably faster at
+  128^3 (7,132 vs 8,034 cycles) because partitioning curbs greedy
+  prefetch over-filling L3.
+
 - **DNN Milestone M1: MLP baseline demo + benchmark (#129).**
   `examples/milestones/m1_mlp_baseline` packages the first rung of the DNN
   milestone ladder: XOR 2-4-1 (exact expected outputs) and the canonical

--- a/docs/sessions/2026-07-11_v0.9_partitioned_credit_wiring.md
+++ b/docs/sessions/2026-07-11_v0.9_partitioned_credit_wiring.md
@@ -1,0 +1,105 @@
+# v0.9 PartitionedCreditPool Wiring Decision Log
+
+**Date:** 2026-07-11
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 100/100 suites passing (test_credit_pool +6 partition cases;
+test_multi_tile_execution +2 cases incl. starvation pair)
+**Issue:** #89 (Wave 0, epic #69)
+
+## 1. Summary
+
+Wired PartitionedCreditPool into the ConcurrentTimingExecutor, closing the
+gap identified in the #67 provenance analysis: the original v0.9 design
+specified per-matrix credit partitioning as the executor's structural
+livelock prevention, Phase 1 built the class, Phase 3 shipped the executor
+without it. CreditPool now carries an opt-in partition mode that composes a
+PartitionedCreditPool; all processes use matrix-indexed acquire/release
+that behave identically in shared mode, so the change is fully
+backward-compatible (100/100 pre-existing tests unchanged).
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| CreditPool partition mode (partition_equal/partition, indexed ops) | Done |
+| DMA/BlockMover/Streamer matrix-indexed credit calls (10 sites) | Done |
+| Executor Config knobs + constructor wiring | Done |
+| run_matmul --partition-credits | Done |
+| Unit tests (isolation, throws, reset, custom shares) | Done |
+| Defense-in-depth starvation test (shared starves, partitioned doesn't) | Done |
+| Partitioned strategy-matrix regression | Done |
+
+Files modified:
+- `include/sw/kpu/timing/credit_pool.hpp` (implementation)
+- `include/sw/kpu/timing/dma_engine_process.hpp` (implementation)
+- `include/sw/kpu/timing/block_mover_process.hpp` (implementation)
+- `include/sw/kpu/timing/streamer_process.hpp` (implementation)
+- `include/sw/kpu/timing/concurrent_timing_executor.hpp` (implementation)
+- `examples/schedule/run_matmul.cpp` (--partition-credits)
+- `tests/timing/test_credit_pool.cpp`, `tests/timing/test_multi_tile_execution.cpp`
+- `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: partition mode inside CreditPool, not new process signatures**
+- **Choice:** CreditPool composes an optional PartitionedCreditPool;
+  indexed acquire/release/available(partition) overloads (0=A, 1=B, 2+=C,
+  matching isa::MatrixID) delegate to the partition in partitioned mode and
+  to the shared counters otherwise.
+- **Alternatives considered:** (a) processes take PartitionedCreditPool& -
+  breaks every process constructor and unit test, and loses shared mode;
+  (b) a polymorphic ICreditSource interface - virtual dispatch in the
+  per-cycle hot path and the same constructor churn; (c) processes hold
+  either pool via variant - call-site branching in every process.
+- **Rationale:** call sites are written once and correct in both modes;
+  zero signature churn; the un-indexed calls throwing in partition mode
+  turns any missed conversion into an immediate, loud failure.
+
+**Decision 2: partition index = size_t, not isa::MatrixID**
+- **Choice:** credit_pool.hpp stays free of the isa dependency; processes
+  pass static_cast<size_t>(tile_id.matrix) (A=0, B=1, C=2 verified).
+- **Alternative considered:** overload on isa::MatrixID directly - couples
+  the foundational primitive header to the ISA header.
+
+**Decision 3: default OFF**
+- **Choice:** partition_l3_credits/partition_l2_credits default false.
+- **Alternatives considered:** default ON - breaks legitimate
+  single-matrix workloads (pure DMA streaming tests fill the whole pool by
+  design; the same failure mode the #61-era reserve experiment hit).
+- **Rationale:** partitioning is defense-in-depth for hand-written or
+  dynamic schedules; the shipped generators are constructively safe (#67)
+  without it. Opt-in, with the regression matrix exercising it ON.
+
+## 4. Issues Encountered
+
+1. Namespace slip in the new test (isa::MatrixID vs the file's imported
+   MatrixID) - compile error under -Werror, fixed immediately.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                                        # 100/100
+./build/examples/schedule/run_matmul --partition-credits      # SUCCESS
+./build/examples/schedule/run_matmul -M 128 -N 128 -K 128 \
+  --strategy blocked --partition-credits                      # SUCCESS 7132 cycles
+```
+
+Notable measurement: partitioned 128^3 runs are FASTER than shared
+(7,132 vs 8,034 cycles) - partitioning curbs the greedy DMA prefetch from
+over-filling L3 with far-future input tiles, so C writebacks proceed
+earlier. Defense-in-depth with a throughput benefit.
+
+## 7. Next Steps
+
+- Wave 0 continues: infra-T2 (#90) envelope for conv2d/softmax/norm
+  generators; infra-T3 (#91) envelope-mismatch warning; infra-T4 (#92)
+  fix #18; infra-T5 (#93) coverage-matrix scaffold; then the four pattern
+  epics E1-E4.
+- Consider partition-aware generator envelope (burst share vs partition
+  share consistency is currently implicit: min(pool)/4 <= pool/3 always).

--- a/examples/schedule/run_matmul.cpp
+++ b/examples/schedule/run_matmul.cpp
@@ -61,6 +61,7 @@ void print_usage(const char* prog) {
     std::cout << "  --validate     Run schedule validation before execution\n";
     std::cout << "  --l3-buffers <n>  L3 buffer count (default: 32)\n";
     std::cout << "  --livelock <n>    Livelock threshold cycles (default: 10000)\n";
+    std::cout << "  --partition-credits  Partition L3/L2 credits per matrix (A/B/C)\n";
     std::cout << "  -h, --help     Show this help\n";
 }
 
@@ -74,6 +75,7 @@ int main(int argc, char* argv[]) {
     std::string strategy_name = "INTERLEAVED_AB";
     std::string trace_file;
     bool validate = false;
+    bool partition_credits = false;
     size_t l3_buffers = 32;
     size_t livelock_threshold = 10000;
 
@@ -117,6 +119,8 @@ int main(int argc, char* argv[]) {
             validate = true;
         } else if (strcmp(argv[i], "--l3-buffers") == 0 && i + 1 < argc) {
             l3_buffers = std::stoull(argv[++i]);
+        } else if (strcmp(argv[i], "--partition-credits") == 0) {
+            partition_credits = true;
         } else if (strcmp(argv[i], "--livelock") == 0 && i + 1 < argc) {
             livelock_threshold = std::stoull(argv[++i]);
         } else {
@@ -235,6 +239,8 @@ int main(int argc, char* argv[]) {
     exec_config.max_cycles = 10000000;  // 10M cycles max
     exec_config.enable_livelock_detection = true;
     exec_config.livelock_threshold = livelock_threshold;
+    exec_config.partition_l3_credits = partition_credits;
+    exec_config.partition_l2_credits = partition_credits;
 
     std::cout << "  Memory controllers: " << exec_config.num_memory_controllers << "\n";
     std::cout << "  L3 buffers: " << exec_config.l3_buffer_count << "\n";

--- a/include/sw/kpu/timing/block_mover_process.hpp
+++ b/include/sw/kpu/timing/block_mover_process.hpp
@@ -246,7 +246,8 @@ private:
                 // Only release L3 credit if tile was fully removed (ref_count reached 0)
                 bool credit_released = l3_tag_cam_.invalidate(in_flight_->tile.tile_id);
                 if (credit_released) {
-                    l3_credits_.release();
+                    l3_credits_.release(
+                        static_cast<size_t>(in_flight_->tile.tile_id.matrix));
                 }
                 total_tiles_moved_++;
 
@@ -284,7 +285,8 @@ private:
                 // Only release L2 credit if tile was fully removed (ref_count reached 0)
                 bool credit_released = l2_tag_cam_.invalidate(in_flight_->tile.tile_id);
                 if (credit_released) {
-                    l2_credits_.release();
+                    l2_credits_.release(
+                        static_cast<size_t>(in_flight_->tile.tile_id.matrix));
                 }
                 total_tiles_writeback_++;
 
@@ -360,7 +362,7 @@ private:
             // Consume this move's L3 reference
             bool credit_released = l3_tag_cam_.invalidate(dedup_tile.tile_id);
             if (credit_released) {
-                l3_credits_.release();
+                l3_credits_.release(static_cast<size_t>(dedup_tile.tile_id.matrix));
             }
             total_tiles_moved_++;
 
@@ -441,11 +443,15 @@ private:
             return false;
         }
 
-        // Check if L2 credit available. Moves may not consume the reserved
-        // credits - those are kept for compute-result drains (Streamer),
-        // which otherwise starve because BlockMovers tick before Streamers.
-        if (l2_credits_.available() <= config_.l2_credit_reserve ||
-            !l2_credits_.acquire()) {
+        // Check if L2 credit available (from the tile's matrix partition
+        // when the pool is partitioned, per #89). Moves may not consume the
+        // reserved credits - those are kept for compute-result drains
+        // (Streamer), which otherwise starve because BlockMovers tick
+        // before Streamers.
+        const size_t move_part =
+            static_cast<size_t>(move_queue_.at(found_index).tile_id.matrix);
+        if (l2_credits_.available(move_part) <= config_.l2_credit_reserve ||
+            !l2_credits_.acquire(move_part)) {
             const auto& tile = move_queue_.at(found_index);
             events.push_back(TimingEvent(
                 EventType::BM_STALL_CREDIT,
@@ -550,8 +556,10 @@ private:
             return false;
         }
 
-        // Check if L3 credit available
-        if (!l3_credits_.acquire()) {
+        // Check if L3 credit available (writebacks carry C tiles, which have
+        // their own partition when the pool is partitioned, per #89)
+        if (!l3_credits_.acquire(
+                static_cast<size_t>(writeback_queue_.at(found_index).tile_id.matrix))) {
             const auto& tile = writeback_queue_.at(found_index);
             events.push_back(TimingEvent(
                 EventType::BM_STALL_CREDIT,

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -616,8 +616,15 @@ inline void ConcurrentTimingExecutor::create_components() {
         DMAEngineProcess::Config dma_config;
         dma_config.engine_id = static_cast<uint32_t>(dma);
         dma_config.queue_depth = config_.dma_queue_depth;
-        dma_config.l3_credit_reserve = Config::clamp_reserve(
-            config_.l3_writeback_credit_reserve, config_.l3_buffer_count);
+        // The writeback reserve is a heuristic guard that per-matrix
+        // partitioning supersedes structurally (the C partition IS the
+        // writeback protection). A pool-clamped reserve can also exceed a
+        // partition's share and block it permanently, so it is disabled in
+        // partition mode.
+        dma_config.l3_credit_reserve = config_.partition_l3_credits
+            ? 0
+            : Config::clamp_reserve(
+                  config_.l3_writeback_credit_reserve, config_.l3_buffer_count);
         dma_config.name = dma_config.display_name();
 
         // Assign DMA to MC (round-robin if more DMAs than MCs)
@@ -643,8 +650,13 @@ inline void ConcurrentTimingExecutor::create_components() {
         bm_config.startup_latency = config_.bm_startup_latency;
         bm_config.clock_ghz = config_.clock_ghz;
         bm_config.priority_aging = config_.enable_priority_aging;
-        bm_config.l2_credit_reserve = Config::clamp_reserve(
-            config_.l2_drain_credit_reserve, config_.l2_bank_count);
+        // Drain reserve disabled in partition mode for the same reason as
+        // the DMA writeback reserve: the C partition supersedes it, and a
+        // pool-clamped reserve can exceed a partition's share
+        bm_config.l2_credit_reserve = config_.partition_l2_credits
+            ? 0
+            : Config::clamp_reserve(
+                  config_.l2_drain_credit_reserve, config_.l2_bank_count);
         bm_config.name = bm_config.display_name();
 
         block_movers_.push_back(std::make_unique<BlockMoverProcess>(

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -128,6 +128,19 @@ public:
         bool enable_work_conserving = true;
         bool enable_priority_aging = false;
 
+        // Per-matrix credit partitioning (issue #89): partitions the L3/L2
+        // credit pools by matrix class (A/B/C, equal split with remainder
+        // to C) via PartitionedCreditPool, restoring the original v0.9
+        // design's structural livelock prevention - no matrix class can
+        // monopolize the buffers another needs, regardless of schedule
+        // ordering. Defense-in-depth for hand-written or third-party
+        // schedules; the shipped generators are constructively safe (#67)
+        // even without it. Off by default because partitioning
+        // intentionally forbids single-matrix workloads (e.g. pure DMA
+        // streaming tests) from filling the whole pool.
+        bool partition_l3_credits = false;
+        bool partition_l2_credits = false;
+
         // Credit reserves (optional guard against upstream producers
         // starving downstream completion paths - see issue #61):
         // - L3 reserve: credits DMA loads may not consume, kept for C-tile
@@ -554,6 +567,12 @@ inline ConcurrentTimingExecutor::ConcurrentTimingExecutor(const Config& config)
       l3_tag_cam_(config.l3_buffer_count),
       l2_tag_cam_(config.l2_bank_count),
       compute_result_tag_cam_(256) {  // 256 pending compute results max
+    if (config_.partition_l3_credits) {
+        l3_credits_.partition_equal();
+    }
+    if (config_.partition_l2_credits) {
+        l2_credits_.partition_equal();
+    }
     create_components();
 
     if (config_.enable_livelock_detection) {

--- a/include/sw/kpu/timing/credit_pool.hpp
+++ b/include/sw/kpu/timing/credit_pool.hpp
@@ -9,145 +9,10 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <stdexcept>
 
 namespace sw::kpu::timing {
-
-/**
- * @brief Credit pool for credit-based dataflow synchronization
- *
- * In the KPU's credit-based dataflow model:
- * - Upstream producers must acquire a credit before pushing data downstream
- * - Downstream consumers release credits when done with data
- * - Credits represent available buffer/bank slots at the downstream level
- *
- * Example flow:
- * 1. DMA engine acquires L3 credit (checks if L3 buffer available)
- * 2. DMA pushes tile to L3 buffer
- * 3. BlockMover consumes tile from L3, releases L3 credit
- *
- * Invariants:
- * - available_ <= capacity_ (never more credits than capacity)
- * - available_ >= 0 (implicitly, since size_t is unsigned)
- * - acquire() decrements available_, release() increments it
- */
-class CreditPool {
-public:
-    /**
-     * @brief Construct a credit pool with given capacity
-     * @param capacity Maximum number of credits (e.g., number of L3 buffers)
-     * @throws std::invalid_argument if capacity is 0
-     */
-    explicit CreditPool(size_t capacity)
-        : capacity_(capacity), available_(capacity) {
-        if (capacity == 0) {
-            throw std::invalid_argument("CreditPool capacity must be > 0");
-        }
-    }
-
-    /**
-     * @brief Try to acquire a credit
-     * @return true if credit acquired, false if no credits available
-     *
-     * Called by upstream producer before pushing data downstream.
-     * Non-blocking: returns immediately with result.
-     */
-    bool acquire() {
-        if (available_ > 0) {
-            --available_;
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * @brief Acquire a credit, blocking until one is available
-     * @note In discrete event simulation, this should not be called directly.
-     *       Use acquire() and handle the false case by rescheduling.
-     * @throws std::runtime_error always (not supported in DES)
-     */
-    void acquire_blocking() {
-        throw std::runtime_error(
-            "acquire_blocking() not supported in discrete event simulation. "
-            "Use acquire() and reschedule if false.");
-    }
-
-    /**
-     * @brief Get number of available credits
-     * @return Number of credits that can be acquired
-     */
-    [[nodiscard]] size_t available() const {
-        return available_;
-    }
-
-    /**
-     * @brief Get pool capacity
-     * @return Maximum number of credits
-     */
-    [[nodiscard]] size_t capacity() const {
-        return capacity_;
-    }
-
-    /**
-     * @brief Check if any credits are available
-     * @return true if at least one credit is available
-     */
-    [[nodiscard]] bool has_credit() const {
-        return available_ > 0;
-    }
-
-    /**
-     * @brief Check if pool is empty (no credits available)
-     * @return true if no credits available
-     */
-    [[nodiscard]] bool empty() const {
-        return available_ == 0;
-    }
-
-    /**
-     * @brief Check if pool is full (all credits available)
-     * @return true if all credits available (no outstanding acquisitions)
-     */
-    [[nodiscard]] bool full() const {
-        return available_ == capacity_;
-    }
-
-    /**
-     * @brief Release a credit back to the pool
-     * @throws std::overflow_error if releasing more credits than capacity
-     *
-     * Called by downstream consumer when done with data.
-     */
-    void release() {
-        if (available_ >= capacity_) {
-            throw std::overflow_error(
-                "CreditPool::release() called but pool is already full. "
-                "This indicates a double-release bug.");
-        }
-        ++available_;
-    }
-
-    /**
-     * @brief Reset the pool to full capacity
-     *
-     * Used at simulation start or when resetting state.
-     */
-    void reset() {
-        available_ = capacity_;
-    }
-
-    /**
-     * @brief Get number of outstanding (acquired but not released) credits
-     * @return Number of credits currently in use
-     */
-    [[nodiscard]] size_t outstanding() const {
-        return capacity_ - available_;
-    }
-
-private:
-    size_t capacity_;   ///< Maximum number of credits
-    size_t available_;  ///< Currently available credits
-};
 
 // ============================================================================
 // PartitionedCreditPool - Credits partitioned by matrix type
@@ -167,6 +32,9 @@ private:
  * Partition strategy (configurable):
  * - Default: Equal partition (capacity/3 per matrix, remainder to C)
  * - Custom: User-specified per-matrix allocation
+ *
+ * This class is wired into the executor via CreditPool's partition mode
+ * (see CreditPool::partition_equal / CreditPool::partition), issue #89.
  */
 class PartitionedCreditPool {
 public:
@@ -316,6 +184,267 @@ private:
     size_t total_capacity_;
     size_t capacity_a_, capacity_b_, capacity_c_;
     size_t available_a_, available_b_, available_c_;
+};
+
+// ============================================================================
+// CreditPool - shared pool with optional per-matrix partition mode
+// ============================================================================
+
+/**
+ * @brief Credit pool for credit-based dataflow synchronization
+ *
+ * In the KPU's credit-based dataflow model:
+ * - Upstream producers must acquire a credit before pushing data downstream
+ * - Downstream consumers release credits when done with data
+ * - Credits represent available buffer/bank slots at the downstream level
+ *
+ * Example flow:
+ * 1. DMA engine acquires L3 credit (checks if L3 buffer available)
+ * 2. DMA pushes tile to L3 buffer
+ * 3. BlockMover consumes tile from L3, releases L3 credit
+ *
+ * Invariants:
+ * - available_ <= capacity_ (never more credits than capacity)
+ * - available_ >= 0 (implicitly, since size_t is unsigned)
+ * - acquire() decrements available_, release() increments it
+ *
+ * Partition mode (issue #89): partition_equal() / partition(a,b,c) switch
+ * the pool to per-matrix (A/B/C) partitioning backed by an internal
+ * PartitionedCreditPool - the original v0.9 design's livelock prevention:
+ * no matrix class can monopolize the buffers another needs. The indexed
+ * acquire/release/available overloads take a partition index (0 = A,
+ * 1 = B, 2+ = C, matching isa::MatrixID) and behave identically to the
+ * shared calls when the pool is not partitioned, so callers can be written
+ * once for both modes. The un-indexed acquire()/release() throw in
+ * partition mode to catch call sites that were missed in a conversion.
+ */
+class CreditPool {
+public:
+    /**
+     * @brief Construct a credit pool with given capacity
+     * @param capacity Maximum number of credits (e.g., number of L3 buffers)
+     * @throws std::invalid_argument if capacity is 0
+     */
+    explicit CreditPool(size_t capacity)
+        : capacity_(capacity), available_(capacity) {
+        if (capacity == 0) {
+            throw std::invalid_argument("CreditPool capacity must be > 0");
+        }
+    }
+
+    // ========================================================================
+    // Partition mode
+    // ========================================================================
+
+    /**
+     * @brief Switch to per-matrix partition mode with an equal split
+     *        (capacity/3 per matrix, remainder to C)
+     * @throws std::invalid_argument if capacity < 3
+     * @throws std::logic_error if credits are outstanding
+     */
+    void partition_equal() {
+        require_full_for_partitioning();
+        partitions_.emplace(capacity_);
+    }
+
+    /**
+     * @brief Switch to per-matrix partition mode with a custom split
+     * @throws std::invalid_argument if a+b+c != capacity or any share is 0
+     * @throws std::logic_error if credits are outstanding
+     */
+    void partition(size_t a, size_t b, size_t c) {
+        if (a + b + c != capacity_) {
+            throw std::invalid_argument(
+                "CreditPool::partition shares must sum to pool capacity");
+        }
+        require_full_for_partitioning();
+        partitions_.emplace(a, b, c);
+    }
+
+    /// @return true if the pool is in per-matrix partition mode
+    [[nodiscard]] bool partitioned() const { return partitions_.has_value(); }
+
+    /**
+     * @brief Try to acquire a credit from a matrix partition
+     * @param partition_index 0 = A, 1 = B, 2 (or greater) = C - matching
+     *        isa::MatrixID's underlying values
+     * @return true if credit acquired
+     *
+     * In shared (non-partitioned) mode this is identical to acquire().
+     */
+    bool acquire(size_t partition_index) {
+        if (partitions_) {
+            return partitions_->acquire(to_matrix(partition_index));
+        }
+        return acquire_shared();
+    }
+
+    /**
+     * @brief Release a credit back to a matrix partition
+     *
+     * In shared (non-partitioned) mode this is identical to release().
+     */
+    void release(size_t partition_index) {
+        if (partitions_) {
+            partitions_->release(to_matrix(partition_index));
+            return;
+        }
+        release_shared();
+    }
+
+    /**
+     * @brief Available credits in a matrix partition (whole pool when shared)
+     */
+    [[nodiscard]] size_t available(size_t partition_index) const {
+        if (partitions_) {
+            return partitions_->available(to_matrix(partition_index));
+        }
+        return available_;
+    }
+
+    // ========================================================================
+    // Shared-mode interface
+    // ========================================================================
+
+    /**
+     * @brief Try to acquire a credit
+     * @return true if credit acquired, false if no credits available
+     * @throws std::logic_error in partition mode (use acquire(partition))
+     *
+     * Called by upstream producer before pushing data downstream.
+     * Non-blocking: returns immediately with result.
+     */
+    bool acquire() {
+        if (partitions_) {
+            throw std::logic_error(
+                "CreditPool is partitioned: use acquire(partition_index)");
+        }
+        return acquire_shared();
+    }
+
+    /**
+     * @brief Acquire a credit, blocking until one is available
+     * @note In discrete event simulation, this should not be called directly.
+     *       Use acquire() and handle the false case by rescheduling.
+     * @throws std::runtime_error always (not supported in DES)
+     */
+    void acquire_blocking() {
+        throw std::runtime_error(
+            "acquire_blocking() not supported in discrete event simulation. "
+            "Use acquire() and reschedule if false.");
+    }
+
+    /**
+     * @brief Get number of available credits (total across partitions)
+     * @return Number of credits that can be acquired
+     */
+    [[nodiscard]] size_t available() const {
+        return partitions_ ? partitions_->total_available() : available_;
+    }
+
+    /**
+     * @brief Get pool capacity
+     * @return Maximum number of credits
+     */
+    [[nodiscard]] size_t capacity() const {
+        return capacity_;
+    }
+
+    /**
+     * @brief Check if any credits are available
+     * @return true if at least one credit is available
+     */
+    [[nodiscard]] bool has_credit() const {
+        return available() > 0;
+    }
+
+    /**
+     * @brief Check if pool is empty (no credits available)
+     * @return true if no credits available
+     */
+    [[nodiscard]] bool empty() const {
+        return available() == 0;
+    }
+
+    /**
+     * @brief Check if pool is full (all credits available)
+     * @return true if all credits available (no outstanding acquisitions)
+     */
+    [[nodiscard]] bool full() const {
+        return available() == capacity_;
+    }
+
+    /**
+     * @brief Release a credit back to the pool
+     * @throws std::overflow_error if releasing more credits than capacity
+     * @throws std::logic_error in partition mode (use release(partition))
+     *
+     * Called by downstream consumer when done with data.
+     */
+    void release() {
+        if (partitions_) {
+            throw std::logic_error(
+                "CreditPool is partitioned: use release(partition_index)");
+        }
+        release_shared();
+    }
+
+    /**
+     * @brief Reset the pool to full capacity
+     *
+     * Used at simulation start or when resetting state. Partition mode
+     * (and its shares) is retained across resets.
+     */
+    void reset() {
+        available_ = capacity_;
+        if (partitions_) partitions_->reset();
+    }
+
+    /**
+     * @brief Get number of outstanding (acquired but not released) credits
+     * @return Number of credits currently in use
+     */
+    [[nodiscard]] size_t outstanding() const {
+        return capacity_ - available();
+    }
+
+private:
+    size_t capacity_;   ///< Maximum number of credits
+    size_t available_;  ///< Currently available credits (shared mode)
+    std::optional<PartitionedCreditPool> partitions_;  ///< Partition mode state
+
+    bool acquire_shared() {
+        if (available_ > 0) {
+            --available_;
+            return true;
+        }
+        return false;
+    }
+
+    void release_shared() {
+        if (available_ >= capacity_) {
+            throw std::overflow_error(
+                "CreditPool::release() called but pool is already full. "
+                "This indicates a double-release bug.");
+        }
+        ++available_;
+    }
+
+    void require_full_for_partitioning() {
+        if (available_ != capacity_ ||
+            (partitions_ && partitions_->total_available() != capacity_)) {
+            throw std::logic_error(
+                "CreditPool can only be partitioned while all credits are free");
+        }
+    }
+
+    static PartitionedCreditPool::Matrix to_matrix(size_t partition_index) {
+        switch (partition_index) {
+            case 0: return PartitionedCreditPool::Matrix::A;
+            case 1: return PartitionedCreditPool::Matrix::B;
+            default: return PartitionedCreditPool::Matrix::C;
+        }
+    }
 };
 
 } // namespace sw::kpu::timing

--- a/include/sw/kpu/timing/dma_engine_process.hpp
+++ b/include/sw/kpu/timing/dma_engine_process.hpp
@@ -301,7 +301,8 @@ private:
                         // Invalidate tile in L3 and release credit
                         bool released = l3_tag_cam_.invalidate(completed->tile.tile_id);
                         if (released) {
-                            l3_credits_.release();
+                            l3_credits_.release(
+                                static_cast<size_t>(completed->tile.tile_id.matrix));
                             events.push_back(TimingEvent(
                                 EventType::CREDIT_RELEASED,
                                 current_cycle_,
@@ -366,13 +367,16 @@ private:
                 continue;  // All slots occupied - dedup hits above can still complete
             }
 
-            // Need L3 credit. Loads may not consume the reserved credits -
-            // those are kept for C-tile writebacks (BlockMover L2->L3).
-            // Without the reserve, greedy prefetch loads re-acquire every
-            // freed credit before a writeback can, starving the downstream
-            // path and wedging the pipeline (credit cycle livelock).
-            if (l3_credits_.available() <= config_.l3_credit_reserve ||
-                !l3_credits_.acquire()) {
+            // Need L3 credit (from the tile's matrix partition when the pool
+            // is partitioned, per #89 - partitioning makes the downstream
+            // protection structural). Loads may not consume the reserved
+            // credits - those are kept for C-tile writebacks (BlockMover
+            // L2->L3). Without the reserve, greedy prefetch loads re-acquire
+            // every freed credit before a writeback can, starving the
+            // downstream path and wedging the pipeline (credit cycle livelock).
+            const size_t load_part = static_cast<size_t>(req.tile.tile_id.matrix);
+            if (l3_credits_.available(load_part) <= config_.l3_credit_reserve ||
+                !l3_credits_.acquire(load_part)) {
                 if (!credit_stalled) {
                     credit_stalled = true;
                     stalled_tile = req.tile.tile_id;
@@ -384,7 +388,7 @@ private:
             req.slot_id = allocate_slot();
             if (!mc_.submit_request(req.tile, true, config_.engine_id)) {
                 // MC queue full - release credit and retry later
-                l3_credits_.release();
+                l3_credits_.release(load_part);
                 continue;
             }
 

--- a/include/sw/kpu/timing/streamer_process.hpp
+++ b/include/sw/kpu/timing/streamer_process.hpp
@@ -248,7 +248,8 @@ private:
                 // Only release L2 credit if tile was fully removed (ref_count reached 0)
                 bool credit_released = l2_tag_cam_.invalidate(in_flight_->tile.tile_id);
                 if (credit_released) {
-                    l2_credits_.release();
+                    l2_credits_.release(
+                        static_cast<size_t>(in_flight_->tile.tile_id.matrix));
                 }
                 total_tiles_fed_++;
 
@@ -414,8 +415,11 @@ private:
             return false;
         }
 
-        // Second check: Is L2 credit available?
-        if (!l2_credits_.acquire()) {
+        // Second check: Is L2 credit available? (Drains carry C result
+        // tiles, which have their own partition when the pool is
+        // partitioned, per #89 - a flood of A/B moves can never starve
+        // result draining.)
+        if (!l2_credits_.acquire(static_cast<size_t>(tile.tile_id.matrix))) {
             events.push_back(TimingEvent(
                 EventType::STR_STALL_CREDIT,
                 current_cycle,

--- a/tests/timing/test_credit_pool.cpp
+++ b/tests/timing/test_credit_pool.cpp
@@ -321,3 +321,83 @@ TEST_CASE("PartitionedCreditPool livelock prevention scenario", "[timing][credit
     pool.release(PartitionedCreditPool::Matrix::A);
     REQUIRE(pool.acquire(PartitionedCreditPool::Matrix::A));
 }
+
+// ============================================================================
+// CreditPool partition mode (issue #89): PartitionedCreditPool wired behind
+// the CreditPool interface via indexed acquire/release
+// ============================================================================
+
+TEST_CASE("CreditPool partition mode splits capacity per matrix", "[timing][credit_pool][partition]") {
+    CreditPool pool(10);
+    REQUIRE_FALSE(pool.partitioned());
+    pool.partition_equal();  // 10 -> A=3, B=3, C=4 (remainder to C)
+    REQUIRE(pool.partitioned());
+
+    REQUIRE(pool.available(0) == 3);   // A
+    REQUIRE(pool.available(1) == 3);   // B
+    REQUIRE(pool.available(2) == 4);   // C
+    REQUIRE(pool.available() == 10);   // total
+    REQUIRE(pool.capacity() == 10);
+}
+
+TEST_CASE("CreditPool partition isolation: exhausting A leaves B and C usable", "[timing][credit_pool][partition]") {
+    CreditPool pool(9);
+    pool.partition_equal();  // 3/3/3
+
+    REQUIRE(pool.acquire(0));
+    REQUIRE(pool.acquire(0));
+    REQUIRE(pool.acquire(0));
+    REQUIRE_FALSE(pool.acquire(0));    // A exhausted
+
+    REQUIRE(pool.acquire(1));          // B unaffected
+    REQUIRE(pool.acquire(2));          // C unaffected
+    REQUIRE(pool.available() == 4);
+    REQUIRE(pool.outstanding() == 5);
+
+    pool.release(0);
+    REQUIRE(pool.acquire(0));
+}
+
+TEST_CASE("CreditPool partition mode rejects un-indexed acquire/release", "[timing][credit_pool][partition]") {
+    CreditPool pool(6);
+    pool.partition_equal();
+    REQUIRE_THROWS_AS(pool.acquire(), std::logic_error);
+    REQUIRE_THROWS_AS(pool.release(), std::logic_error);
+}
+
+TEST_CASE("CreditPool indexed calls behave as shared when not partitioned", "[timing][credit_pool][partition]") {
+    CreditPool pool(2);
+    REQUIRE(pool.acquire(0));
+    REQUIRE(pool.acquire(1));          // same shared pool
+    REQUIRE_FALSE(pool.acquire(2));    // exhausted regardless of index
+    pool.release(2);
+    REQUIRE(pool.available() == 1);
+    REQUIRE(pool.acquire());           // un-indexed still valid in shared mode
+}
+
+TEST_CASE("CreditPool custom partition validates shares", "[timing][credit_pool][partition]") {
+    CreditPool pool(8);
+    REQUIRE_THROWS_AS(pool.partition(4, 4, 4), std::invalid_argument);  // sums to 12
+    pool.partition(2, 2, 4);
+    REQUIRE(pool.available(2) == 4);
+
+    // Per-partition over-release throws
+    REQUIRE(pool.acquire(2));
+    pool.release(2);
+    REQUIRE_THROWS_AS(pool.release(2), std::overflow_error);
+}
+
+TEST_CASE("CreditPool partitioning requires a quiescent pool; reset keeps partitions", "[timing][credit_pool][partition]") {
+    CreditPool pool(6);
+    REQUIRE(pool.acquire());
+    REQUIRE_THROWS_AS(pool.partition_equal(), std::logic_error);
+    pool.release();
+    pool.partition_equal();
+
+    REQUIRE(pool.acquire(0));
+    REQUIRE(pool.acquire(1));
+    pool.reset();
+    REQUIRE(pool.partitioned());
+    REQUIRE(pool.available() == 6);
+    REQUIRE(pool.available(0) == 2);
+}

--- a/tests/timing/test_multi_tile_execution.cpp
+++ b/tests/timing/test_multi_tile_execution.cpp
@@ -143,6 +143,93 @@ TEST_CASE("Multi-tile schedules execute to completion across strategies and size
 }
 
 // ============================================================================
+// Per-matrix credit partitioning (issue #89)
+// ============================================================================
+
+TEST_CASE("Multi-tile schedules execute under partitioned credits",
+          "[timing][executor][regression][partition]") {
+    // Defense-in-depth mode: the same strategy x size matrix must complete
+    // with per-matrix (A/B/C) credit partitioning enabled
+    for (const auto& strat : kStrategies) {
+        for (size_t n : {Size(64), Size(128)}) {
+            DYNAMIC_SECTION(strat.name << " " << n << "^3 partitioned") {
+                auto gen_config = make_generator_config(static_cast<Size>(n),
+                                                        strat.strategy);
+                MatMulScheduleGenerator generator(gen_config);
+                auto schedule = generator.generate();
+                REQUIRE(schedule.valid);
+
+                auto exec_config = make_executor_config();
+                exec_config.partition_l3_credits = true;
+                exec_config.partition_l2_credits = true;
+                ConcurrentTimingExecutor executor(exec_config);
+                ScheduleExecutor sched_exec(executor);
+                auto result = sched_exec.execute(schedule);
+
+                INFO("strategy=" << strat.name << " n=" << n
+                     << " cycles=" << result.total_cycles
+                     << " error=" << result.error_message);
+                REQUIRE(result.success);
+                REQUIRE_FALSE(result.livelock_detected);
+            }
+        }
+    }
+}
+
+TEST_CASE("Partitioned credits prevent single-matrix buffer monopolization",
+          "[timing][executor][partition]") {
+    // Adversarial pattern no generator emits but a hand-written or dynamic
+    // schedule could: a flood of A loads with NO downstream consumption,
+    // plus one B load. With a shared pool the A flood takes every L3 credit
+    // and the B tile never arrives; with per-matrix partitioning the B
+    // partition is untouchable by A traffic.
+    auto make_flood_tile = [](MatrixID m, Size ti) {
+        TileDescriptor tile;
+        tile.tile_id = {m, ti, 0, 0};
+        tile.dram_address = 0x1000 + static_cast<Address>(ti) * 0x1000;
+        tile.height = 16;
+        tile.width = 16;
+        tile.element_size = 4;
+        tile.size_bytes = 1024;
+        return tile;
+    };
+
+    auto run_flood = [&](bool partitioned) {
+        auto config = make_executor_config();
+        config.l3_buffer_count = 9;  // partitions to 3/3/3
+        config.enable_livelock_detection = false;
+        config.partition_l3_credits = partitioned;
+        ConcurrentTimingExecutor executor(config);
+
+        // 12 A loads against 9 buffers - demand exceeds the pool - and one
+        // B load queued behind them. No moves: the A tiles never leave.
+        for (Size i = 0; i < 12; ++i) {
+            executor.schedule_load(make_flood_tile(MatrixID::A, i));
+        }
+        executor.schedule_load(make_flood_tile(MatrixID::B, 0));
+
+        for (int i = 0; i < 2000 && !executor.is_complete(); ++i) {
+            executor.step();
+        }
+
+        for (const auto& event : executor.events()) {
+            if (event.type == EventType::TILE_ARRIVED_L3 &&
+                event.tile_id.matrix == MatrixID::B) {
+                return true;  // B tile made it into L3
+            }
+        }
+        return false;
+    };
+
+    SECTION("shared pool: the A flood starves B") {
+        REQUIRE_FALSE(run_flood(false));
+    }
+    SECTION("partitioned pool: B arrives despite the A flood") {
+        REQUIRE(run_flood(true));
+    }
+}
+
+// ============================================================================
 // Envelope-aware blocked schedules under constrained buffers (issue #67)
 // ============================================================================
 


### PR DESCRIPTION
Fixes #89 — the first Wave 0 task of the CSP pattern-coverage program (epic #69, umbrella #88).

## Background

The #67 provenance analysis showed the original v0.9 design placed livelock prevention in the **executor** — per-matrix credit partitioning so no matrix class can monopolize the buffers another needs. Phase 1 built `PartitionedCreditPool` (tested, never referenced); Phase 3 shipped `ConcurrentTimingExecutor` with plain shared pools. This PR completes the wiring.

## Design

`CreditPool` gains an **opt-in partition mode** composing a `PartitionedCreditPool` internally:
- `partition_equal()` / `partition(a,b,c)` switch a quiescent pool to per-matrix mode (equal split, remainder to C).
- Indexed `acquire/release/available(partition)` overloads (0=A, 1=B, 2+=C — matching `isa::MatrixID`) **behave identically to the shared calls when unpartitioned**, so the ten process call sites (DMA, BlockMover, Streamer) were converted once and are correct in both modes. No process constructor signature changed; every pre-existing test passes unmodified.
- Un-indexed `acquire()`/`release()` **throw in partition mode** — a missed conversion fails loudly instead of silently bypassing partitioning.

Executor: `Config::partition_l3_credits` / `partition_l2_credits`, default **off** (partitioning intentionally forbids single-matrix workloads — e.g. pure DMA streaming tests — from filling the whole pool; it's defense-in-depth for hand-written/dynamic schedules, while the shipped generators are constructively safe per #67). `run_matmul --partition-credits` enables it.

## Evidence

- **Defense-in-depth regression (both directions):** a 12-A-load flood plus one B load against a 9-buffer pool — with the shared pool the B tile *never arrives*; partitioned, it does. This is the adversarial pattern no generator emits but a dynamic scheduler could.
- **Full strategy matrix under partitioning:** all strategies × 64³/128³ complete without livelock.
- **Unexpected bonus:** partitioned 128³ is *faster* than shared — 7,132 vs 8,034 cycles — because partitioning curbs the greedy DMA prefetch from over-filling L3 with far-future input tiles, letting C writebacks proceed earlier.
- Full suite: **100/100 pass** (shared-mode behavior bit-identical).

Session log: `docs/sessions/2026-07-11_v0.9_partitioned_credit_wiring.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional per-matrix credit partitioning for L2 and L3 resources, including partition-aware credit tracking.
  - Added `--partition-credits` to the matrix multiplication example.
  - Added executor configuration flags to enable partitioning independently for L2 and L3 credits.
- **Bug Fixes**
  - Restored livelock/starvation prevention between competing matrix workloads by enforcing partition-correct credit accounting.
  - Improved reliability for multi-matrix and adversarial execution scenarios.
- **Documentation**
  - Documented partitioning behavior, validation details, and performance observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->