### PR TITLE
feat(schedule): envelope-mismatch warning in executor and validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CSP timing: envelope-mismatch detection (#91, Wave 0).** Schedule
+  generators stamp their generation envelope into `ScheduleMetadata`
+  (`l3_buffer_count`/`l2_bank_count`; 0 = hand-built/legacy, not checked).
+  `ScheduleExecutor::execute` compares it against the executor's configured
+  pools and surfaces a warning in the new `ExecutionResult::warnings` -
+  with a may-wedge note when the executor pools are smaller (which voids
+  the #67/#90 constructive-safety guarantees) and a benign note when
+  larger. `validate_livelock_safety` raises the matching VAL-007 issue.
+  `run_matmul` prints execution warnings.
+
 - **CSP timing: resource envelope on all schedule generators (#90, Wave 0).**
   The conv2d/softmax/layernorm/batchnorm generators now carry the #67
   resource envelope (`l3_buffer_count`/`l2_bank_count`, `max_burst_tiles()`)

--- a/docs/sessions/2026-07-11_v0.9_envelope_mismatch_warning.md
+++ b/docs/sessions/2026-07-11_v0.9_envelope_mismatch_warning.md
@@ -1,0 +1,77 @@
+# v0.9 Envelope-Mismatch Warning Decision Log
+
+**Date:** 2026-07-11
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 100/100 suites passing (new: 3 test cases / 7 sections)
+**Issue:** #91 (Wave 0, epic #69)
+
+## 1. Summary
+
+Closed the loop between schedule generation and execution envelopes: the
+five generators stamp their generation envelope into ScheduleMetadata,
+ScheduleExecutor compares it against the executor's configured credit
+pools and warns on disagreement (strongly when the executor pools are
+smaller, which voids the #67/#90 constructive-safety guarantees), and
+validate_livelock_safety raises the matching VAL-007 issue.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| ScheduleMetadata envelope fields (0 = unrecorded) | Done |
+| Envelope stamping in all five generators | Done |
+| ExecutionResult::warnings + executor mismatch check | Done |
+| VAL-007 validation rule | Done |
+| run_matmul warning printout | Done |
+| Tests: stamping, match-silence, smaller/larger mismatch, unrecorded skip, VAL-007 | Done |
+
+Files modified:
+- `include/sw/kpu/timing/schedule/schedule_generator_interface.hpp`
+- `include/sw/kpu/timing/schedule/{matmul,conv2d,softmax,layernorm,batchnorm}_schedule_generator.hpp`
+- `include/sw/kpu/timing/schedule/schedule_executor.hpp`
+- `include/sw/kpu/timing/schedule/schedule_validator.hpp`
+- `examples/schedule/run_matmul.cpp`
+- `tests/timing/test_schedule_generators.cpp`
+- `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: warning, not refusal, at execution time.**
+- **Choice:** mismatch produces ExecutionResult::warnings; execution
+  proceeds.
+- **Alternatives considered:** hard refusal at execute() - too strict for
+  the larger-pool direction (benign) and for exploratory runs; a config
+  knob for strictness - deferred until a caller needs it.
+- **Rationale:** generation-time refusal (#90) is the a-priori guard;
+  execution-time is the last chance to surface the mismatch visibly
+  without blocking legitimate experimentation. Direction-aware messaging
+  (smaller = may wedge, larger = benign) keeps severity honest.
+
+**Decision 2: 0-valued metadata means unrecorded, not zero envelope.**
+- **Choice:** hand-built/legacy schedules (metadata fields 0) are not
+  checked.
+- **Alternatives considered:** treat 0 as mismatch - would spam warnings
+  for every hand-built schedule in tests and demos.
+
+## 4. Issues Encountered
+
+None.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build            # 100/100 pass
+./build/examples/schedule/run_matmul --l3-buffers 16   # no warning
+                                   # (generator + executor share envelope)
+```
+
+## 7. Next Steps
+
+- Wave 0: infra-T4 (#92) fix non-matmul Kernel factories (#18);
+  infra-T5 (#93) pattern-coverage matrix scaffold.

--- a/examples/schedule/run_matmul.cpp
+++ b/examples/schedule/run_matmul.cpp
@@ -271,6 +271,9 @@ int main(int argc, char* argv[]) {
     if (result.livelock_detected) {
         std::cout << "  WARNING: Livelock detected!\n";
     }
+    for (const auto& warning : result.warnings) {
+        std::cout << "  WARNING: " << warning << "\n";
+    }
 
     // ========================================
     // Print statistics

--- a/include/sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp
@@ -183,6 +183,8 @@ public:
         result.metadata.c_tiles = input_tiles;
 
         result.metadata.strategy = config_.training ? "training_batchnorm" : "inference_batchnorm";
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
         result.valid = true;
 
         return result;

--- a/include/sw/kpu/timing/schedule/conv2d_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/conv2d_schedule_generator.hpp
@@ -232,6 +232,8 @@ public:
         result.metadata.b_tiles = config_.k_tiles() * config_.n_tiles();
         result.metadata.c_tiles = config_.m_tiles() * config_.n_tiles();
         result.metadata.strategy = strategy_name(config_.strategy);
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
 
         result.valid = true;
         return result;

--- a/include/sw/kpu/timing/schedule/layernorm_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/layernorm_schedule_generator.hpp
@@ -182,6 +182,8 @@ public:
         result.metadata.c_tiles = input_tiles;
 
         result.metadata.strategy = "multi_pass_layernorm";
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
         result.valid = true;
 
         return result;

--- a/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp
@@ -210,6 +210,8 @@ public:
         result.metadata.b_tiles = config_.total_b_tiles();
         result.metadata.c_tiles = config_.total_c_tiles();
         result.metadata.strategy = strategy_name(config_.strategy);
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
 
         result.valid = true;
         return result;

--- a/include/sw/kpu/timing/schedule/schedule_executor.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_executor.hpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace sw::kpu::timing::schedule {
 
@@ -29,6 +30,7 @@ struct ExecutionResult {
     bool success = false;               ///< Whether execution completed successfully
     Cycle total_cycles = 0;             ///< Total cycles taken
     std::string error_message;          ///< Error message if failed
+    std::vector<std::string> warnings;  ///< Non-fatal issues (e.g. envelope mismatch, #91)
 
     // Per-operation statistics
     size_t ops_completed = 0;           ///< Operations successfully executed
@@ -141,6 +143,8 @@ public:
             return result;
         }
 
+        check_envelope_mismatch(schedule, result);
+
         // Reset executor state
         executor_.reset();
 
@@ -230,6 +234,46 @@ private:
     ConcurrentTimingExecutor& executor_;
     Config config_;
     ProgressCallback progress_callback_;
+
+    /**
+     * @brief Warn when the schedule's generation envelope differs from the
+     *        executor's configured credit pools (issue #91)
+     *
+     * The #67/#90 constructive-safety guarantees (burst bounds, working-set
+     * fit) were established against the generation envelope. Executing under
+     * SMALLER pools voids them - the schedule may wedge; larger pools are
+     * benign but still flagged so the mismatch is visible. Schedules with no
+     * recorded envelope (hand-built or legacy, metadata fields 0) are not
+     * checked.
+     */
+    void check_envelope_mismatch(const ScheduleResult& schedule,
+                                 ExecutionResult& result) const {
+        const auto& meta = schedule.metadata;
+        if (meta.l3_buffer_count == 0 && meta.l2_bank_count == 0) {
+            return;  // envelope not recorded
+        }
+        const auto& exec_config = executor_.config();
+        if (meta.l3_buffer_count == exec_config.l3_buffer_count &&
+            meta.l2_bank_count == exec_config.l2_bank_count) {
+            return;  // envelopes agree
+        }
+        const bool shrunk =
+            exec_config.l3_buffer_count < meta.l3_buffer_count ||
+            exec_config.l2_bank_count < meta.l2_bank_count;
+        std::string warning =
+            "schedule '" + meta.name + "' was generated against envelope L3=" +
+            std::to_string(meta.l3_buffer_count) + "/L2=" +
+            std::to_string(meta.l2_bank_count) +
+            " but the executor is configured with L3=" +
+            std::to_string(exec_config.l3_buffer_count) + "/L2=" +
+            std::to_string(exec_config.l2_bank_count);
+        warning += shrunk
+            ? " - the executor pools are SMALLER: the schedule's working-set "
+              "and burst-safety guarantees do not hold and it may wedge"
+            : " - the executor pools are larger; execution is safe but "
+              "regenerate against the actual envelope for faithful timing";
+        result.warnings.push_back(std::move(warning));
+    }
 
     /**
      * @brief Enqueue a single operation on the executor

--- a/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
@@ -256,6 +256,13 @@ struct ScheduleMetadata {
     Size l3_buffers_needed = 0; ///< Minimum L3 buffers required
     Size l2_banks_needed = 0;   ///< Minimum L2 banks required
 
+    // Generation envelope (issue #91): the credit pools this schedule was
+    // generated against (#67/#90 constructive-safety guarantees hold only
+    // under an executor configured with at least these pools). 0 = not
+    // recorded (hand-built or legacy schedule).
+    Size l3_buffer_count = 0;   ///< L3 envelope used at generation time
+    Size l2_bank_count = 0;     ///< L2 envelope used at generation time
+
     // Scheduling strategy metadata
     std::string strategy;       ///< E.g., "OUTPUT_STATIONARY", "INTERLEAVED_AB"
 

--- a/include/sw/kpu/timing/schedule/schedule_validator.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_validator.hpp
@@ -224,6 +224,33 @@ public:
 
         auto analysis = ScheduleAnalysis::analyze(schedule);
 
+        // VAL-007 (issue #91): the schedule's recorded generation envelope
+        // must match the pools it is validated/executed against - the
+        // #67/#90 constructive guarantees were established under that
+        // envelope. Smaller actual pools void them.
+        const auto& meta = schedule.metadata;
+        if ((meta.l3_buffer_count != 0 || meta.l2_bank_count != 0) &&
+            (meta.l3_buffer_count != l3_credits ||
+             meta.l2_bank_count != l2_credits)) {
+            const bool shrunk = l3_credits < meta.l3_buffer_count ||
+                                l2_credits < meta.l2_bank_count;
+            result.issues.push_back({
+                ValidationSeverity::WARNING,
+                "VAL-007",
+                "Schedule was generated against envelope L3=" +
+                    std::to_string(meta.l3_buffer_count) + "/L2=" +
+                    std::to_string(meta.l2_bank_count) +
+                    " but is being validated against L3=" +
+                    std::to_string(l3_credits) + "/L2=" +
+                    std::to_string(l2_credits) +
+                    (shrunk ? " (smaller - constructive safety guarantees "
+                              "do not hold)"
+                            : " (larger - safe, but timing assumptions "
+                              "differ)"),
+                0
+            });
+        }
+
         // Check if consecutive operations exceed available credits
         if (analysis.max_consecutive_a > l3_credits / 2) {
             result.issues.push_back({

--- a/include/sw/kpu/timing/schedule/softmax_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/softmax_schedule_generator.hpp
@@ -163,6 +163,8 @@ public:
         result.metadata.c_tiles = input_tiles;  // Same shape output
 
         result.metadata.strategy = "multi_pass_safe_softmax";
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
         result.valid = true;
 
         return result;

--- a/tests/timing/test_schedule_generators.cpp
+++ b/tests/timing/test_schedule_generators.cpp
@@ -652,3 +652,113 @@ TEST_CASE("BatchNorm and Conv2D carry the envelope and refuse degenerate shares"
         REQUIRE_FALSE(gen.generate().valid);
     }
 }
+
+// ============================================================================
+// Envelope-mismatch detection (issue #91): generators stamp their envelope
+// into the metadata; ScheduleExecutor and VAL-007 surface disagreements
+// ============================================================================
+
+TEST_CASE("Generators record their envelope in schedule metadata", "[timing][schedule][envelope]") {
+    MatMulScheduleGenerator::Config config;
+    config.M = 32; config.N = 32; config.K = 32;
+    config.Ti = 16; config.Tj = 16; config.Tk = 16;
+    config.l3_buffer_count = 16;
+    config.l2_bank_count = 24;
+
+    MatMulScheduleGenerator gen(config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+    REQUIRE(schedule.metadata.l3_buffer_count == 16);
+    REQUIRE(schedule.metadata.l2_bank_count == 24);
+}
+
+TEST_CASE("ScheduleExecutor warns when the execution envelope differs", "[timing][schedule][envelope]") {
+    MatMulScheduleGenerator::Config gen_config;
+    gen_config.M = 32; gen_config.N = 32; gen_config.K = 32;
+    gen_config.Ti = 16; gen_config.Tj = 16; gen_config.Tk = 16;
+    gen_config.l3_buffer_count = 32;
+    gen_config.l2_bank_count = 64;
+
+    MatMulScheduleGenerator gen(gen_config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor::Config exec_config;
+    exec_config.max_cycles = 1'000'000;
+
+    SECTION("matching envelope executes without warnings") {
+        exec_config.l3_buffer_count = 32;
+        exec_config.l2_bank_count = 64;
+        ConcurrentTimingExecutor executor(exec_config);
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(schedule);
+        REQUIRE(result.success);
+        REQUIRE(result.warnings.empty());
+    }
+
+    SECTION("smaller executor pools produce a may-wedge warning") {
+        exec_config.l3_buffer_count = 8;
+        exec_config.l2_bank_count = 16;
+        ConcurrentTimingExecutor executor(exec_config);
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(schedule);
+        REQUIRE(result.warnings.size() == 1);
+        REQUIRE(result.warnings[0].find("SMALLER") != std::string::npos);
+        REQUIRE(result.warnings[0].find("may wedge") != std::string::npos);
+    }
+
+    SECTION("larger executor pools produce a benign mismatch warning") {
+        exec_config.l3_buffer_count = 128;
+        exec_config.l2_bank_count = 128;
+        ConcurrentTimingExecutor executor(exec_config);
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(schedule);
+        REQUIRE(result.success);
+        REQUIRE(result.warnings.size() == 1);
+        REQUIRE(result.warnings[0].find("larger") != std::string::npos);
+    }
+
+    SECTION("hand-built schedules without a recorded envelope are not flagged") {
+        ScheduleResult hand_built = schedule;
+        hand_built.metadata.l3_buffer_count = 0;
+        hand_built.metadata.l2_bank_count = 0;
+        exec_config.l3_buffer_count = 8;
+        exec_config.l2_bank_count = 16;
+        ConcurrentTimingExecutor executor(exec_config);
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(hand_built);
+        REQUIRE(result.warnings.empty());
+    }
+}
+
+TEST_CASE("VAL-007 flags envelope disagreement in validation", "[timing][schedule][envelope][validation]") {
+    MatMulScheduleGenerator::Config config;
+    config.M = 32; config.N = 32; config.K = 32;
+    config.Ti = 16; config.Tj = 16; config.Tk = 16;
+    config.l3_buffer_count = 32;
+    config.l2_bank_count = 64;
+
+    MatMulScheduleGenerator gen(config);
+    auto schedule = gen.generate();
+
+    ScheduleValidator validator;
+
+    SECTION("matching pools raise no VAL-007") {
+        auto result = validator.validate_livelock_safety(schedule, 32, 64);
+        for (const auto& issue : result.issues) {
+            REQUIRE(issue.rule_id != "VAL-007");
+        }
+    }
+
+    SECTION("smaller pools raise VAL-007 with the guarantees-void note") {
+        auto result = validator.validate_livelock_safety(schedule, 8, 16);
+        bool found = false;
+        for (const auto& issue : result.issues) {
+            if (issue.rule_id == "VAL-007") {
+                found = true;
+                REQUIRE(issue.message.find("smaller") != std::string::npos);
+            }
+        }
+        REQUIRE(found);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes the generation/execution envelope loop for Wave 0 (epic #69): generators record the envelope they generated against, and both the executor and the validator surface any disagreement with the pools actually in use.
- Rationale: #90 made generation refuse envelope-violating schedules a priori; this adds the complementary guard for the remaining silent path — a valid schedule executed under a *different* envelope than it was generated for.

## Changes
- `schedule_generator_interface.hpp` — `ScheduleMetadata` gains `l3_buffer_count`/`l2_bank_count` (0 = unrecorded/hand-built, exempt from checking)
- all five generators — stamp their Config envelope into the metadata
- `schedule_executor.hpp` — `ExecutionResult::warnings`; `execute()` warns on mismatch, direction-aware: **smaller** executor pools ⇒ "guarantees do not hold, may wedge"; larger ⇒ benign note to regenerate for faithful timing
- `schedule_validator.hpp` — VAL-007 in `validate_livelock_safety(schedule, l3, l2)`
- `examples/schedule/run_matmul.cpp` — prints execution warnings
- `tests/timing/test_schedule_generators.cpp` — stamping, match-silence, both mismatch directions, unrecorded skip, VAL-007 presence/absence

## Test Results
| Suite | Result |
|---|---|
| full ctest | 100/100 pass |
| test_schedule_generators | all pass (incl. 3 new cases / 7 sections) |
| run_matmul (matched envelope) | SUCCESS, no warnings |

## Test plan
- [ ] CI passes (3 platform builds + benchmark + CodeRabbit)
- [ ] Promote to ready: `gh pr ready <NNN>`

Resolves #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedules now record the resource capacity used during generation.
  * Execution reports warnings when available resources differ from those assumed by the schedule, including potential execution risks.
  * Livelock-safety validation now flags resource-envelope mismatches with a dedicated warning.
  * The matrix multiplication example displays all execution warnings.

* **Documentation**
  * Added release notes and a decision log describing envelope-mismatch handling and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->