### PR TITLE
feat(coverage): machine-checkable pattern-coverage matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CSP pattern-coverage matrix (#93, completes Wave 0).**
+  `tests/coverage/pattern_coverage.json` is the machine-checkable operator
+  x pattern x lifecycle-stage matrix for the coverage program (21
+  operators, 9 pattern classes, 5 stages, truthful current statuses -
+  baseline 8/105 cells done). `test_pattern_coverage` enforces schema
+  consistency and **milestone gates**: a milestone marked achieved must
+  have every required capability at "done", so the matrix cannot
+  overclaim and achieved milestones cannot silently regress. Pattern
+  epics update rows as they land; the model-validation epic (E18)
+  asserts the full matrix through these gates.
+
 ### Fixed
 
 - **Non-matmul Kernel factories now compile their actual op (#92, fixes

--- a/docs/sessions/2026-07-12_v0.9_pattern_coverage_matrix.md
+++ b/docs/sessions/2026-07-12_v0.9_pattern_coverage_matrix.md
@@ -1,0 +1,89 @@
+# v0.9 Pattern-Coverage Matrix Scaffold Decision Log
+
+**Date:** 2026-07-12
+**Version:** v0.9
+**Status:** Complete (closes Wave 0 of the pattern-coverage program)
+**Tests:** 101/101 suites passing (new: test_pattern_coverage, 469 assertions)
+**Issue:** #93 (Wave 0 infra-T5, epic #69)
+
+## 1. Summary
+
+Built the machine-checkable coverage matrix that the pattern-coverage
+program tracks itself against: a JSON manifest of 21 operators x 9 pattern
+classes x 5 lifecycle stages (the epic T1-T5 stages) with truthful current
+statuses, and a Catch2 test enforcing schema consistency plus milestone
+gates - an "achieved" milestone must have every required capability at
+"done". Baseline: 8/105 cells done (matmul fully green, epilogue-fusion
+functional via M1). This completes Wave 0 (infra-T1..T5 all merged).
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| tests/coverage/pattern_coverage.json (21 ops, honest statuses) | Done |
+| Schema test: unique names, valid patterns/epics/models/stages/statuses | Done |
+| Pattern-class exercise check (every P1-P9 referenced) | Done |
+| Milestone gates (M1 achieved + gated; M2/M4/M7/M8 declared) | Done |
+| Coverage summary WARN line (8/105 = 7.6%) | Done |
+| ctest wiring (label: coverage, csp-patterns) | Done |
+
+Files:
+- `tests/coverage/pattern_coverage.json` (new)
+- `tests/coverage/test_pattern_coverage.cpp` (new)
+- `tests/coverage/CMakeLists.txt` (new), `tests/CMakeLists.txt`
+- `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: JSON manifest + C++ test, not a generated report.**
+- **Choice:** hand-maintained JSON as the single source of truth; the test
+  enforces consistency and gates.
+- **Alternatives considered:** derive coverage from code introspection
+  (grep for generators/tests) - brittle and blind to functional-vs-marker
+  distinctions; markdown table in docs - not machine-checkable.
+- **Rationale:** the statuses encode judgment (e.g. "VE opcode exists but
+  is a structural marker" = partial) that only humans can assert; the test
+  makes the judgments consistent and the milestones honest.
+
+**Decision 2: milestone gates as the enforcement mechanism.**
+- **Choice:** a milestone marked achieved requires all its (operator,
+  stage) requirements at done; unachieved milestones declare requirements
+  without enforcement.
+- **Rationale:** two failure modes are blocked: overclaiming (marking M2
+  achieved while conv2d.functional is missing fails CI) and silent
+  regression (downgrading a cell below an achieved milestone fails CI).
+  E18 (#87) becomes "flip the remaining milestones to achieved and keep
+  this test green".
+
+**Decision 3: truthful statuses over optimistic ones.**
+- **Choice:** kernel-level streaming programs (#142) rate "partial" on
+  generator (structural, no VE semantics); #139-affected schedule
+  generators rate "partial"; only matmul's five cells and epilogue's
+  functional (M1-validated) rate "done".
+- **Rationale:** the matrix's value is credibility; 8/105 is the honest
+  starting line the program will visibly move.
+
+## 4. Issues Encountered
+
+None.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                      # 101/101 pass
+./build/tests/coverage/test_pattern_coverage # 469 assertions,
+                                             # "8/105 cells done (7.6%)"
+```
+
+## 7. Next Steps
+
+- Wave 0 is COMPLETE (infra-T1 #89, T2 #90, T3 #91, T4 #92, T5 #93).
+- Epic #69 can close; Wave 0/1 pattern epics open: E1 gather (#70),
+  E2 broadcast/elementwise (#71), E3 online reductions (#72), E4 layout
+  (#73), then Wave 1 dense compute (E5-E7) toward milestone M2 (ResNet).
+- Each landing epic updates its manifest rows in the same PR.

--- a/docs/sessions/2026-07-12_v0.9_pattern_coverage_matrix.md
+++ b/docs/sessions/2026-07-12_v0.9_pattern_coverage_matrix.md
@@ -13,8 +13,9 @@ program tracks itself against: a JSON manifest of 21 operators x 9 pattern
 classes x 5 lifecycle stages (the epic T1-T5 stages) with truthful current
 statuses, and a Catch2 test enforcing schema consistency plus milestone
 gates - an "achieved" milestone must have every required capability at
-"done". Baseline: 8/105 cells done (matmul fully green, epilogue-fusion
-functional via M1). This completes Wave 0 (infra-T1..T5 all merged).
+"done". Baseline: 8/105 cells done (matmul all 5 stages; epilogue-fusion
+functional via M1; ISA closure for gemm_family and epilogue_fused, whose
+opcodes are complete). This completes Wave 0 (infra-T1..T5 all merged).
 
 ## 2. Scope
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ add_subdirectory(quantization)
 add_subdirectory(dsl)
 add_subdirectory(harness)
 add_subdirectory(timing)
+add_subdirectory(coverage)
 
 # Custom test targets for different categories
 # These targets are defined here because they orchestrate across all subdirectories

--- a/tests/coverage/CMakeLists.txt
+++ b/tests/coverage/CMakeLists.txt
@@ -1,0 +1,19 @@
+# ============================================================================
+# tests/coverage/CMakeLists.txt
+# CSP pattern-coverage matrix (issue #93)
+#
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+# ============================================================================
+
+kpu_add_component_test(test_pattern_coverage "coverage"
+    test_pattern_coverage.cpp
+)
+
+target_compile_definitions(test_pattern_coverage PRIVATE
+    COVERAGE_MANIFEST_PATH="${CMAKE_CURRENT_SOURCE_DIR}/pattern_coverage.json"
+)
+
+set_tests_properties(test_pattern_coverage PROPERTIES
+    LABELS "coverage;csp-patterns;v0.9"
+)

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -1,0 +1,371 @@
+{
+  "description": "Machine-checkable CSP data-movement pattern coverage matrix (issue #93). Pattern epics update operator rows as capabilities land; test_pattern_coverage enforces schema consistency and milestone gates; the model-validation epic (E18, #87) asserts the full matrix. Plan: docs/plans/csp_pattern_coverage_roadmap.md.",
+  "pattern_classes": {
+    "P1": "dense GEMM streaming",
+    "P2": "sliding-window reuse (halo)",
+    "P3": "row-streaming/online reduction",
+    "P4": "gather/scatter (indirect)",
+    "P5": "broadcast",
+    "P6": "two-operand aligned streaming",
+    "P7": "layout transform in flight",
+    "P8": "chained-GEMM fusion (on-chip intermediates)",
+    "P9": "append/growing extent"
+  },
+  "stages": ["design", "isa_closure", "generator", "functional", "regression"],
+  "statuses": ["done", "partial", "missing"],
+  "operators": [
+    {
+      "name": "matmul",
+      "patterns": ["P1"],
+      "epic": 74,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "done",
+        "isa_closure": "done",
+        "generator": "done",
+        "functional": "done",
+        "regression": "done"
+      },
+      "notes": "Square matmul baseline: envelope-aware generators (#67/#68), value-producing CSP execution (#66), strategy x size x envelope regression (#64), partitioned credits (#89)."
+    },
+    {
+      "name": "gemm_family",
+      "patterns": ["P1"],
+      "epic": 74,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "partial",
+        "isa_closure": "done",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Batched GEMM, strongly rectangular aspect ratios, envelope-aware weight/input-stationary strategies."
+    },
+    {
+      "name": "conv2d",
+      "patterns": ["P1", "P2", "P7"],
+      "epic": 75,
+      "models": ["cv"],
+      "stages": {
+        "design": "partial",
+        "isa_closure": "partial",
+        "generator": "partial",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "im2col+GEMM lowering exists (kernel factory, intentional per #18/#142); CSP schedule generator emits DRAIN without COMPUTE (#139); direct sliding-window/halo path missing."
+    },
+    {
+      "name": "pooling",
+      "patterns": ["P2", "P3"],
+      "epic": 76,
+      "models": ["cv"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "partial",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Kernel-level streaming program with VE_REDUCE markers (#142); VE semantics and CSP schedule missing."
+    },
+    {
+      "name": "softmax",
+      "patterns": ["P3"],
+      "epic": 77,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "partial",
+        "isa_closure": "partial",
+        "generator": "partial",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Multi-pass form only (envelope-checked, #90); online single-pass is the epic's core; schedule generator affected by #139; kernel program op-faithful (#142)."
+    },
+    {
+      "name": "layernorm",
+      "patterns": ["P3", "P5"],
+      "epic": 78,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "partial",
+        "isa_closure": "partial",
+        "generator": "partial",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Multi-pass generator (envelope-checked, #90; #139 applies); kernel program op-faithful (#142)."
+    },
+    {
+      "name": "rmsnorm",
+      "patterns": ["P3", "P5"],
+      "epic": 78,
+      "models": ["llm"],
+      "stages": {
+        "design": "partial",
+        "isa_closure": "partial",
+        "generator": "partial",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Kernel-level 2-pass streaming program (#142); no CSP schedule generator yet."
+    },
+    {
+      "name": "batchnorm",
+      "patterns": ["P3", "P5"],
+      "epic": 78,
+      "models": ["cv"],
+      "stages": {
+        "design": "partial",
+        "isa_closure": "partial",
+        "generator": "partial",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Multi-pass generator (envelope-checked incl. all-channel preload residency, #90/#140; #139 applies); inference fold is the epic's target."
+    },
+    {
+      "name": "elementwise",
+      "patterns": ["P5", "P6"],
+      "epic": 71,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "partial",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "VE_ELEMENTWISE opcode is a structural marker (no functional semantics); kernel program op-faithful (#142); two-operand aligned streaming pattern is the epic's core."
+    },
+    {
+      "name": "epilogue_fused",
+      "patterns": ["P1", "P5", "P6"],
+      "epic": 79,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "partial",
+        "isa_closure": "done",
+        "generator": "partial",
+        "functional": "done",
+        "regression": "partial"
+      },
+      "notes": "matmul+bias+activation: fused drain in the ISA, MatMulComputeSpec computes it functionally (#66), validated numerically in milestone M1 (#137); conv+BN+relu fusion and tiled epilogue generators are the epic's remainder."
+    },
+    {
+      "name": "ffn_fused",
+      "patterns": ["P8", "P6"],
+      "epic": 80,
+      "models": ["llm", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "partial",
+        "regression": "missing"
+      },
+      "notes": "Multi-layer MLP chains execute functionally with resident intermediates (FunctionalMLPExecutor, #66); SwiGLU gating and the fused-block schedule are missing."
+    },
+    {
+      "name": "gather_scatter",
+      "patterns": ["P4"],
+      "epic": 70,
+      "models": ["llm", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "DMA_LOAD_GATHER/STORE_SCATTER opcodes exist as annotation-only no-ops."
+    },
+    {
+      "name": "broadcast",
+      "patterns": ["P5"],
+      "epic": 71,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "STR_BROADCAST_ROW/COL opcodes exist as annotation-only no-ops."
+    },
+    {
+      "name": "online_reduction",
+      "patterns": ["P3"],
+      "epic": 72,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "VE_REDUCE opcode is a structural marker; running max/sum/mean/var semantics are the epic's core (enables online softmax and flash attention)."
+    },
+    {
+      "name": "layout_transform",
+      "patterns": ["P7"],
+      "epic": 73,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "BM_TRANSPOSE exercised only for B-matrix transpose; BM_RESHAPE, patchify, head split/merge missing."
+    },
+    {
+      "name": "attention",
+      "patterns": ["P8", "P3", "P1"],
+      "epic": 81,
+      "models": ["cv", "llm", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Kernel factory lowers the QK^T core as a matmul shape only; chained and flash-fused movement patterns missing."
+    },
+    {
+      "name": "kv_cache",
+      "patterns": ["P9", "P4"],
+      "epic": 82,
+      "models": ["llm"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "missing",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Append/growing-extent movement has no ISA or executor support yet."
+    },
+    {
+      "name": "rope",
+      "patterns": ["P5", "P6"],
+      "epic": 83,
+      "models": ["llm"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Depends on broadcast + elementwise primitives (E2)."
+    },
+    {
+      "name": "embedding_logits",
+      "patterns": ["P4", "P1"],
+      "epic": 84,
+      "models": ["llm"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "partial",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Gather side depends on E1; logits side on rectangular GEMM (gemm_family)."
+    },
+    {
+      "name": "spatial_boundary",
+      "patterns": ["P7", "P2"],
+      "epic": 85,
+      "models": ["cv", "jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "missing",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Patchify, upsample/interpolation, transposed conv."
+    },
+    {
+      "name": "jepa_masking",
+      "patterns": ["P4", "P7"],
+      "epic": 86,
+      "models": ["jepa"],
+      "stages": {
+        "design": "missing",
+        "isa_closure": "missing",
+        "generator": "missing",
+        "functional": "missing",
+        "regression": "missing"
+      },
+      "notes": "Context/target token gather-scatter by mask indices."
+    }
+  ],
+  "milestones": [
+    {
+      "id": "M1",
+      "issue": 129,
+      "achieved": true,
+      "requires": [
+        {"operator": "matmul", "stage": "functional"},
+        {"operator": "matmul", "stage": "regression"},
+        {"operator": "epilogue_fused", "stage": "functional"}
+      ]
+    },
+    {
+      "id": "M2",
+      "issue": 130,
+      "achieved": false,
+      "requires": [
+        {"operator": "conv2d", "stage": "functional"},
+        {"operator": "pooling", "stage": "functional"},
+        {"operator": "batchnorm", "stage": "functional"},
+        {"operator": "epilogue_fused", "stage": "regression"},
+        {"operator": "elementwise", "stage": "functional"}
+      ]
+    },
+    {
+      "id": "M4",
+      "issue": 132,
+      "achieved": false,
+      "requires": [
+        {"operator": "attention", "stage": "functional"},
+        {"operator": "softmax", "stage": "functional"},
+        {"operator": "online_reduction", "stage": "functional"},
+        {"operator": "layout_transform", "stage": "functional"}
+      ]
+    },
+    {
+      "id": "M7",
+      "issue": 135,
+      "achieved": false,
+      "requires": [
+        {"operator": "attention", "stage": "regression"},
+        {"operator": "kv_cache", "stage": "functional"},
+        {"operator": "rope", "stage": "functional"},
+        {"operator": "rmsnorm", "stage": "functional"},
+        {"operator": "ffn_fused", "stage": "functional"},
+        {"operator": "embedding_logits", "stage": "functional"}
+      ]
+    },
+    {
+      "id": "M8",
+      "issue": 136,
+      "achieved": false,
+      "requires": [
+        {"operator": "jepa_masking", "stage": "functional"},
+        {"operator": "gather_scatter", "stage": "functional"},
+        {"operator": "attention", "stage": "functional"},
+        {"operator": "layernorm", "stage": "functional"}
+      ]
+    }
+  ]
+}

--- a/tests/coverage/test_pattern_coverage.cpp
+++ b/tests/coverage/test_pattern_coverage.cpp
@@ -1,0 +1,157 @@
+// ============================================================================
+// tests/coverage/test_pattern_coverage.cpp
+// Machine-checkable CSP pattern-coverage matrix (issue #93)
+//
+// Enforces the schema and consistency of tests/coverage/pattern_coverage.json
+// and asserts milestone gates: a milestone marked "achieved" must have every
+// required (operator, stage) at "done". Pattern epics update the manifest as
+// capabilities land; the model-validation epic (E18, #87) asserts the full
+// matrix through these gates.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+
+namespace {
+
+nlohmann::json load_manifest() {
+    std::ifstream file(COVERAGE_MANIFEST_PATH);
+    REQUIRE(file.is_open());
+    nlohmann::json manifest;
+    file >> manifest;
+    return manifest;
+}
+
+} // namespace
+
+TEST_CASE("Coverage manifest is schema-consistent", "[coverage]") {
+    auto manifest = load_manifest();
+
+    // Pattern classes P1..P9 are all defined
+    const auto& patterns = manifest.at("pattern_classes");
+    for (int p = 1; p <= 9; ++p) {
+        std::string key = "P" + std::to_string(p);
+        INFO("pattern class " << key);
+        REQUIRE(patterns.contains(key));
+    }
+
+    std::set<std::string> valid_stages;
+    for (const auto& s : manifest.at("stages")) {
+        valid_stages.insert(s.get<std::string>());
+    }
+    std::set<std::string> valid_statuses;
+    for (const auto& s : manifest.at("statuses")) {
+        valid_statuses.insert(s.get<std::string>());
+    }
+    REQUIRE(valid_stages.size() == 5);
+    REQUIRE(valid_statuses == std::set<std::string>{"done", "partial", "missing"});
+
+    std::set<std::string> names;
+    std::set<std::string> referenced_patterns;
+    const std::set<std::string> valid_models{"cv", "llm", "jepa"};
+
+    for (const auto& op : manifest.at("operators")) {
+        std::string name = op.at("name").get<std::string>();
+        INFO("operator " << name);
+
+        // Unique names
+        REQUIRE(names.insert(name).second);
+
+        // Valid, non-empty pattern references
+        REQUIRE_FALSE(op.at("patterns").empty());
+        for (const auto& p : op.at("patterns")) {
+            REQUIRE(patterns.contains(p.get<std::string>()));
+            referenced_patterns.insert(p.get<std::string>());
+        }
+
+        // Epic reference is a plausible issue number
+        REQUIRE(op.at("epic").get<int>() > 0);
+
+        // At least one model family
+        REQUIRE_FALSE(op.at("models").empty());
+        for (const auto& m : op.at("models")) {
+            REQUIRE(valid_models.count(m.get<std::string>()) == 1);
+        }
+
+        // Every stage present with a valid status
+        const auto& stages = op.at("stages");
+        REQUIRE(stages.size() == valid_stages.size());
+        for (const auto& stage : valid_stages) {
+            INFO("stage " << stage);
+            REQUIRE(stages.contains(stage));
+            REQUIRE(valid_statuses.count(
+                        stages.at(stage).get<std::string>()) == 1);
+        }
+    }
+
+    // Every pattern class is exercised by at least one operator
+    for (int p = 1; p <= 9; ++p) {
+        std::string key = "P" + std::to_string(p);
+        INFO("pattern class " << key << " must be referenced by an operator");
+        REQUIRE(referenced_patterns.count(key) == 1);
+    }
+}
+
+TEST_CASE("Milestone gates hold", "[coverage][milestones]") {
+    auto manifest = load_manifest();
+
+    // Index operator stages by name
+    std::map<std::string, nlohmann::json> ops;
+    for (const auto& op : manifest.at("operators")) {
+        ops[op.at("name").get<std::string>()] = op.at("stages");
+    }
+
+    for (const auto& milestone : manifest.at("milestones")) {
+        std::string id = milestone.at("id").get<std::string>();
+        bool achieved = milestone.at("achieved").get<bool>();
+
+        for (const auto& req : milestone.at("requires")) {
+            std::string op_name = req.at("operator").get<std::string>();
+            std::string stage = req.at("stage").get<std::string>();
+            INFO("milestone " << id << " requires " << op_name << "." << stage);
+
+            // Requirements must reference real operators and stages
+            REQUIRE(ops.count(op_name) == 1);
+            REQUIRE(ops[op_name].contains(stage));
+
+            // An achieved milestone's requirements must all be done -
+            // this is the gate that keeps the matrix honest: you cannot
+            // mark a milestone achieved while a required capability is
+            // partial or missing, and you cannot regress a capability
+            // below an achieved milestone without this test failing.
+            if (achieved) {
+                REQUIRE(ops[op_name].at(stage).get<std::string>() == "done");
+            }
+        }
+    }
+}
+
+TEST_CASE("Coverage summary is reportable", "[coverage]") {
+    auto manifest = load_manifest();
+
+    size_t total = 0;
+    size_t done = 0;
+    for (const auto& op : manifest.at("operators")) {
+        for (const auto& [stage, status] : op.at("stages").items()) {
+            ++total;
+            if (status.get<std::string>() == "done") ++done;
+        }
+    }
+    // The matrix must never be empty, and the baseline (matmul + M1) work
+    // guarantees a nonzero floor of completed cells
+    REQUIRE(total >= 100);
+    REQUIRE(done >= 6);
+
+    WARN("Pattern coverage: " << done << "/" << total
+         << " operator-stage cells done ("
+         << (100.0 * static_cast<double>(done) / static_cast<double>(total))
+         << "%)");
+}


### PR DESCRIPTION
Fixes #93 — the **final Wave 0 task** of the CSP pattern-coverage program (epic #69, umbrella #88).

## What

- **`tests/coverage/pattern_coverage.json`** — the operator × pattern × lifecycle-stage matrix: 21 operators, the 9 pattern classes (P1–P9), and the five epic stages (design / isa_closure / generator / functional / regression), with **truthful current statuses**: matmul fully green (the #61–#68 arc), epilogue fusion functional (M1-validated), everything VE-marker-based honestly rated partial. Baseline: **8/105 cells done (7.6%)** — the starting line the program will visibly move.
- **`test_pattern_coverage`** (ctest, label `coverage`) enforces:
  - schema consistency — unique names, valid pattern/epic/model/stage/status references, every pattern class exercised by ≥1 operator
  - **milestone gates** — a milestone marked `achieved` must have every required (operator, stage) at `done`. This blocks both failure modes: *overclaiming* (marking M2 achieved while `conv2d.functional` is missing fails CI) and *silent regression* (downgrading a cell below an achieved milestone fails CI). M1 is achieved and gated; M2/M4/M7/M8 requirements are declared for when their epics land.
  - a coverage summary line in the test output so CI logs always show the number

## Process contract

Pattern epics update their manifest rows **in the same PR** that lands the capability; E18 (#87, model-block validation) becomes "flip the remaining milestone gates to achieved and keep this test green."

## Verification

Full suite: **101/101 pass** (new test: 469 assertions). Session log: `docs/sessions/2026-07-12_v0.9_pattern_coverage_matrix.md`.

Merging this completes Wave 0 (infra-T1 #89 → T5 #93 all landed) and opens the pattern epics E1–E4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CSP “pattern-coverage matrix” detailing operators, pattern classes, lifecycle stages, and milestone-gated progress.
  * Introduced machine-checkable coverage reporting that emphasizes truthful “done” statuses and milestone enforcement.

* **Tests**
  * Added automated validation for matrix schema/consistency, operator-stage completeness, and milestone gate correctness.
  * Wired the coverage checks into the standard CMake/CTest test suite.

* **Documentation**
  * Added a session decision log for the v0.9 Wave 0 completion and verification results.
  * Updated the changelog with the new coverage matrix capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->