### PR TITLE
feat(isa): VE_ELEMENTWISE operands + semantics; broadcast ref seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VE_ELEMENTWISE functional semantics + broadcast ref-count seeding
+  (#100, epic E2 broadcast/elementwise).** `VEOperands` gives
+  VE_ELEMENTWISE real operands (14 op kinds: binary/unary/scalar forms,
+  L1 src/dst addressing) with factory methods, assembler syntax, and
+  binary serializer round-trip (`.kpubin` format v2, with static_assert
+  drift guards); the behavioral executor applies the ops elementwise over
+  L1 buffers with IEEE semantics, validated exactly against a host oracle
+  - the elementwise share of #18's numerical half. Broadcast (P5):
+  `TileDescriptor.consumer_count` lets one MOVE seed the L2 TagCAM
+  ref-count with the downstream feed count (1:1:k discipline, one credit
+  per entry preserved), tested at TagCAM and BlockMover level. Discovered
+  and filed #144: the serializer cannot round-trip register-file/AUTO
+  operand types (pre-existing; reader throws).
+
 - **CSP pattern-coverage matrix (#93, completes Wave 0).**
   `tests/coverage/pattern_coverage.json` is the machine-checkable operator
   x pattern x lifecycle-stage matrix for the coverage program (21

--- a/docs/sessions/2026-07-12_v0.9_e2_ve_operands_broadcast.md
+++ b/docs/sessions/2026-07-12_v0.9_e2_ve_operands_broadcast.md
@@ -1,0 +1,108 @@
+# v0.9 E2-T2: VE Operands + Broadcast Seeding Decision Log
+
+**Date:** 2026-07-12
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 101/101 suites passing (new: 6 behavioral VE oracle checks,
+VEOperands round-trip case, 4 TagCAM broadcast sections, BM seeding case)
+**Issues:** #100 (done), #144 (filed - discovered defect), #18 (elementwise
+share of the numerical half delivered)
+
+## 1. Summary
+
+Implemented E2-T2 per the approved design
+(docs/plans/e2_broadcast_elementwise_pattern.md): VE_ELEMENTWISE gained
+real operand encoding and functional semantics in the behavioral executor
+(exact-match host-oracle validation), and the broadcast movement pattern
+gained its 1:1:k mechanism - one MOVE seeds the L2 TagCAM reference count
+with the tile's consumer count, preserving one-credit-per-entry
+conservation. Discovered and filed #144: the serializer cannot round-trip
+register-file/AUTO operand types (pre-existing, reader throws).
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| VEOp enum (14 kinds) + VEOperands struct + variant widening | Done |
+| Factories: ve_elementwise / _unary / _scalar with labels | Done |
+| Assembler syntax (binary/unary/scalar forms) | Done |
+| Serializer round-trip, format v2, static_assert drift guards | Done |
+| Behavioral executor semantics (IEEE, no domain guards) | Done |
+| TagCAM seeded insert (refs=k; 0 clamps to 1; capacity respected) | Done |
+| TileDescriptor.consumer_count + BlockMover seeding | Done |
+| Tests: oracle exactness, round-trip, seeding at CAM + BM level | Done |
+| Coverage rows: elementwise.isa_closure -> done; notes updated | Done |
+| #144 filed (serializer gap for operand indices 7-15) | Done |
+
+Files modified:
+- `include/sw/kpu/isa/data_movement_isa.hpp`, `src/software/isa/data_movement_isa.cpp`
+- `include/sw/kpu/isa/program_serializer.hpp`, `src/software/isa/program_serializer.cpp`
+- `src/software/isa/assembler.cpp`
+- `include/sw/kpu/isa/behavioral_program_executor.hpp`, `src/software/isa/behavioral_program_executor.cpp`
+- `include/sw/kpu/timing/tag_cam.hpp`, `tile_descriptor.hpp`, `block_mover_process.hpp`
+- `tests/isa/test_behavioral_program_executor.cpp`, `tests/isa/test_serialization.cpp`
+- `tests/timing/test_tag_cam.cpp`, `tests/timing/test_block_mover_process.cpp`
+- `tests/coverage/pattern_coverage.json`
+- `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: IEEE semantics without domain guards.**
+- **Choice:** DIV by zero -> inf, sqrt of negative -> NaN, per std ops.
+- **Alternatives considered:** guarded variants (return 0) - diverges from
+  any host oracle and hides numerical issues.
+- **Rationale:** the oracle applies the same std operations; validation
+  compares like for like, and tests exercise in-domain inputs.
+
+**Decision 2: static_assert drift guards in the serializer.**
+- **Choice:** assert variant size == 17 and VEOperands at index 16.
+- **Rationale:** the operand-type tag is the variant index; silent
+  reordering would corrupt every .kpubin. The guard also forces whoever
+  fixes #144 to bump the version deliberately.
+
+**Decision 3: broadcast seeding via TileDescriptor.consumer_count.**
+- **Choice:** the descriptor carries the downstream feed count; the
+  BlockMover seeds the L2 entry on move-complete. Default 1 = ordinary
+  pipeline, bit-identical behavior.
+- **Alternatives considered:** a distinct BROADCAST_MOVE schedule op -
+  schema growth for what is a property of the tile's consumption; k
+  duplicate moves - the #61 credit-leak class the design explicitly
+  forbids.
+
+**Decision 4: behavioral STR_BROADCAST stays annotation-only in T2.**
+- **Choice:** the resident-operand realization (design option 1) is the
+  E2 primary and lands with T4's functional integration; the replicated
+  delivery already has ConcurrentExecutor timing.
+- **Rationale:** T2 is capability closure for the ops the generator (T3)
+  and functional path (T4) consume next; implementing an unused behavioral
+  replication path now would be speculative.
+
+## 4. Issues Encountered
+
+1. Discovered #144: serializer writer emits no payload for operand
+   indices 7-15 and the reader throws on them - .kpubin round-trip is
+   broken for AUTO/config programs (pre-existing; all #142 kernel
+   programs affected).
+2. Namespace slip in test_tag_cam additions (isa:: vs imported names) -
+   -Werror caught it.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                                  # 101/101
+./build/tests/isa/behavioral_program_executor_test      # VE oracle: exact
+./build/tests/coverage/test_pattern_coverage            # gates hold
+```
+
+## 7. Next Steps
+
+- E2-T3 (#101): ElementwiseScheduleGenerator (paired two-stream emission)
+  + broadcast emission helper; resolves #139 for the elementwise family.
+- E2-T4 (#102): CSP functional execution with oracles (flips
+  elementwise/broadcast functional cells).
+- #144: serializer round-trip for operand indices 7-15.

--- a/include/sw/kpu/isa/behavioral_program_executor.hpp
+++ b/include/sw/kpu/isa/behavioral_program_executor.hpp
@@ -159,6 +159,13 @@ private:
     void fire_compute();
 
     /**
+     * @brief Apply a Vector Engine elementwise operation over L1 buffers
+     *        (issue #100): out = op(a[, b or scalar]) elementwise, over
+     *        the program's Ti x Tj tile
+     */
+    void execute_ve_elementwise(const VEOperands& ops);
+
+    /**
      * @brief Resolve external memory address for a tile
      */
     Address resolve_address(MatrixID matrix, const TileCoord& tile) const;

--- a/include/sw/kpu/isa/data_movement_isa.hpp
+++ b/include/sw/kpu/isa/data_movement_isa.hpp
@@ -389,6 +389,41 @@ struct AutoStreamerOperands {
 // Data Movement Instruction
 // ============================================================================
 
+// ============================================================================
+// Vector Engine Operands (issue #100, epic E2 #71)
+// ============================================================================
+
+/**
+ * @brief Vector Engine elementwise operation kinds
+ *
+ * Binary forms consume two L1 operands; unary forms one; *_S forms apply
+ * a scalar broadcast to one operand. Reduction kinds (running max/sum/
+ * mean/var) belong to VE_REDUCE and are designed in epic E3.
+ */
+enum class VEOp : uint8_t {
+    // Binary (num_inputs = 2)
+    ADD = 0, SUB, MUL, DIV, MAX, MIN,
+    // Unary (num_inputs = 1)
+    NEG, ABS, SQRT, EXP, LOG,
+    // Scalar broadcast (num_inputs = 1 + scalar)
+    ADD_S, MUL_S, POW_S
+};
+
+/**
+ * @brief Vector Engine elementwise operands (VE_ELEMENTWISE)
+ *
+ * Gives VE_ELEMENTWISE real semantics (previously a monostate structural
+ * marker): apply `op` over the addressed L1 buffers, elementwise.
+ */
+struct VEOperands {
+    VEOp op = VEOp::ADD;        // Operation kind
+    uint8_t num_inputs = 2;     // 1 (unary / scalar forms), 2 (binary)
+    float scalar = 0.0f;        // Operand for ADD_S / MUL_S / POW_S
+    uint8_t l1_src_a = 0;       // L1 buffer of operand A
+    uint8_t l1_src_b = 0;       // L1 buffer of operand B (binary forms)
+    uint8_t l1_dst = 0;         // L1 buffer of the result
+};
+
 /**
  * @brief A single data movement instruction
  *
@@ -417,7 +452,9 @@ struct DMInstruction {
         // AUTO addressing operands
         AutoDMAOperands,            // DMA_*_AUTO
         AutoBlockMoverOperands,     // BM_*_AUTO
-        AutoStreamerOperands        // STR_*_AUTO
+        AutoStreamerOperands,       // STR_*_AUTO
+        // Vector Engine operands (issue #100)
+        VEOperands                  // VE_ELEMENTWISE
     > operands;
 
     // Timing hints (from SURE analysis)
@@ -502,7 +539,27 @@ struct DMInstruction {
                                         BufferSlot buf = BufferSlot::BUF_0,
                                         bool ve_enabled = false,
                                         ActivationType ve_act = ActivationType::NONE);
+
+    // Vector Engine factory methods (issue #100)
+    static DMInstruction ve_elementwise(VEOp op,
+                                        uint8_t l1_src_a, uint8_t l1_src_b,
+                                        uint8_t l1_dst);
+    static DMInstruction ve_elementwise_unary(VEOp op,
+                                              uint8_t l1_src, uint8_t l1_dst);
+    static DMInstruction ve_elementwise_scalar(VEOp op, float scalar,
+                                               uint8_t l1_src, uint8_t l1_dst);
 };
+
+/**
+ * @brief Name of a Vector Engine operation (for labels/assembly)
+ */
+const char* to_string(VEOp op);
+
+/**
+ * @brief Parse a Vector Engine operation name (inverse of to_string)
+ * @return true and sets op on success
+ */
+bool ve_op_from_string(const std::string& name, VEOp& op);
 
 // ============================================================================
 // Data Movement Program

--- a/include/sw/kpu/isa/program_serializer.hpp
+++ b/include/sw/kpu/isa/program_serializer.hpp
@@ -18,7 +18,7 @@ namespace sw::kpu::isa {
  * @brief Binary format magic number and version
  */
 constexpr uint32_t DMPROGRAM_MAGIC = 0x4B505544;  // "KPUD" in little-endian
-constexpr uint32_t DMPROGRAM_VERSION = 1;
+constexpr uint32_t DMPROGRAM_VERSION = 2;  // v2: VEOperands (issue #100)
 
 /**
  * @brief Error thrown during serialization/deserialization

--- a/include/sw/kpu/timing/block_mover_process.hpp
+++ b/include/sw/kpu/timing/block_mover_process.hpp
@@ -246,7 +246,8 @@ private:
                 // the ordinary pipeline has consumer_count = 1.
                 l2_tag_cam_.insert(in_flight_->tile.tile_id, in_flight_->slot_id,
                                    current_cycle,
-                                   in_flight_->tile.consumer_count);
+                                   static_cast<uint32_t>(
+                                       in_flight_->tile.consumer_count));
                 // Only release L3 credit if tile was fully removed (ref_count reached 0)
                 bool credit_released = l3_tag_cam_.invalidate(in_flight_->tile.tile_id);
                 if (credit_released) {

--- a/include/sw/kpu/timing/block_mover_process.hpp
+++ b/include/sw/kpu/timing/block_mover_process.hpp
@@ -241,8 +241,12 @@ private:
 
         if (in_flight_->is_complete(current_cycle)) {
             if (in_flight_is_move_) {
-                // Move complete: tile arrived at L2
-                l2_tag_cam_.insert(in_flight_->tile.tile_id, in_flight_->slot_id, current_cycle);
+                // Move complete: tile arrived at L2. The ref count is seeded
+                // with the tile's consumer count (broadcast 1:1:k, #100);
+                // the ordinary pipeline has consumer_count = 1.
+                l2_tag_cam_.insert(in_flight_->tile.tile_id, in_flight_->slot_id,
+                                   current_cycle,
+                                   in_flight_->tile.consumer_count);
                 // Only release L3 credit if tile was fully removed (ref_count reached 0)
                 bool credit_released = l3_tag_cam_.invalidate(in_flight_->tile.tile_id);
                 if (credit_released) {

--- a/include/sw/kpu/timing/tag_cam.hpp
+++ b/include/sw/kpu/timing/tag_cam.hpp
@@ -88,10 +88,29 @@ public:
      * after completing a load to L3).
      */
     bool insert(const TileID& tile_id, uint32_t slot_id, Cycle arrival_cycle) {
-        // Check if already present - increment ref_count
+        return insert(tile_id, slot_id, arrival_cycle, 1);
+    }
+
+    /**
+     * @brief Insert a tile arrival with a seeded reference count (issue #100)
+     * @param refs Number of pending consumers for this arrival
+     *
+     * Broadcast discipline (docs/plans/e2_broadcast_elementwise_pattern.md):
+     * one MOVE delivering a tile that k feeds will consume seeds the entry
+     * with ref_count = k, instead of accumulating references through k
+     * duplicate moves (the #61 credit-leak class). Credit conservation is
+     * unchanged: the entry holds exactly one credit for its lifetime,
+     * released when the reference count reaches zero. If the tile is
+     * already present, the references are added to the existing entry.
+     */
+    bool insert(const TileID& tile_id, uint32_t slot_id, Cycle arrival_cycle,
+                size_t refs) {
+        if (refs == 0) refs = 1;
+
+        // Check if already present - add references
         auto it = entries_.find(tile_id);
         if (it != entries_.end()) {
-            it->second.ref_count++;
+            it->second.ref_count += refs;
             return true;  // Success - tile reuse
         }
 
@@ -100,7 +119,9 @@ public:
             return false;  // Full
         }
 
-        entries_[tile_id] = TagCAMEntry(tile_id, slot_id, arrival_cycle);
+        TagCAMEntry entry(tile_id, slot_id, arrival_cycle);
+        entry.ref_count = refs;
+        entries_[tile_id] = entry;
         return true;
     }
 

--- a/include/sw/kpu/timing/tag_cam.hpp
+++ b/include/sw/kpu/timing/tag_cam.hpp
@@ -104,7 +104,7 @@ public:
      * already present, the references are added to the existing entry.
      */
     bool insert(const TileID& tile_id, uint32_t slot_id, Cycle arrival_cycle,
-                size_t refs) {
+                uint32_t refs) {
         if (refs == 0) refs = 1;
 
         // Check if already present - add references

--- a/include/sw/kpu/timing/tile_descriptor.hpp
+++ b/include/sw/kpu/timing/tile_descriptor.hpp
@@ -130,6 +130,14 @@ struct TileDescriptor {
     Cycle enqueue_cycle = 0;  // When this was added to work queue
     Size priority = 0;        // Higher = more urgent (for aging)
 
+    // Broadcast consumer count (issue #100): how many downstream feeds
+    // will consume this tile after one MOVE delivers it. The BlockMover
+    // seeds the L2 TagCAM ref_count with this value, making the
+    // one-load-many-feeds (1:1:k) broadcast discipline explicit while
+    // preserving one-credit-per-entry conservation. Default 1 = the
+    // ordinary 1:1:1 pipeline.
+    Size consumer_count = 1;
+
     // Compute size from dimensions
     Size compute_size_bytes() const {
         return height * width * element_size;

--- a/src/software/isa/assembler.cpp
+++ b/src/software/isa/assembler.cpp
@@ -765,11 +765,45 @@ DMInstruction Assembler::parse_str_broadcast_col() {
 }
 
 DMInstruction Assembler::parse_ve_elementwise() {
+    // Syntax (issue #100):
+    //   binary:  VE_ELEMENTWISE <OP>, <l1_src_a>, <l1_src_b>, <l1_dst>
+    //   unary:   VE_ELEMENTWISE <OP>, <l1_src>, <l1_dst>
+    //   scalar:  VE_ELEMENTWISE <OP_S> <scalar>, <l1_src>, <l1_dst>
     DMInstruction instr;
     instr.opcode = DMOpcode::VE_ELEMENTWISE;
-    // For now, just consume the operation name
-    consume(TokenType::IDENTIFIER, "elementwise operation");
-    instr.operands = std::monostate{};
+
+    Token op_tok = consume(TokenType::IDENTIFIER, "elementwise operation");
+    VEOp op;
+    if (!ve_op_from_string(op_tok.text, op)) {
+        error("Unknown VE elementwise operation: " + op_tok.text);
+    }
+
+    VEOperands ops;
+    ops.op = op;
+
+    const bool scalar_form =
+        op == VEOp::ADD_S || op == VEOp::MUL_S || op == VEOp::POW_S;
+    const bool unary_form =
+        scalar_form || op == VEOp::NEG || op == VEOp::ABS ||
+        op == VEOp::SQRT || op == VEOp::EXP || op == VEOp::LOG;
+
+    if (scalar_form) {
+        ops.scalar = static_cast<float>(parse_number());
+    }
+    match(TokenType::COMMA);
+    ops.l1_src_a = static_cast<uint8_t>(parse_number());
+    match(TokenType::COMMA);
+    if (unary_form) {
+        ops.num_inputs = 1;
+        ops.l1_dst = static_cast<uint8_t>(parse_number());
+    } else {
+        ops.num_inputs = 2;
+        ops.l1_src_b = static_cast<uint8_t>(parse_number());
+        match(TokenType::COMMA);
+        ops.l1_dst = static_cast<uint8_t>(parse_number());
+    }
+
+    instr.operands = ops;
     return instr;
 }
 

--- a/src/software/isa/behavioral_program_executor.cpp
+++ b/src/software/isa/behavioral_program_executor.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <sw/kpu/isa/behavioral_program_executor.hpp>
+#include <cmath>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
@@ -225,10 +226,18 @@ void BehavioralProgramExecutor::dispatch(const DMInstruction& instr, [[maybe_unu
         // (data already in L2, compute reads it directly in softmax path)
         break;
 
-    // Gather/scatter and VE opcodes — annotations, not functional in behavioral
+    case DMOpcode::VE_ELEMENTWISE:
+        // Functional when carrying VEOperands (issue #100); legacy
+        // monostate markers remain no-ops
+        if (std::holds_alternative<VEOperands>(instr.operands)) {
+            execute_ve_elementwise(std::get<VEOperands>(instr.operands));
+        }
+        break;
+
+    // Gather/scatter, VE_REDUCE (E3 scope), and scratch opcodes —
+    // annotations, not functional in behavioral
     case DMOpcode::DMA_LOAD_GATHER:
     case DMOpcode::DMA_STORE_SCATTER:
-    case DMOpcode::VE_ELEMENTWISE:
     case DMOpcode::VE_REDUCE:
     case DMOpcode::L2_SCRATCH_WRITE:
     case DMOpcode::L2_SCRATCH_READ:
@@ -511,6 +520,56 @@ void BehavioralProgramExecutor::dispatch_barrier() {
 // ============================================================================
 // Compute: C += A × B on L1 tile data
 // ============================================================================
+
+void BehavioralProgramExecutor::execute_ve_elementwise(const VEOperands& ops) {
+    if (!program_) return;
+    Size elems = program_->Ti * program_->Tj;
+    if (elems == 0) return;
+    if (ops.l1_src_a >= hw_.l1_buffers.size() ||
+        ops.l1_dst >= hw_.l1_buffers.size()) {
+        return;
+    }
+
+    const Size bytes = elems * sizeof(float);
+    std::vector<float> a(elems);
+    hw_.l1_buffers[ops.l1_src_a].read(0, a.data(), bytes);
+
+    std::vector<float> b;
+    if (ops.num_inputs == 2) {
+        if (ops.l1_src_b >= hw_.l1_buffers.size()) return;
+        b.resize(elems);
+        hw_.l1_buffers[ops.l1_src_b].read(0, b.data(), bytes);
+    }
+
+    // IEEE semantics without domain guards (div-by-zero -> inf, sqrt of
+    // negative -> NaN): the host oracle applies the same std operations,
+    // so validation compares like for like
+    std::vector<float> out(elems);
+    for (Size i = 0; i < elems; ++i) {
+        const float x = a[i];
+        const float y = ops.num_inputs == 2 ? b[i] : ops.scalar;
+        float r = 0.0f;
+        switch (ops.op) {
+            case VEOp::ADD:   r = x + y; break;
+            case VEOp::SUB:   r = x - y; break;
+            case VEOp::MUL:   r = x * y; break;
+            case VEOp::DIV:   r = x / y; break;
+            case VEOp::MAX:   r = x > y ? x : y; break;
+            case VEOp::MIN:   r = x < y ? x : y; break;
+            case VEOp::NEG:   r = -x; break;
+            case VEOp::ABS:   r = std::fabs(x); break;
+            case VEOp::SQRT:  r = std::sqrt(x); break;
+            case VEOp::EXP:   r = std::exp(x); break;
+            case VEOp::LOG:   r = std::log(x); break;
+            case VEOp::ADD_S: r = x + ops.scalar; break;
+            case VEOp::MUL_S: r = x * ops.scalar; break;
+            case VEOp::POW_S: r = std::pow(x, ops.scalar); break;
+        }
+        out[i] = r;
+    }
+
+    hw_.l1_buffers[ops.l1_dst].write(0, out.data(), bytes);
+}
 
 void BehavioralProgramExecutor::fire_compute() {
     if (!program_) return;

--- a/src/software/isa/data_movement_isa.cpp
+++ b/src/software/isa/data_movement_isa.cpp
@@ -586,6 +586,112 @@ DMInstruction DMInstruction::str_drain_auto(uint8_t l2_bank, BufferSlot buf,
 }
 
 // ============================================================================
+// Vector Engine factory methods (issue #100)
+// ============================================================================
+
+const char* to_string(VEOp op) {
+    switch (op) {
+        case VEOp::ADD:   return "ADD";
+        case VEOp::SUB:   return "SUB";
+        case VEOp::MUL:   return "MUL";
+        case VEOp::DIV:   return "DIV";
+        case VEOp::MAX:   return "MAX";
+        case VEOp::MIN:   return "MIN";
+        case VEOp::NEG:   return "NEG";
+        case VEOp::ABS:   return "ABS";
+        case VEOp::SQRT:  return "SQRT";
+        case VEOp::EXP:   return "EXP";
+        case VEOp::LOG:   return "LOG";
+        case VEOp::ADD_S: return "ADD_S";
+        case VEOp::MUL_S: return "MUL_S";
+        case VEOp::POW_S: return "POW_S";
+    }
+    return "UNKNOWN";
+}
+
+bool ve_op_from_string(const std::string& name, VEOp& op) {
+    static const std::pair<const char*, VEOp> kMap[] = {
+        {"ADD", VEOp::ADD},     {"SUB", VEOp::SUB},   {"MUL", VEOp::MUL},
+        {"DIV", VEOp::DIV},     {"MAX", VEOp::MAX},   {"MIN", VEOp::MIN},
+        {"NEG", VEOp::NEG},     {"ABS", VEOp::ABS},   {"SQRT", VEOp::SQRT},
+        {"EXP", VEOp::EXP},     {"LOG", VEOp::LOG},
+        {"ADD_S", VEOp::ADD_S}, {"MUL_S", VEOp::MUL_S},
+        {"POW_S", VEOp::POW_S},
+    };
+    for (const auto& [key, value] : kMap) {
+        if (name == key) {
+            op = value;
+            return true;
+        }
+    }
+    return false;
+}
+
+DMInstruction DMInstruction::ve_elementwise(VEOp op, uint8_t l1_src_a,
+                                            uint8_t l1_src_b, uint8_t l1_dst) {
+    DMInstruction instr;
+    instr.opcode = DMOpcode::VE_ELEMENTWISE;
+
+    VEOperands ops;
+    ops.op = op;
+    ops.num_inputs = 2;
+    ops.l1_src_a = l1_src_a;
+    ops.l1_src_b = l1_src_b;
+    ops.l1_dst = l1_dst;
+    instr.operands = ops;
+
+    std::ostringstream oss;
+    oss << "VE_ELEMENTWISE " << to_string(op)
+        << ", L1[" << static_cast<int>(l1_src_a) << "]"
+        << ", L1[" << static_cast<int>(l1_src_b) << "]"
+        << " -> L1[" << static_cast<int>(l1_dst) << "]";
+    instr.label = oss.str();
+    return instr;
+}
+
+DMInstruction DMInstruction::ve_elementwise_unary(VEOp op, uint8_t l1_src,
+                                                  uint8_t l1_dst) {
+    DMInstruction instr;
+    instr.opcode = DMOpcode::VE_ELEMENTWISE;
+
+    VEOperands ops;
+    ops.op = op;
+    ops.num_inputs = 1;
+    ops.l1_src_a = l1_src;
+    ops.l1_dst = l1_dst;
+    instr.operands = ops;
+
+    std::ostringstream oss;
+    oss << "VE_ELEMENTWISE " << to_string(op)
+        << ", L1[" << static_cast<int>(l1_src) << "]"
+        << " -> L1[" << static_cast<int>(l1_dst) << "]";
+    instr.label = oss.str();
+    return instr;
+}
+
+DMInstruction DMInstruction::ve_elementwise_scalar(VEOp op, float scalar,
+                                                   uint8_t l1_src,
+                                                   uint8_t l1_dst) {
+    DMInstruction instr;
+    instr.opcode = DMOpcode::VE_ELEMENTWISE;
+
+    VEOperands ops;
+    ops.op = op;
+    ops.num_inputs = 1;
+    ops.scalar = scalar;
+    ops.l1_src_a = l1_src;
+    ops.l1_dst = l1_dst;
+    instr.operands = ops;
+
+    std::ostringstream oss;
+    oss << "VE_ELEMENTWISE " << to_string(op) << " " << scalar
+        << ", L1[" << static_cast<int>(l1_src) << "]"
+        << " -> L1[" << static_cast<int>(l1_dst) << "]";
+    instr.label = oss.str();
+    return instr;
+}
+
+// ============================================================================
 // DMProgram Statistics
 // ============================================================================
 

--- a/src/software/isa/program_serializer.cpp
+++ b/src/software/isa/program_serializer.cpp
@@ -239,7 +239,17 @@ void ProgramSerializer::write_instruction(std::vector<uint8_t>& buffer, const DM
             write_value(buffer, arg.stride_m);
             write_value(buffer, arg.stride_n);
             write_value(buffer, arg.stride_k);
+        } else if constexpr (std::is_same_v<T, VEOperands>) {
+            write_value(buffer, static_cast<uint8_t>(arg.op));
+            write_value(buffer, arg.num_inputs);
+            write_value(buffer, arg.scalar);
+            write_value(buffer, arg.l1_src_a);
+            write_value(buffer, arg.l1_src_b);
+            write_value(buffer, arg.l1_dst);
         }
+        // NOTE: register-file config (SET_BASE family) and AUTO operand
+        // types are not yet serialized - pre-existing gap, tracked
+        // separately (programs using them cannot round-trip .kpubin)
     }, instr.operands);
 }
 
@@ -375,12 +385,33 @@ size_t ProgramSerializer::read_instruction(const std::vector<uint8_t>& data, siz
             instr.operands = ops;
             break;
         }
+        case 16: { // VEOperands (issue #100)
+            VEOperands ops;
+            ops.op = static_cast<VEOp>(read_value<uint8_t>(data, offset));
+            ops.num_inputs = read_value<uint8_t>(data, offset);
+            ops.scalar = read_value<float>(data, offset);
+            ops.l1_src_a = read_value<uint8_t>(data, offset);
+            ops.l1_src_b = read_value<uint8_t>(data, offset);
+            ops.l1_dst = read_value<uint8_t>(data, offset);
+            instr.operands = ops;
+            break;
+        }
         default:
             throw SerializationError("Unknown operand type: " + std::to_string(operand_type));
     }
 
     return offset;
 }
+
+// Guard against variant drift: VEOperands must stay at index 16 (the
+// serialized operand-type tag) unless the format version is bumped again
+static_assert(std::variant_size_v<decltype(DMInstruction::operands)> == 17,
+              "DMInstruction operand variant changed - update the serializer "
+              "cases and bump DMPROGRAM_VERSION");
+static_assert(std::is_same_v<
+                  std::variant_alternative_t<16, decltype(DMInstruction::operands)>,
+                  VEOperands>,
+              "VEOperands moved in the operand variant - update case 16");
 
 // ============================================================================
 // Memory Map Serialization

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -11,14 +11,30 @@
     "P8": "chained-GEMM fusion (on-chip intermediates)",
     "P9": "append/growing extent"
   },
-  "stages": ["design", "isa_closure", "generator", "functional", "regression"],
-  "statuses": ["done", "partial", "missing"],
+  "stages": [
+    "design",
+    "isa_closure",
+    "generator",
+    "functional",
+    "regression"
+  ],
+  "statuses": [
+    "done",
+    "partial",
+    "missing"
+  ],
   "operators": [
     {
       "name": "matmul",
-      "patterns": ["P1"],
+      "patterns": [
+        "P1"
+      ],
       "epic": 74,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "done",
         "isa_closure": "done",
@@ -30,9 +46,15 @@
     },
     {
       "name": "gemm_family",
-      "patterns": ["P1"],
+      "patterns": [
+        "P1"
+      ],
       "epic": 74,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "partial",
         "isa_closure": "done",
@@ -44,9 +66,15 @@
     },
     {
       "name": "conv2d",
-      "patterns": ["P1", "P2", "P7"],
+      "patterns": [
+        "P1",
+        "P2",
+        "P7"
+      ],
       "epic": 75,
-      "models": ["cv"],
+      "models": [
+        "cv"
+      ],
       "stages": {
         "design": "partial",
         "isa_closure": "partial",
@@ -58,9 +86,14 @@
     },
     {
       "name": "pooling",
-      "patterns": ["P2", "P3"],
+      "patterns": [
+        "P2",
+        "P3"
+      ],
       "epic": 76,
-      "models": ["cv"],
+      "models": [
+        "cv"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -72,9 +105,15 @@
     },
     {
       "name": "softmax",
-      "patterns": ["P3"],
+      "patterns": [
+        "P3"
+      ],
       "epic": 77,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "partial",
         "isa_closure": "partial",
@@ -86,9 +125,16 @@
     },
     {
       "name": "layernorm",
-      "patterns": ["P3", "P5"],
+      "patterns": [
+        "P3",
+        "P5"
+      ],
       "epic": 78,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "partial",
         "isa_closure": "partial",
@@ -100,9 +146,14 @@
     },
     {
       "name": "rmsnorm",
-      "patterns": ["P3", "P5"],
+      "patterns": [
+        "P3",
+        "P5"
+      ],
       "epic": 78,
-      "models": ["llm"],
+      "models": [
+        "llm"
+      ],
       "stages": {
         "design": "partial",
         "isa_closure": "partial",
@@ -114,9 +165,14 @@
     },
     {
       "name": "batchnorm",
-      "patterns": ["P3", "P5"],
+      "patterns": [
+        "P3",
+        "P5"
+      ],
       "epic": 78,
-      "models": ["cv"],
+      "models": [
+        "cv"
+      ],
       "stages": {
         "design": "partial",
         "isa_closure": "partial",
@@ -128,23 +184,38 @@
     },
     {
       "name": "elementwise",
-      "patterns": ["P5", "P6"],
+      "patterns": [
+        "P5",
+        "P6"
+      ],
       "epic": 71,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
-        "isa_closure": "partial",
+        "isa_closure": "done",
         "generator": "partial",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "VE_ELEMENTWISE opcode is a structural marker (no functional semantics); kernel program op-faithful (#142); two-operand aligned streaming pattern is the epic's core."
+      "notes": "VE_ELEMENTWISE has full operand encoding (VEOperands, format v2), assembler/serializer round-trip, and functional semantics in the behavioral executor (#100); CSP functional path rides FunctionalComputeSpec. Two-operand aligned streaming schedule is E2-T3."
     },
     {
       "name": "epilogue_fused",
-      "patterns": ["P1", "P5", "P6"],
+      "patterns": [
+        "P1",
+        "P5",
+        "P6"
+      ],
       "epic": 79,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "partial",
         "isa_closure": "done",
@@ -156,9 +227,15 @@
     },
     {
       "name": "ffn_fused",
-      "patterns": ["P8", "P6"],
+      "patterns": [
+        "P8",
+        "P6"
+      ],
       "epic": 80,
-      "models": ["llm", "jepa"],
+      "models": [
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -170,9 +247,14 @@
     },
     {
       "name": "gather_scatter",
-      "patterns": ["P4"],
+      "patterns": [
+        "P4"
+      ],
       "epic": 70,
-      "models": ["llm", "jepa"],
+      "models": [
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -184,9 +266,15 @@
     },
     {
       "name": "broadcast",
-      "patterns": ["P5"],
+      "patterns": [
+        "P5"
+      ],
       "epic": 71,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -194,13 +282,19 @@
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "STR_BROADCAST_ROW/COL opcodes exist as annotation-only no-ops."
+      "notes": "STR_BROADCAST_ROW/COL opcodes timed in ConcurrentExecutor; broadcast ref-count seeding (1:1:k via TileDescriptor.consumer_count, #100) in the CSP tier. Behavioral STR_BROADCAST semantics + resident-operand realization land with E2-T4."
     },
     {
       "name": "online_reduction",
-      "patterns": ["P3"],
+      "patterns": [
+        "P3"
+      ],
       "epic": 72,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -212,9 +306,15 @@
     },
     {
       "name": "layout_transform",
-      "patterns": ["P7"],
+      "patterns": [
+        "P7"
+      ],
       "epic": 73,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -226,9 +326,17 @@
     },
     {
       "name": "attention",
-      "patterns": ["P8", "P3", "P1"],
+      "patterns": [
+        "P8",
+        "P3",
+        "P1"
+      ],
       "epic": 81,
-      "models": ["cv", "llm", "jepa"],
+      "models": [
+        "cv",
+        "llm",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -240,9 +348,14 @@
     },
     {
       "name": "kv_cache",
-      "patterns": ["P9", "P4"],
+      "patterns": [
+        "P9",
+        "P4"
+      ],
       "epic": 82,
-      "models": ["llm"],
+      "models": [
+        "llm"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "missing",
@@ -254,9 +367,14 @@
     },
     {
       "name": "rope",
-      "patterns": ["P5", "P6"],
+      "patterns": [
+        "P5",
+        "P6"
+      ],
       "epic": 83,
-      "models": ["llm"],
+      "models": [
+        "llm"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -268,9 +386,14 @@
     },
     {
       "name": "embedding_logits",
-      "patterns": ["P4", "P1"],
+      "patterns": [
+        "P4",
+        "P1"
+      ],
       "epic": 84,
-      "models": ["llm"],
+      "models": [
+        "llm"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
@@ -282,9 +405,15 @@
     },
     {
       "name": "spatial_boundary",
-      "patterns": ["P7", "P2"],
+      "patterns": [
+        "P7",
+        "P2"
+      ],
       "epic": 85,
-      "models": ["cv", "jepa"],
+      "models": [
+        "cv",
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "missing",
@@ -296,9 +425,14 @@
     },
     {
       "name": "jepa_masking",
-      "patterns": ["P4", "P7"],
+      "patterns": [
+        "P4",
+        "P7"
+      ],
       "epic": 86,
-      "models": ["jepa"],
+      "models": [
+        "jepa"
+      ],
       "stages": {
         "design": "missing",
         "isa_closure": "missing",
@@ -315,9 +449,18 @@
       "issue": 129,
       "achieved": true,
       "requires": [
-        {"operator": "matmul", "stage": "functional"},
-        {"operator": "matmul", "stage": "regression"},
-        {"operator": "epilogue_fused", "stage": "functional"}
+        {
+          "operator": "matmul",
+          "stage": "functional"
+        },
+        {
+          "operator": "matmul",
+          "stage": "regression"
+        },
+        {
+          "operator": "epilogue_fused",
+          "stage": "functional"
+        }
       ]
     },
     {
@@ -325,11 +468,26 @@
       "issue": 130,
       "achieved": false,
       "requires": [
-        {"operator": "conv2d", "stage": "functional"},
-        {"operator": "pooling", "stage": "functional"},
-        {"operator": "batchnorm", "stage": "functional"},
-        {"operator": "epilogue_fused", "stage": "regression"},
-        {"operator": "elementwise", "stage": "functional"}
+        {
+          "operator": "conv2d",
+          "stage": "functional"
+        },
+        {
+          "operator": "pooling",
+          "stage": "functional"
+        },
+        {
+          "operator": "batchnorm",
+          "stage": "functional"
+        },
+        {
+          "operator": "epilogue_fused",
+          "stage": "regression"
+        },
+        {
+          "operator": "elementwise",
+          "stage": "functional"
+        }
       ]
     },
     {
@@ -337,10 +495,22 @@
       "issue": 132,
       "achieved": false,
       "requires": [
-        {"operator": "attention", "stage": "functional"},
-        {"operator": "softmax", "stage": "functional"},
-        {"operator": "online_reduction", "stage": "functional"},
-        {"operator": "layout_transform", "stage": "functional"}
+        {
+          "operator": "attention",
+          "stage": "functional"
+        },
+        {
+          "operator": "softmax",
+          "stage": "functional"
+        },
+        {
+          "operator": "online_reduction",
+          "stage": "functional"
+        },
+        {
+          "operator": "layout_transform",
+          "stage": "functional"
+        }
       ]
     },
     {
@@ -348,12 +518,30 @@
       "issue": 135,
       "achieved": false,
       "requires": [
-        {"operator": "attention", "stage": "regression"},
-        {"operator": "kv_cache", "stage": "functional"},
-        {"operator": "rope", "stage": "functional"},
-        {"operator": "rmsnorm", "stage": "functional"},
-        {"operator": "ffn_fused", "stage": "functional"},
-        {"operator": "embedding_logits", "stage": "functional"}
+        {
+          "operator": "attention",
+          "stage": "regression"
+        },
+        {
+          "operator": "kv_cache",
+          "stage": "functional"
+        },
+        {
+          "operator": "rope",
+          "stage": "functional"
+        },
+        {
+          "operator": "rmsnorm",
+          "stage": "functional"
+        },
+        {
+          "operator": "ffn_fused",
+          "stage": "functional"
+        },
+        {
+          "operator": "embedding_logits",
+          "stage": "functional"
+        }
       ]
     },
     {
@@ -361,10 +549,22 @@
       "issue": 136,
       "achieved": false,
       "requires": [
-        {"operator": "jepa_masking", "stage": "functional"},
-        {"operator": "gather_scatter", "stage": "functional"},
-        {"operator": "attention", "stage": "functional"},
-        {"operator": "layernorm", "stage": "functional"}
+        {
+          "operator": "jepa_masking",
+          "stage": "functional"
+        },
+        {
+          "operator": "gather_scatter",
+          "stage": "functional"
+        },
+        {
+          "operator": "attention",
+          "stage": "functional"
+        },
+        {
+          "operator": "layernorm",
+          "stage": "functional"
+        }
       ]
     }
   ]

--- a/tests/isa/test_behavioral_program_executor.cpp
+++ b/tests/isa/test_behavioral_program_executor.cpp
@@ -14,6 +14,7 @@
 
 #include <iostream>
 #include <cmath>
+#include <functional>
 #include <vector>
 #include <string>
 #include <cassert>
@@ -569,6 +570,77 @@ void test_loop_machinery() {
 }
 
 // ============================================================================
+// Test: VE_ELEMENTWISE functional semantics (issue #100, epic E2)
+// ============================================================================
+
+void test_ve_elementwise() {
+    std::cout << "\n=== Test: VE_ELEMENTWISE semantics (16x16 tiles) ===\n";
+
+    const Size Ti = 16, Tj = 16;
+    const Size elems = Ti * Tj;
+    const Size bytes = elems * sizeof(float);
+
+    // Three L1 buffers: src A (0), src B (1), dst (2)
+    TestHardware hw(16, 4, 256, 8, 128, /*num_l1=*/3, 64);
+
+    // Deterministic inputs (positive so SQRT/LOG are in-domain)
+    std::vector<float> a(elems), b(elems);
+    for (Size i = 0; i < elems; ++i) {
+        a[i] = 0.5f + static_cast<float>(i % 17) * 0.25f;
+        b[i] = 1.0f + static_cast<float>(i % 5) * 0.5f;
+    }
+
+    struct Case {
+        DMInstruction instr;
+        std::function<float(float, float)> ref;
+        std::string name;
+    };
+    std::vector<Case> cases;
+    cases.push_back({DMInstruction::ve_elementwise(VEOp::ADD, 0, 1, 2),
+                     [](float x, float y) { return x + y; }, "ADD"});
+    cases.push_back({DMInstruction::ve_elementwise(VEOp::MUL, 0, 1, 2),
+                     [](float x, float y) { return x * y; }, "MUL"});
+    cases.push_back({DMInstruction::ve_elementwise(VEOp::DIV, 0, 1, 2),
+                     [](float x, float y) { return x / y; }, "DIV"});
+    cases.push_back({DMInstruction::ve_elementwise_unary(VEOp::EXP, 0, 2),
+                     [](float x, float) { return std::exp(x); }, "EXP"});
+    cases.push_back({DMInstruction::ve_elementwise_unary(VEOp::SQRT, 0, 2),
+                     [](float x, float) { return std::sqrt(x); }, "SQRT"});
+    cases.push_back({DMInstruction::ve_elementwise_scalar(VEOp::MUL_S, 2.5f, 0, 2),
+                     [](float x, float) { return x * 2.5f; }, "MUL_S 2.5"});
+
+    for (auto& tc : cases) {
+        // Write inputs directly into L1 and run a one-instruction program
+        hw.l1_buffers[0].write(0, a.data(), bytes);
+        hw.l1_buffers[1].write(0, b.data(), bytes);
+
+        DMProgram program;
+        program.name = "ve_test";
+        program.Ti = Ti;
+        program.Tj = Tj;
+        program.Tk = 1;
+        program.instructions.push_back(tc.instr);
+        program.instructions.push_back(DMInstruction::halt());
+
+        BehavioralProgramExecutor executor(hw.context());
+        executor.load_program(program, 0, 0, 0);
+        bool ran = executor.run();
+
+        std::vector<float> out(elems, -1.0f);
+        hw.l1_buffers[2].read(0, out.data(), bytes);
+
+        float max_err = 0.0f;
+        for (Size i = 0; i < elems; ++i) {
+            float expected = tc.ref(a[i], b[i]);
+            max_err = std::max(max_err, std::fabs(out[i] - expected));
+        }
+        check(ran && max_err == 0.0f,
+              "VE " + tc.name + " exact vs host oracle (max err " +
+              std::to_string(max_err) + ")");
+    }
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
@@ -584,6 +656,7 @@ int main() {
     test_reference_matmul();
     test_execution_statistics();
     test_loop_machinery();
+    test_ve_elementwise();
 
     std::cout << "\n" << std::string(60, '*') << "\n";
     std::cout << "Results: " << passed << " passed, " << failed << " failed\n";

--- a/tests/isa/test_serialization.cpp
+++ b/tests/isa/test_serialization.cpp
@@ -664,3 +664,46 @@ TEST_CASE("Serialization round-trip integrity", "[serialization][roundtrip]") {
         }
     }
 }
+
+// ============================================================================
+// VEOperands round-trip (issue #100, format v2)
+// ============================================================================
+
+TEST_CASE("ProgramSerializer round-trips VEOperands", "[serialization][ve]") {
+    ProgramSerializer serializer;
+
+    DMProgram program;
+    program.name = "ve_roundtrip";
+    program.Ti = 16; program.Tj = 16; program.Tk = 1;
+    program.instructions.push_back(
+        DMInstruction::ve_elementwise(VEOp::SUB, 3, 4, 5));
+    program.instructions.push_back(
+        DMInstruction::ve_elementwise_unary(VEOp::EXP, 1, 2));
+    program.instructions.push_back(
+        DMInstruction::ve_elementwise_scalar(VEOp::POW_S, 0.5f, 6, 7));
+    program.instructions.push_back(DMInstruction::halt());
+
+    auto buffer = serializer.serialize(program);
+    DMProgram loaded = serializer.deserialize(buffer);
+
+    REQUIRE(loaded.instructions.size() == 4);
+
+    const auto& binary = std::get<VEOperands>(loaded.instructions[0].operands);
+    REQUIRE(binary.op == VEOp::SUB);
+    REQUIRE(binary.num_inputs == 2);
+    REQUIRE(binary.l1_src_a == 3);
+    REQUIRE(binary.l1_src_b == 4);
+    REQUIRE(binary.l1_dst == 5);
+
+    const auto& unary = std::get<VEOperands>(loaded.instructions[1].operands);
+    REQUIRE(unary.op == VEOp::EXP);
+    REQUIRE(unary.num_inputs == 1);
+    REQUIRE(unary.l1_src_a == 1);
+    REQUIRE(unary.l1_dst == 2);
+
+    const auto& scalar = std::get<VEOperands>(loaded.instructions[2].operands);
+    REQUIRE(scalar.op == VEOp::POW_S);
+    REQUIRE(scalar.scalar == 0.5f);
+    REQUIRE(scalar.l1_src_a == 6);
+    REQUIRE(scalar.l1_dst == 7);
+}

--- a/tests/timing/test_block_mover_process.cpp
+++ b/tests/timing/test_block_mover_process.cpp
@@ -655,3 +655,37 @@ TEST_CASE("BlockMoverProcess priority aging: prevents starvation of old requests
     // Old tile should not be starved - it should be processed first
     REQUIRE(first_processed == old_tile.tile_id);
 }
+
+// ============================================================================
+// Broadcast consumer-count seeding (issue #100, epic E2)
+// ============================================================================
+
+TEST_CASE("BlockMoverProcess seeds L2 ref count with the tile consumer count", "[timing][block_mover_process][broadcast]") {
+    TagCAM l3_tag_cam(8);
+    CreditPool l3_credits(8);
+    CreditPool l2_credits(8);
+    TagCAM l2_tag_cam(8);
+    BlockMoverProcess bm(default_config(0), l3_tag_cam, l3_credits, l2_credits, l2_tag_cam);
+
+    // A broadcast tile: one MOVE, three downstream feeds
+    auto tile = make_tile(MatrixID::B, 0, 0);
+    tile.consumer_count = 3;
+    REQUIRE(l3_credits.acquire());
+    l3_tag_cam.insert(tile.tile_id, 0, 0);
+
+    bm.schedule_move(tile);
+    Cycle cycle = 0;
+    while (!bm.is_idle() || bm.has_pending_work()) {
+        bm.tick(cycle++);
+        REQUIRE(cycle < 1000);
+    }
+
+    // One MOVE consumed exactly one L2 credit...
+    REQUIRE(l2_credits.outstanding() == 1);
+
+    // ...and seeded three references: the credit-release signal fires on
+    // the THIRD invalidate (feed), not the first
+    REQUIRE_FALSE(l2_tag_cam.invalidate(tile.tile_id));
+    REQUIRE_FALSE(l2_tag_cam.invalidate(tile.tile_id));
+    REQUIRE(l2_tag_cam.invalidate(tile.tile_id));
+}

--- a/tests/timing/test_tag_cam.cpp
+++ b/tests/timing/test_tag_cam.cpp
@@ -379,3 +379,40 @@ TEST_CASE("TagCAM work-conserving scan", "[timing][tag_cam]") {
     REQUIRE(oldest->tile_id.matrix == MatrixID::B);
     REQUIRE(oldest->arrival_cycle == 300);
 }
+
+// ============================================================================
+// Seeded reference counts for broadcast (issue #100, epic E2)
+// ============================================================================
+
+TEST_CASE("TagCAM seeded insert supports one-move many-feeds broadcast", "[timing][tag_cam][broadcast]") {
+    TagCAM cam(4);
+    TileID tile{MatrixID::B, 0, 0, 0};
+
+    SECTION("insert with refs=k releases only on the k-th invalidate") {
+        REQUIRE(cam.insert(tile, 0, 100, 3));
+        REQUIRE_FALSE(cam.invalidate(tile));  // 3 -> 2
+        REQUIRE_FALSE(cam.invalidate(tile));  // 2 -> 1
+        REQUIRE(cam.invalidate(tile));        // 1 -> 0: credit release signal
+        REQUIRE_FALSE(cam.lookup(tile));
+    }
+
+    SECTION("seeded insert on an existing entry adds references") {
+        REQUIRE(cam.insert(tile, 0, 100));      // ref 1
+        REQUIRE(cam.insert(tile, 0, 101, 2));   // ref 3
+        REQUIRE_FALSE(cam.invalidate(tile));
+        REQUIRE_FALSE(cam.invalidate(tile));
+        REQUIRE(cam.invalidate(tile));
+    }
+
+    SECTION("refs=0 clamps to 1 (ordinary pipeline)") {
+        REQUIRE(cam.insert(tile, 0, 100, 0));
+        REQUIRE(cam.invalidate(tile));
+    }
+
+    SECTION("seeded insert still respects capacity") {
+        TagCAM small(1);
+        TileID other{MatrixID::A, 1, 0, 0};
+        REQUIRE(small.insert(tile, 0, 100, 5));
+        REQUIRE_FALSE(small.insert(other, 1, 100, 5));
+    }
+}


### PR DESCRIPTION
Fixes #100 — E2-T2 of the broadcast/elementwise epic (#71), implementing the approved design (`docs/plans/e2_broadcast_elementwise_pattern.md`). Delivers the **elementwise share of #18's numerical half**.

## VE_ELEMENTWISE: from marker to instruction

- **`VEOp` + `VEOperands`**: 14 op kinds (binary / unary / scalar-broadcast forms) with L1 src/dst addressing, widening the `DMInstruction` variant; factories with descriptive labels; assembler syntax for all three forms.
- **Serializer round-trip**: `.kpubin` format **v2**, with `static_assert` drift guards pinning the variant size and VEOperands' index (the serialized tag is the variant index — silent reordering would corrupt every program).
- **Behavioral semantics**: elementwise application over L1 buffers with IEEE semantics (div-by-zero → inf, no domain guards — the oracle applies identical std ops). Validated **exactly** (max err 0.0) against a host oracle for ADD/MUL/DIV/EXP/SQRT/MUL_S.

## Broadcast (P5): the 1:1:k mechanism

One MOVE delivering a tile that k feeds will consume now **seeds** the L2 TagCAM ref-count via `TileDescriptor.consumer_count` — instead of k duplicate moves (the #61 credit-leak class the design forbids). One credit per entry, released on the k-th feed; default `consumer_count = 1` keeps the ordinary pipeline bit-identical. Tested at TagCAM level (seeding, add-to-existing, clamp, capacity) and BlockMover level (one credit outstanding, release on third invalidate).

## Discovered defect → #144

The serializer writes **no payload** for operand indices 7–15 (register-file config + AUTO types) and the reader **throws** on them — `.kpubin` round-trip is broken for every AUTO-based program (including all #142 kernel-compiler output). Pre-existing; filed as #144 with the drift guards already in place to force a deliberate version bump on fix.

## Verification

- Full suite: **101/101 pass** (new: 6 behavioral VE oracle checks, VEOperands round-trip, 4 TagCAM broadcast sections, BM seeding case)
- Coverage matrix updated per the process contract: `elementwise.isa_closure → done`
- Session log: `docs/sessions/2026-07-12_v0.9_e2_ve_operands_broadcast.md`

Next: E2-T3 (#101) `ElementwiseScheduleGenerator` + broadcast emission helper (resolves #139 for this family), then T4 functional integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vector Engine elementwise operations (binary, unary, and scalar-broadcast forms) with end-to-end execution.
  * Improved broadcast behavior by seeding downstream reference counts so tiles are released only after all consumers complete.
* **Documentation**
  * Added a new session log and updated release documentation for VE elementwise and broadcast seeding.
* **Tests**
  * Added functional execution tests, VE operand serialization round-trip tests, and broadcast/tag reference-count integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->