### PR TITLE
fix(kernel): non-matmul factories compile their actual op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streaming ops. Numerical validation of the VE semantics lands with the
   pattern epics (E2/E3); tracked in #18, which stays open for that half.
 
+### Added
+
 - **CSP timing: envelope-mismatch detection (#91, Wave 0).** Schedule
   generators stamp their generation envelope into `ScheduleMetadata`
   (`l3_buffer_count`/`l2_bank_count`; 0 = hand-built/legacy, not checked).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Fixed
+
+- **Non-matmul Kernel factories now compile their actual op (#92, fixes
+  the structural half of #18).** `KernelCompiler` gains per-op streaming
+  compilers (`compile_softmax/layernorm/rmsnorm/batchnorm/elementwise/
+  pool2d`) emitting loop-based DMPrograms with real tile traffic and
+  VE_REDUCE/VE_ELEMENTWISE pass markers - a "softmax kernel" no longer
+  executes a matmul. Loop-based emission keeps vocab-scale programs
+  compact (the unrolled approach behind the #17 Windows OOM is gone for
+  good). conv2d is documented as an intentional im2col+GEMM lowering with
+  fused epilogue. `ConcurrentExecutor` learns to interpret hardware loops
+  (LOOP_BEGIN/END), AUTO-addressed ops (via SET_TILE_DIM geometry), and VE
+  ops for timing - which also un-breaks the bandwidth benchmarks for
+  streaming ops. Numerical validation of the VE semantics lands with the
+  pattern epics (E2/E3); tracked in #18, which stays open for that half.
 
 - **CSP timing: envelope-mismatch detection (#91, Wave 0).** Schedule
   generators stamp their generation envelope into `ScheduleMetadata`

--- a/docs/sessions/2026-07-12_v0.9_nonmatmul_kernel_factories.md
+++ b/docs/sessions/2026-07-12_v0.9_nonmatmul_kernel_factories.md
@@ -23,7 +23,7 @@ timing. conv2d was confirmed and documented as intentional im2col+GEMM.
 | Item | Status |
 |------|--------|
 | Streaming emitter (loop-based, exact 65535-decomposition) | Done |
-| compile_softmax (4-pass), _layernorm (3), _rmsnorm (2), _batchnorm (preload+1), _elementwise (1), _pool2d (1) | Done |
+| compile_softmax (4-pass), compile_layernorm (3), compile_rmsnorm (2), compile_batchnorm (preload+1), compile_elementwise (1), compile_pool2d (1) | Done |
 | Factories rewired; placeholder comments removed | Done |
 | conv2d documented as intentional im2col+GEMM (resolves #18's open question) | Done |
 | ConcurrentExecutor: LOOP_BEGIN/END interpretation | Done |

--- a/docs/sessions/2026-07-12_v0.9_nonmatmul_kernel_factories.md
+++ b/docs/sessions/2026-07-12_v0.9_nonmatmul_kernel_factories.md
@@ -1,0 +1,106 @@
+# v0.9 Non-Matmul Kernel Factories Fix Decision Log
+
+**Date:** 2026-07-12
+**Version:** v0.9
+**Status:** Complete (structural half of #18; numerical half deferred to E2/E3)
+**Tests:** 100/100 suites passing (new: op-faithfulness case, 21 assertions;
+benchmark_bandwidth un-broken)
+**Issues:** #92 (done), #18 (structural half - stays open for numerics)
+
+## 1. Summary
+
+Fixed the structural lie in the Kernel factories: every non-matmul
+`create_*` (softmax, layernorm, rmsnorm, batchnorm, elementwise, pool2d)
+piggybacked on `compile_matmul` and stamped a different op_type over an
+unrelated instruction stream - launching a "softmax kernel" computed a
+matmul. `KernelCompiler` now has per-op streaming compilers emitting
+loop-based DMPrograms with real tile traffic and VE pass markers, and
+`ConcurrentExecutor` interprets hardware loops, AUTO ops, and VE ops for
+timing. conv2d was confirmed and documented as intentional im2col+GEMM.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| Streaming emitter (loop-based, exact 65535-decomposition) | Done |
+| compile_softmax (4-pass), _layernorm (3), _rmsnorm (2), _batchnorm (preload+1), _elementwise (1), _pool2d (1) | Done |
+| Factories rewired; placeholder comments removed | Done |
+| conv2d documented as intentional im2col+GEMM (resolves #18's open question) | Done |
+| ConcurrentExecutor: LOOP_BEGIN/END interpretation | Done |
+| ConcurrentExecutor: AUTO ops + SET_TILE_DIM state + VE timing | Done |
+| Op-faithfulness tests (incl. GPT-2-shaped softmax compactness) | Done |
+| Benchmarks verified: performance-model-only, now over faithful programs | Done |
+
+Files modified:
+- `include/sw/compiler/kernel_compiler.hpp`, `src/software/compiler/kernel_compiler.cpp`
+- `src/system/simulator/kernel.cpp`
+- `include/sw/kpu/isa/concurrent_executor.hpp`, `src/software/isa/concurrent_executor.cpp`
+- `tests/driver/test_kernel.cpp`
+- `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: loop-based emission, not unrolled.**
+- **Choice:** programs use LOOP_BEGIN/END (exact decomposition into
+  <=65535-count loops) around a constant-size body.
+- **Alternatives considered:** unrolled per-tile emission - exactly the
+  hundreds-of-MB Windows MSVC OOM that #17 dodged by shrinking the
+  placeholder; per-op bespoke builders like OutputStationaryProgramBuilder -
+  heavyweight for streaming ops that share one shape.
+- **Rationale:** GPT-2-shaped softmax (64x50257) compiles to <300
+  instructions; the anti-OOM property is asserted in the tests.
+
+**Decision 2: structural fix now, numerics with the pattern epics.**
+- **Choice:** VE_ELEMENTWISE/VE_REDUCE are structural markers with
+  descriptive labels; #18 stays open for executor-level numerical
+  validation.
+- **Alternatives considered:** implement VE functional semantics here -
+  that IS the E2 (broadcast/elementwise) and E3 (online reductions)
+  pattern-epic capability-closure work, scheduled with its own design and
+  oracle tasks; doing it inside an estimate-5 infra task would rush the
+  operand encoding design.
+- **Rationale:** the factories' lie (wrong op entirely) and the missing
+  semantics (right op, marker-level) are different defects; fixing the
+  first makes the second visible and properly scoped.
+
+**Decision 3: teach ConcurrentExecutor loops/AUTO rather than avoid them.**
+- **Choice:** the timing executor interprets LOOP/AUTO/VE (round-robin
+  resources, SET_TILE_DIM geometry, one-elem-per-lane VE envelope).
+- **Alternatives considered:** emit only legacy unrolled non-AUTO opcodes -
+  reintroduces Decision 1's problem; pre-expand loops before execute() -
+  same memory blowup, just relocated.
+- **Rationale:** benchmark_bandwidth executes kernels through this path;
+  without interpretation the streaming programs timed to 0 cycles (caught
+  by the suite immediately).
+
+## 4. Issues Encountered
+
+1. benchmark_bandwidth + analytical_validation failed after the rewiring:
+   ConcurrentExecutor had no LOOP/AUTO support, so streaming programs
+   scheduled nothing (0 cycles). Fixed per Decision 3 - the failures were
+   the correctness signal working.
+2. Opcode name drift: BM_MOVE_TILE_AUTO (not BM_MOVE_AUTO) - caught by
+   -Werror build.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                                    # 100/100
+./build/tests/driver/kernel_test "[kernel][programs]"     # 21 assertions
+```
+
+Benchmark note (acceptance criterion of #18): `src/tools/benchmark` runs
+kernels through ConcurrentExecutor, which is a timing model everywhere
+(matmul included) - its numbers are performance-model-only and now reflect
+faithful per-op movement; no numerical claims are made by that suite.
+
+## 7. Next Steps
+
+- Wave 0 final task: infra-T5 (#93) pattern-coverage matrix scaffold.
+- #18 numerical half: executor-level oracle tests when E2/E3 land VE
+  functional semantics.

--- a/include/sw/compiler/kernel_compiler.hpp
+++ b/include/sw/compiler/kernel_compiler.hpp
@@ -358,6 +358,33 @@ public:
                        const CompileOptions& options = CompileOptions::defaults());
 
     // =========================================
+    // Per-op streaming compilers (issue #18/#92)
+    // =========================================
+    //
+    // Each produces an op-faithful DMProgram: loop-based streaming of the
+    // real tile traffic (DMA_LOAD -> BM_MOVE -> STR_FEED per input tile,
+    // STR_DRAIN -> BM_WRITEBACK -> DMA_STORE per output tile) with
+    // VE_ELEMENTWISE / VE_REDUCE instructions marking the per-pass compute.
+    // These replace the matmul-piggyback placeholders that made a "softmax
+    // kernel" execute a matmul. The VE opcodes are structural markers today
+    // (operand encoding and functional semantics land with the
+    // broadcast/elementwise and online-reduction pattern epics, E2/E3);
+    // the movement, tiling, memory traffic, and FLOP accounting are real.
+
+    Kernel compile_softmax(const SoftmaxConfig& config,
+                           const CompileOptions& options = CompileOptions::defaults());
+    Kernel compile_layernorm(const LayerNormConfig& config,
+                             const CompileOptions& options = CompileOptions::defaults());
+    Kernel compile_rmsnorm(const RMSNormConfig& config,
+                           const CompileOptions& options = CompileOptions::defaults());
+    Kernel compile_batchnorm(const BatchNormConfig& config,
+                             const CompileOptions& options = CompileOptions::defaults());
+    Kernel compile_elementwise(const ElementwiseConfig& config,
+                               const CompileOptions& options = CompileOptions::defaults());
+    Kernel compile_pool2d(const Pool2DConfig& config,
+                          const CompileOptions& options = CompileOptions::defaults());
+
+    // =========================================
     // Tile Optimization
     // =========================================
 
@@ -444,6 +471,46 @@ private:
     void count_operations(const isa::DMProgram& program,
                           Size elem_size,
                           const TileOptimizer::TileConfig& tiles);
+
+    // =========================================
+    // Streaming-op emission helpers (issue #18/#92)
+    // =========================================
+
+    /**
+     * @brief One pass of a streaming operator
+     *
+     * A pass streams input_tiles through the pipeline, applies the marked
+     * VE compute per tile, and (when output_tiles > 0) drains/stores that
+     * many result tiles. ve_opcode NOP means pure data movement (e.g. a
+     * parameter preload pass).
+     */
+    struct StreamingPass {
+        std::string label;            ///< Human-readable pass description
+        isa::DMOpcode ve_opcode;      ///< VE_ELEMENTWISE, VE_REDUCE, or NOP
+        Size input_tiles = 0;         ///< Tiles streamed in
+        Size output_tiles = 0;        ///< Result tiles drained/stored
+    };
+
+    /**
+     * @brief Emit a loop-based streaming program from a pass list
+     *
+     * Uses hardware loops (LOOP_BEGIN/END) rather than unrolled per-tile
+     * emission so the instruction stream stays compact regardless of
+     * tensor size (large-shape kernels previously OOMed unrolled builds).
+     */
+    isa::DMProgram emit_streaming_program(
+        const std::string& name,
+        const std::vector<StreamingPass>& passes,
+        Size tile_elems, Size elem_size,
+        uint64_t total_flops, uint64_t external_bytes);
+
+    /**
+     * @brief Append body inside exact hardware loops of total `count`
+     *        iterations (decomposed into <=65535-count loops)
+     */
+    static void append_tile_loop(isa::DMProgram& program, uint8_t loop_id,
+                                 Size count,
+                                 const std::vector<isa::DMInstruction>& body);
 };
 
 } // namespace sw::kpu::compiler

--- a/include/sw/kpu/isa/concurrent_executor.hpp
+++ b/include/sw/kpu/isa/concurrent_executor.hpp
@@ -322,6 +322,13 @@ private:
     // Barrier tracking
     Cycle last_barrier_cycle_;
 
+    // AUTO-addressing interpreter state (issue #92): tile geometry from
+    // SET_TILE_DIM and a round-robin counter for resource assignment of
+    // AUTO-addressed ops
+    Size auto_tile_bytes_ = 1024;
+    Size auto_elem_size_ = 4;
+    uint32_t auto_rr_ = 0;
+
     // Tile layout policy
     std::unique_ptr<TileLayout> tile_layout_;
 

--- a/src/software/compiler/kernel_compiler.cpp
+++ b/src/software/compiler/kernel_compiler.cpp
@@ -551,4 +551,234 @@ void KernelCompiler::count_operations(const isa::DMProgram& program,
     last_stats_.compute_ops = 0;  // Compute is implicit in streaming
 }
 
+// ============================================================================
+// Per-op streaming compilers (issue #18/#92)
+// ============================================================================
+
+namespace {
+
+isa::DMInstruction ve_marker(isa::DMOpcode opcode, std::string label) {
+    isa::DMInstruction instr;
+    instr.opcode = opcode;
+    instr.operands = std::monostate{};
+    instr.label = std::move(label);
+    return instr;
+}
+
+Size ceil_div_sz(Size a, Size b) { return (a + b - 1) / b; }
+
+} // namespace
+
+void KernelCompiler::append_tile_loop(isa::DMProgram& program, uint8_t loop_id,
+                                      Size count,
+                                      const std::vector<isa::DMInstruction>& body) {
+    constexpr Size kMaxLoopCount = 65535;  // LOOP_BEGIN count is uint16_t
+    while (count > 0) {
+        Size chunk = count < kMaxLoopCount ? count : kMaxLoopCount;
+        program.instructions.push_back(isa::DMInstruction::loop_begin(
+            loop_id, static_cast<uint16_t>(chunk)));
+        for (const auto& instr : body) {
+            program.instructions.push_back(instr);
+        }
+        program.instructions.push_back(isa::DMInstruction::loop_end(loop_id));
+        count -= chunk;
+    }
+}
+
+isa::DMProgram KernelCompiler::emit_streaming_program(
+    const std::string& name,
+    const std::vector<StreamingPass>& passes,
+    Size tile_elems, Size elem_size,
+    uint64_t total_flops, uint64_t external_bytes) {
+
+    isa::DMProgram program;
+    program.name = name;
+    program.Ti = tile_elems;   // Streaming ops are 1-D tiled: Ti elements/tile
+    program.Tj = 1;
+    program.Tk = 1;
+
+    // Configuration prologue: tile geometry and base addresses (actual
+    // addresses are bound at load time via the memory map)
+    program.instructions.push_back(
+        isa::DMInstruction::set_tile_dim(tile_elems, 1, 1, elem_size));
+    program.instructions.push_back(
+        isa::DMInstruction::set_base(isa::MatrixID::A, 0));
+    program.instructions.push_back(
+        isa::DMInstruction::set_base(isa::MatrixID::C, 0));
+
+    uint8_t loop_id = 0;
+    for (const auto& pass : passes) {
+        if (pass.input_tiles > 0) {
+            std::vector<isa::DMInstruction> body = {
+                isa::DMInstruction::dma_load_auto(isa::MatrixID::A, 0),
+                isa::DMInstruction::bm_move_auto(isa::MatrixID::A, 0),
+                isa::DMInstruction::str_feed_rows_auto(0),
+            };
+            if (pass.ve_opcode != isa::DMOpcode::NOP) {
+                body.push_back(ve_marker(pass.ve_opcode, pass.label));
+            }
+            append_tile_loop(program, loop_id, pass.input_tiles, body);
+            loop_id = static_cast<uint8_t>(loop_id + 1);
+        }
+        if (pass.output_tiles > 0) {
+            std::vector<isa::DMInstruction> body = {
+                isa::DMInstruction::str_drain_auto(0),
+                isa::DMInstruction::bm_writeback_auto(isa::MatrixID::C, 0),
+                isa::DMInstruction::dma_store_auto(isa::MatrixID::C, 0),
+            };
+            append_tile_loop(program, loop_id, pass.output_tiles, body);
+            loop_id = static_cast<uint8_t>(loop_id + 1);
+        }
+        program.instructions.push_back(isa::DMInstruction::barrier());
+    }
+    program.instructions.push_back(isa::DMInstruction::halt());
+
+    program.estimates.external_mem_bytes = external_bytes;
+    program.estimates.l3_bytes = external_bytes;
+    program.estimates.arithmetic_intensity = external_bytes > 0
+        ? static_cast<double>(total_flops) / static_cast<double>(external_bytes)
+        : 0.0;
+
+    last_stats_ = CompilationStats{};
+    last_stats_.instruction_count = program.instructions.size();
+    last_succeeded_ = true;
+    last_error_.clear();
+    return program;
+}
+
+Kernel KernelCompiler::compile_softmax(const SoftmaxConfig& config,
+                                       const CompileOptions& options) {
+    const Size tile_elems = 256;
+    const Size elem_size = dtype_size(options.dtype);
+    Size data_tiles = ceil_div_sz(config.total_elements(), tile_elems);
+    Size stat_tiles = ceil_div_sz(config.num_softmax_ops(), tile_elems);
+
+    // Numerically stable multi-pass softmax (the online single-pass form
+    // is the E8 pattern epic)
+    std::vector<StreamingPass> passes = {
+        {"softmax P1: running row max (VE_REDUCE MAX)",
+         isa::DMOpcode::VE_REDUCE, data_tiles, stat_tiles},
+        {"softmax P2: exp(x - max) (VE_ELEMENTWISE SUB,EXP)",
+         isa::DMOpcode::VE_ELEMENTWISE, data_tiles, data_tiles},
+        {"softmax P3: row sum of exp (VE_REDUCE SUM)",
+         isa::DMOpcode::VE_REDUCE, data_tiles, stat_tiles},
+        {"softmax P4: normalize by sum (VE_ELEMENTWISE DIV)",
+         isa::DMOpcode::VE_ELEMENTWISE, data_tiles, data_tiles},
+    };
+
+    uint64_t bytes = static_cast<uint64_t>(config.total_elements()) * elem_size;
+    auto program = emit_streaming_program("softmax", passes, tile_elems,
+                                          elem_size, config.total_flops(),
+                                          4 * bytes);
+    return Kernel(std::move(program), KernelOpType::SOFTMAX, options.dtype);
+}
+
+Kernel KernelCompiler::compile_layernorm(const LayerNormConfig& config,
+                                         const CompileOptions& options) {
+    const Size tile_elems = 256;
+    const Size elem_size = dtype_size(options.dtype);
+    Size data_tiles = ceil_div_sz(config.total_elements(), tile_elems);
+    Size group_tiles = ceil_div_sz(config.num_groups(), tile_elems);
+
+    std::vector<StreamingPass> passes = {
+        {"layernorm P1: per-group mean (VE_REDUCE SUM)",
+         isa::DMOpcode::VE_REDUCE, data_tiles, group_tiles},
+        {"layernorm P2: per-group variance (VE_ELEMENTWISE SUB,SQ + VE_REDUCE SUM)",
+         isa::DMOpcode::VE_REDUCE, data_tiles, group_tiles},
+        {"layernorm P3: normalize + affine (VE_ELEMENTWISE)",
+         isa::DMOpcode::VE_ELEMENTWISE, data_tiles, data_tiles},
+    };
+
+    uint64_t bytes = static_cast<uint64_t>(config.total_elements()) * elem_size;
+    auto program = emit_streaming_program("layernorm", passes, tile_elems,
+                                          elem_size, config.total_flops(),
+                                          3 * bytes);
+    return Kernel(std::move(program), KernelOpType::LAYERNORM, options.dtype);
+}
+
+Kernel KernelCompiler::compile_rmsnorm(const RMSNormConfig& config,
+                                       const CompileOptions& options) {
+    const Size tile_elems = 256;
+    const Size elem_size = dtype_size(options.dtype);
+    Size data_tiles = ceil_div_sz(config.total_elements(), tile_elems);
+    Size group_tiles = ceil_div_sz(config.num_groups(), tile_elems);
+
+    // RMSNorm skips mean centering: one reduction pass, one scale pass
+    std::vector<StreamingPass> passes = {
+        {"rmsnorm P1: per-group mean of squares (VE_REDUCE SUMSQ)",
+         isa::DMOpcode::VE_REDUCE, data_tiles, group_tiles},
+        {"rmsnorm P2: x * rsqrt(ms + eps) * gamma (VE_ELEMENTWISE)",
+         isa::DMOpcode::VE_ELEMENTWISE, data_tiles, data_tiles},
+    };
+
+    uint64_t bytes = static_cast<uint64_t>(config.total_elements()) * elem_size;
+    auto program = emit_streaming_program("rmsnorm", passes, tile_elems,
+                                          elem_size, config.total_flops(),
+                                          2 * bytes);
+    return Kernel(std::move(program), KernelOpType::RMSNORM, options.dtype);
+}
+
+Kernel KernelCompiler::compile_batchnorm(const BatchNormConfig& config,
+                                         const CompileOptions& options) {
+    const Size tile_elems = 256;
+    const Size elem_size = dtype_size(options.dtype);
+    Size data_tiles = ceil_div_sz(config.total_elements(), tile_elems);
+    // Per-channel parameters: running mean/var (+ gamma/beta when affine)
+    Size params_per_channel = config.affine ? 4 : 2;
+    Size param_tiles =
+        ceil_div_sz(params_per_channel * config.num_features, tile_elems);
+
+    std::vector<StreamingPass> passes = {
+        {"batchnorm P0: preload per-channel params (no VE)",
+         isa::DMOpcode::NOP, param_tiles, 0},
+        {"batchnorm P1: (x - mean) * rsqrt(var + eps) * gamma + beta (VE_ELEMENTWISE)",
+         isa::DMOpcode::VE_ELEMENTWISE, data_tiles, data_tiles},
+    };
+
+    uint64_t bytes = static_cast<uint64_t>(config.total_elements()) * elem_size;
+    auto program = emit_streaming_program("batchnorm", passes, tile_elems,
+                                          elem_size, config.total_flops(),
+                                          2 * bytes);
+    return Kernel(std::move(program), KernelOpType::BATCHNORM, options.dtype);
+}
+
+Kernel KernelCompiler::compile_elementwise(const ElementwiseConfig& config,
+                                           const CompileOptions& options) {
+    const Size tile_elems = 256;
+    const Size elem_size = dtype_size(options.dtype);
+    Size data_tiles = ceil_div_sz(config.total_elements(), tile_elems);
+    Size input_streams = (config.is_unary || config.is_scalar_b) ? 1 : 2;
+
+    std::vector<StreamingPass> passes = {
+        {"elementwise: apply op per tile (VE_ELEMENTWISE)",
+         isa::DMOpcode::VE_ELEMENTWISE, input_streams * data_tiles, data_tiles},
+    };
+
+    uint64_t bytes = static_cast<uint64_t>(config.total_elements()) * elem_size;
+    auto program = emit_streaming_program("elementwise", passes, tile_elems,
+                                          elem_size, config.total_elements(),
+                                          (input_streams + 1) * bytes);
+    return Kernel(std::move(program), KernelOpType::ELEMENTWISE, options.dtype);
+}
+
+Kernel KernelCompiler::compile_pool2d(const Pool2DConfig& config,
+                                      const CompileOptions& options) {
+    const Size tile_elems = 256;
+    const Size elem_size = dtype_size(options.dtype);
+    Size in_tiles = ceil_div_sz(config.input_elements(), tile_elems);
+    Size out_tiles = ceil_div_sz(config.output_elements(), tile_elems);
+
+    std::vector<StreamingPass> passes = {
+        {"pool2d: windowed reduction (VE_REDUCE MAX/AVG)",
+         isa::DMOpcode::VE_REDUCE, in_tiles, out_tiles},
+    };
+
+    uint64_t in_bytes = static_cast<uint64_t>(config.input_elements()) * elem_size;
+    uint64_t out_bytes = static_cast<uint64_t>(config.output_elements()) * elem_size;
+    auto program = emit_streaming_program("pool2d", passes, tile_elems,
+                                          elem_size, config.total_flops(),
+                                          in_bytes + out_bytes);
+    return Kernel(std::move(program), KernelOpType::POOL2D, options.dtype);
+}
+
 } // namespace sw::kpu::compiler

--- a/src/software/compiler/kernel_compiler.cpp
+++ b/src/software/compiler/kernel_compiler.cpp
@@ -641,6 +641,10 @@ isa::DMProgram KernelCompiler::emit_streaming_program(
 
     last_stats_ = CompilationStats{};
     last_stats_.instruction_count = program.instructions.size();
+    last_stats_.estimated_external_bytes = program.estimates.external_mem_bytes;
+    last_stats_.estimated_l3_bytes = program.estimates.l3_bytes;
+    last_stats_.estimated_arithmetic_intensity =
+        program.estimates.arithmetic_intensity;
     last_succeeded_ = true;
     last_error_.clear();
     return program;
@@ -756,7 +760,7 @@ Kernel KernelCompiler::compile_elementwise(const ElementwiseConfig& config,
 
     uint64_t bytes = static_cast<uint64_t>(config.total_elements()) * elem_size;
     auto program = emit_streaming_program("elementwise", passes, tile_elems,
-                                          elem_size, config.total_elements(),
+                                          elem_size, config.total_flops(),
                                           (input_streams + 1) * bytes);
     return Kernel(std::move(program), KernelOpType::ELEMENTWISE, options.dtype);
 }

--- a/src/software/isa/concurrent_executor.cpp
+++ b/src/software/isa/concurrent_executor.cpp
@@ -370,21 +370,23 @@ void ConcurrentExecutor::schedule_instruction(const DMInstruction& instr) {
         // address generation itself is implicit; only timing matters here.
         case DMOpcode::DMA_LOAD_TILE_AUTO:
         case DMOpcode::DMA_STORE_TILE_AUTO: {
+            const auto& ops = std::get<AutoDMAOperands>(instr.operands);
             auto& dma = memory_channels_[auto_rr_ % memory_channels_.size()]
                             .dma_engine;
             completion = dma.schedule_op(earliest, auto_tile_bytes_,
                                          instr.instruction_id, instr.label,
-                                         MatrixID::A, TileCoord{});
+                                         ops.matrix, TileCoord{});
             ++auto_rr_;
             break;
         }
 
         case DMOpcode::BM_MOVE_TILE_AUTO:
         case DMOpcode::BM_WRITEBACK_AUTO: {
+            const auto& ops = std::get<AutoBlockMoverOperands>(instr.operands);
             auto& bm = block_movers_[auto_rr_ % block_movers_.size()];
             completion = bm.schedule_op(earliest, auto_tile_bytes_,
                                         instr.instruction_id, instr.label,
-                                        MatrixID::A, TileCoord{});
+                                        ops.matrix, TileCoord{});
             ++auto_rr_;
             break;
         }
@@ -392,21 +394,31 @@ void ConcurrentExecutor::schedule_instruction(const DMInstruction& instr) {
         case DMOpcode::STR_FEED_ROWS_AUTO:
         case DMOpcode::STR_FEED_COLS_AUTO:
         case DMOpcode::STR_DRAIN_AUTO: {
+            // AutoStreamerOperands carries no matrix; map by opcode
+            // convention (rows feed A, columns feed B, drains produce C)
+            MatrixID mat = instr.opcode == DMOpcode::STR_FEED_ROWS_AUTO
+                ? MatrixID::A
+                : instr.opcode == DMOpcode::STR_FEED_COLS_AUTO
+                    ? MatrixID::B
+                    : MatrixID::C;
             auto& str = streamers_[auto_rr_ % streamers_.size()];
             completion = str.schedule_op(earliest, auto_tile_bytes_,
                                          instr.instruction_id, instr.label,
-                                         MatrixID::A, TileCoord{});
+                                         mat, TileCoord{});
             ++auto_rr_;
             break;
         }
 
         // Vector Engine ops (issue #92): timing envelope of one element per
         // fabric lane-cycle over the current tile; functional semantics land
-        // with the pattern epics (E2/E3)
+        // with the pattern epics (E2/E3). compute_fabric_'s bus_width is an
+        // elements-per-cycle throughput, so pass the ELEMENT count, not bytes
         case DMOpcode::VE_ELEMENTWISE:
         case DMOpcode::VE_REDUCE: {
+            Size tile_elems = auto_elem_size_ > 0
+                ? auto_tile_bytes_ / auto_elem_size_ : auto_tile_bytes_;
             completion = compute_fabric_.schedule_op(
-                earliest, auto_tile_bytes_, instr.instruction_id, instr.label,
+                earliest, tile_elems, instr.instruction_id, instr.label,
                 MatrixID::A, TileCoord{});
             break;
         }

--- a/src/software/isa/concurrent_executor.cpp
+++ b/src/software/isa/concurrent_executor.cpp
@@ -142,8 +142,34 @@ Cycle ConcurrentExecutor::execute(const DMProgram& program) {
     compute_fabric_.next_available_cycle = 0;
     compute_fabric_.completed_ops.clear();
 
-    // Schedule each instruction
-    for (const auto& instr : program.instructions) {
+    // Schedule each instruction, interpreting hardware loops (issue #92:
+    // per-op streaming programs are loop-based so their instruction streams
+    // stay compact; the timing model expands the loops at execution time)
+    struct LoopFrame { size_t body_start; uint16_t remaining; };
+    std::vector<LoopFrame> loop_stack;
+    auto_tile_bytes_ = 1024;
+    auto_elem_size_ = 4;
+    auto_rr_ = 0;
+    for (size_t pc = 0; pc < program.instructions.size(); ++pc) {
+        const auto& instr = program.instructions[pc];
+        if (instr.opcode == DMOpcode::LOOP_BEGIN) {
+            const auto& ops = std::get<LoopOperands>(instr.operands);
+            uint16_t count = ops.loop_count > 0 ? ops.loop_count : 1;
+            loop_stack.push_back({pc + 1, count});
+            continue;
+        }
+        if (instr.opcode == DMOpcode::LOOP_END) {
+            if (!loop_stack.empty()) {
+                auto& top = loop_stack.back();
+                if (top.remaining > 1) {
+                    --top.remaining;
+                    pc = top.body_start - 1;  // ++pc re-enters the body
+                    continue;
+                }
+                loop_stack.pop_back();
+            }
+            continue;
+        }
         schedule_instruction(instr);
     }
 
@@ -336,6 +362,62 @@ void ConcurrentExecutor::schedule_instruction(const DMInstruction& instr) {
             barrier_time = std::max(barrier_time, compute_fabric_.next_available_cycle);
             last_barrier_cycle_ = barrier_time;
             completion = barrier_time;
+            break;
+        }
+
+        // AUTO-addressed streaming ops (issue #92): scheduled with the tile
+        // geometry from SET_TILE_DIM, round-robined across resources. The
+        // address generation itself is implicit; only timing matters here.
+        case DMOpcode::DMA_LOAD_TILE_AUTO:
+        case DMOpcode::DMA_STORE_TILE_AUTO: {
+            auto& dma = memory_channels_[auto_rr_ % memory_channels_.size()]
+                            .dma_engine;
+            completion = dma.schedule_op(earliest, auto_tile_bytes_,
+                                         instr.instruction_id, instr.label,
+                                         MatrixID::A, TileCoord{});
+            ++auto_rr_;
+            break;
+        }
+
+        case DMOpcode::BM_MOVE_TILE_AUTO:
+        case DMOpcode::BM_WRITEBACK_AUTO: {
+            auto& bm = block_movers_[auto_rr_ % block_movers_.size()];
+            completion = bm.schedule_op(earliest, auto_tile_bytes_,
+                                        instr.instruction_id, instr.label,
+                                        MatrixID::A, TileCoord{});
+            ++auto_rr_;
+            break;
+        }
+
+        case DMOpcode::STR_FEED_ROWS_AUTO:
+        case DMOpcode::STR_FEED_COLS_AUTO:
+        case DMOpcode::STR_DRAIN_AUTO: {
+            auto& str = streamers_[auto_rr_ % streamers_.size()];
+            completion = str.schedule_op(earliest, auto_tile_bytes_,
+                                         instr.instruction_id, instr.label,
+                                         MatrixID::A, TileCoord{});
+            ++auto_rr_;
+            break;
+        }
+
+        // Vector Engine ops (issue #92): timing envelope of one element per
+        // fabric lane-cycle over the current tile; functional semantics land
+        // with the pattern epics (E2/E3)
+        case DMOpcode::VE_ELEMENTWISE:
+        case DMOpcode::VE_REDUCE: {
+            completion = compute_fabric_.schedule_op(
+                earliest, auto_tile_bytes_, instr.instruction_id, instr.label,
+                MatrixID::A, TileCoord{});
+            break;
+        }
+
+        case DMOpcode::SET_TILE_DIM: {
+            const auto& ops = std::get<TileDimOperands>(instr.operands);
+            Size elems = ops.Ti * (ops.Tj > 0 ? ops.Tj : 1) *
+                         (ops.Tk > 0 ? ops.Tk : 1);
+            auto_elem_size_ = ops.element_size > 0 ? ops.element_size : 4;
+            auto_tile_bytes_ = elems * auto_elem_size_;
+            completion = earliest;
             break;
         }
 

--- a/src/system/simulator/kernel.cpp
+++ b/src/system/simulator/kernel.cpp
@@ -79,11 +79,14 @@ Kernel Kernel::create_conv2d(const Conv2DConfig& config,
                              bool has_bias,
                              ActivationType activation,
                              DataType dtype) {
-    // Conv2D uses im2col + GEMM approach
-    // GEMM dimensions: [M, K] @ [K, N] -> [M, N]
-    // where M = batch * H_out * W_out
-    //       K = C_in * kernel_h * kernel_w
-    //       N = C_out
+    // Conv2D is INTENTIONALLY lowered as im2col + GEMM (not a placeholder;
+    // clarifies the question raised in issue #18):
+    //   GEMM dimensions: [M, K] @ [K, N] -> [M, N]
+    //   where M = batch * H_out * W_out
+    //         K = C_in * kernel_h * kernel_w
+    //         N = C_out
+    // with bias + activation fused on the drain path via compile_mlp.
+    // A direct sliding-window lowering is the conv2d pattern epic's scope.
 
     compiler::KernelCompiler compiler;
 
@@ -228,15 +231,11 @@ Kernel Kernel::create_layernorm(const LayerNormConfig& config, DataType dtype) {
     Size S = config.seq_len;
     Size D = config.normalized_dim;
 
-    // LayerNorm is not a matmul, but we create a placeholder program
-    // using a simple matmul structure for resource estimation
-    // In practice, layernorm would use the Vector Engine for reductions
+    // Faithful 3-pass streaming program (mean, variance, normalize+affine)
+    // built on VE_REDUCE / VE_ELEMENTWISE - see KernelCompiler::compile_layernorm
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-
-    // Use a 1xD matmul as placeholder for the reduction operations
-    // This gives reasonable resource estimates for the D-dimension operations
-    Kernel kernel = compiler.compile_matmul(1, D, D, opts);
+    Kernel kernel = compiler.compile_layernorm(config, opts);
 
     // Override operation type to LAYERNORM
     kernel.op_type_ = KernelOpType::LAYERNORM;
@@ -279,13 +278,11 @@ Kernel Kernel::create_rmsnorm(const RMSNormConfig& config, DataType dtype) {
     Size S = config.seq_len;
     Size D = config.normalized_dim;
 
-    // RMSNorm is not a matmul, but we create a placeholder program
-    // using a simple matmul structure for resource estimation
+    // Faithful 2-pass streaming program (mean-of-squares, scale) built on
+    // VE_REDUCE / VE_ELEMENTWISE - see KernelCompiler::compile_rmsnorm
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-
-    // Use a 1xD matmul as placeholder for the reduction operations
-    Kernel kernel = compiler.compile_matmul(1, D, D, opts);
+    Kernel kernel = compiler.compile_rmsnorm(config, opts);
 
     // Override operation type to RMSNORM
     kernel.op_type_ = KernelOpType::RMSNORM;
@@ -321,11 +318,11 @@ Kernel Kernel::create_batchnorm(const BatchNormConfig& config, DataType dtype) {
     Size H = config.height;
     Size W = config.width;
 
-    // BatchNorm is elementwise, but we compile a small matmul as placeholder
-    // for instruction generation (actual compute is per-element)
+    // Faithful streaming program (per-channel param preload + elementwise
+    // normalize pass) - see KernelCompiler::compile_batchnorm
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-    Kernel kernel = compiler.compile_matmul(1, C, C, opts);
+    Kernel kernel = compiler.compile_batchnorm(config, opts);
 
     // Override operation type and config
     kernel.op_type_ = KernelOpType::BATCHNORM;
@@ -360,18 +357,14 @@ Kernel Kernel::create_batchnorm(Size batch_size, Size num_features,
 Kernel Kernel::create_elementwise(const ElementwiseConfig& config, DataType dtype) {
     compiler::KernelCompiler compiler;
 
-    // Use a 1x1x1 matmul as the placeholder kernel framework — op_type
-    // and elementwise_config_ are overridden immediately below, so the
-    // placeholder's dimensions don't matter and any per-tile bookkeeping
-    // proportional to N would just be wasted (and large for big shapes:
-    // a vocab head softmax with N ~ 50k blows hundreds of MB on Windows
-    // MSVC). See kernel_test "Language model output" SECTION.
+    // Faithful streaming program (loop-based, so the instruction stream
+    // stays compact even for vocab-sized shapes - the old unrolled
+    // approach OOMed on Windows MSVC) - see
+    // KernelCompiler::compile_elementwise
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-    Kernel kernel = compiler.compile_matmul(1, 1, 1, opts);
+    Kernel kernel = compiler.compile_elementwise(config, opts);
 
-    // Override operation type and config
-    kernel.op_type_ = KernelOpType::ELEMENTWISE;
     kernel.elementwise_config_ = config;
     kernel.dtype_ = dtype;
 
@@ -434,13 +427,12 @@ Kernel Kernel::create_elementwise_scalar(ElementwiseOp op,
 Kernel Kernel::create_pool2d(const Pool2DConfig& config, DataType dtype) {
     compiler::KernelCompiler compiler;
 
-    // 1x1x1 placeholder matmul — see comment in create_elementwise.
+    // Faithful streaming program (windowed VE_REDUCE) - see
+    // KernelCompiler::compile_pool2d
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-    Kernel kernel = compiler.compile_matmul(1, 1, 1, opts);
+    Kernel kernel = compiler.compile_pool2d(config, opts);
 
-    // Override operation type and config
-    kernel.op_type_ = KernelOpType::POOL2D;
     kernel.pool2d_config_ = config;
     kernel.dtype_ = dtype;
 
@@ -528,13 +520,13 @@ Kernel Kernel::create_global_avg_pool2d(Size batch_size, Size channels,
 Kernel Kernel::create_softmax(const SoftmaxConfig& config, DataType dtype) {
     compiler::KernelCompiler compiler;
 
-    // 1x1x1 placeholder matmul — see comment in create_elementwise.
+    // Faithful 4-pass streaming program (max, exp, sum, normalize) built
+    // on VE_REDUCE / VE_ELEMENTWISE, loop-based so vocab-sized shapes stay
+    // compact - see KernelCompiler::compile_softmax
     compiler::CompileOptions opts = compiler::CompileOptions::defaults();
     opts.dtype = dtype;
-    Kernel kernel = compiler.compile_matmul(1, 1, 1, opts);
+    Kernel kernel = compiler.compile_softmax(config, opts);
 
-    // Override operation type and config
-    kernel.op_type_ = KernelOpType::SOFTMAX;
     kernel.softmax_config_ = config;
     kernel.dtype_ = dtype;
 

--- a/tests/driver/test_kernel.cpp
+++ b/tests/driver/test_kernel.cpp
@@ -2684,3 +2684,82 @@ TEST_CASE("Softmax common use cases", "[kernel][softmax]") {
         REQUIRE(kernel.softmax_config().num_softmax_ops() == 1 * 1024);
     }
 }
+
+// ============================================================================
+// Op-faithful programs (issue #18 / #92): non-matmul factories must compile
+// their actual op into the DMProgram, not a matmul placeholder. The VE
+// opcodes are structural markers (functional semantics land with the
+// pattern epics E2/E3); movement, tiling, and loop-based compactness are
+// asserted here.
+// ============================================================================
+
+namespace {
+
+size_t count_opcode(const sw::kpu::Kernel& kernel, sw::kpu::isa::DMOpcode op) {
+    size_t n = 0;
+    for (const auto& instr : kernel.program().instructions) {
+        if (instr.opcode == op) ++n;
+    }
+    return n;
+}
+
+} // namespace
+
+TEST_CASE("Non-matmul kernels compile op-faithful programs", "[kernel][programs]") {
+    using sw::kpu::isa::DMOpcode;
+
+    SECTION("softmax carries its 4-pass reduce/elementwise structure") {
+        // The GPT-2-shaped case that #17 shrank the placeholder to dodge:
+        // vocab-sized softmax must be compact (loops) AND faithful
+        auto kernel = Kernel::create_softmax({64, 50257}, -1);
+        REQUIRE(kernel.op_type() == KernelOpType::SOFTMAX);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_REDUCE) >= 2);       // max, sum
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_ELEMENTWISE) >= 2);  // exp, div
+        REQUIRE(count_opcode(kernel, DMOpcode::LOOP_BEGIN) >= 4);
+        // Loop-based emission keeps vocab-scale programs tiny (anti-OOM)
+        REQUIRE(kernel.program().instructions.size() < 300);
+    }
+
+    SECTION("layernorm carries mean/variance reductions and a normalize pass") {
+        auto kernel = Kernel::create_layernorm(8, 128, 768);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_REDUCE) >= 2);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_ELEMENTWISE) >= 1);
+        REQUIRE(count_opcode(kernel, DMOpcode::LOOP_BEGIN) >= 3);
+    }
+
+    SECTION("rmsnorm carries one reduction and one scale pass") {
+        auto kernel = Kernel::create_rmsnorm(8, 128, 768);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_REDUCE) >= 1);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_ELEMENTWISE) >= 1);
+    }
+
+    SECTION("batchnorm carries a param preload and an elementwise pass") {
+        auto kernel = Kernel::create_batchnorm(8, 64, 56, 56);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_ELEMENTWISE) >= 1);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_REDUCE) == 0);
+        REQUIRE(count_opcode(kernel, DMOpcode::LOOP_BEGIN) >= 2);
+    }
+
+    SECTION("elementwise binary streams two inputs, compact at large shapes") {
+        auto kernel = Kernel::create_elementwise(
+            ElementwiseOp::ADD, {1024, 1024});
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_ELEMENTWISE) >= 1);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_REDUCE) == 0);
+        REQUIRE(kernel.program().instructions.size() < 100);
+    }
+
+    SECTION("pool2d carries a windowed reduction") {
+        auto kernel = Kernel::create_max_pool2d(1, 64, 56, 56, 2, 2);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_REDUCE) >= 1);
+        REQUIRE(count_opcode(kernel, DMOpcode::VE_ELEMENTWISE) == 0);
+    }
+
+    SECTION("conv2d is intentionally an im2col GEMM with fused epilogue") {
+        auto kernel = Kernel::create_conv2d(1, 3, 64, 224, 224, 3, 3);
+        const auto& program = kernel.program();
+        // im2col GEMM dimensions, not a 1x1x1 placeholder
+        REQUIRE(program.K == 3 * 3 * 3);   // C_in * Kh * Kw
+        REQUIRE(program.N == 64);          // C_out
+        REQUIRE(program.M > 1);            // batch * H_out * W_out
+    }
+}


### PR DESCRIPTION
Fixes #92 (Wave 0 infra-T4, epic #69). Resolves the **structural half of #18**; #18 stays open for the numerical half (see below).

## The lie, fixed

Every non-matmul `Kernel::create_*` piggybacked on `compile_matmul` and stamped a different `op_type_` over an unrelated instruction stream — launching a "softmax kernel" computed a matmul. Now `KernelCompiler` has per-op streaming compilers emitting **loop-based DMPrograms with real tile traffic** and VE pass markers:

| Op | Program structure |
|---|---|
| softmax | 4 passes: max (VE_REDUCE), exp (VE_ELEMENTWISE), sum (VE_REDUCE), normalize (VE_ELEMENTWISE) |
| layernorm | 3 passes: mean, variance, normalize+affine |
| rmsnorm | 2 passes: mean-of-squares, scale |
| batchnorm | param preload + elementwise normalize |
| elementwise | 1 pass, 1 or 2 input streams |
| pool2d | windowed VE_REDUCE |
| conv2d | **intentional** im2col+GEMM with fused epilogue — documented, resolving #18's open design question |

Loop-based emission (`LOOP_BEGIN/END`, exact ≤65535 decomposition) keeps vocab-scale programs compact — the GPT-2-shaped softmax that OOMed Windows under unrolled emission (#17's workaround) compiles to <300 instructions, asserted in tests.

## ConcurrentExecutor learns loops/AUTO/VE

The timing executor had no LOOP/AUTO support (the matmul builder emits unrolled non-AUTO ops), so the new programs timed to **0 cycles** — `benchmark_bandwidth` failed immediately, which was the correctness signal working. The executor now interprets hardware loops, AUTO ops (geometry from `SET_TILE_DIM`, round-robin resources), and VE ops (one element/lane-cycle envelope).

## Scope boundary (per #18's own open question)

The VE opcodes are structural markers with descriptive labels; their functional semantics + executor-level numerical oracles are exactly the E2 (broadcast/elementwise) and E3 (online reductions) pattern-epic capability-closure tasks, where the operand-encoding design belongs. #18 remains open for that half. Benchmark acceptance item: `src/tools/benchmark` runs through `ConcurrentExecutor`, a timing model for **every** op (matmul included) — documented as performance-only, now over faithful movement.

## Verification

- Full suite: **100/100 pass** (new op-faithfulness case: 21 assertions; `benchmark_bandwidth` and `analytical_validation` restored)
- Session log: `docs/sessions/2026-07-12_v0.9_nonmatmul_kernel_factories.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-matmul operations now compile into operation-specific, streaming “faithful” kernels instead of placeholder matmul programs.
  * Softmax, normalization, elementwise, batchnorm, and pool2d execution now uses real streaming loops, tile transfers, and VE markers.
  * Enhanced concurrent execution with support for hardware loop control, automatic tile addressing, and timing via VE ops.
  * Conv2D kernel validation now checks realistic im2col/GEMM dimensions.
* **New Features**
  * Added per-operation streaming compiler entry points (softmax/layernorm/rmsnorm/batchnorm/elementwise/pool2d).
* **Documentation**
  * Added a v0.9 decision log with test/benchmark outcomes and next steps.
* **Tests**
  * Added opcode-structure and program-size checks for non-matmul kernel factories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->