### PR TITLE
feat(schedule): ElementwiseScheduleGenerator with executable COMPUTEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ElementwiseScheduleGenerator + broadcast emission (#101, epic E2).**
+  The first generator whose every schedule is executable: paired
+  two-stream emission for `C = op(A, B)` (P6 - interleaved A/B pairs, no
+  stream can monopolize the pools, 3-tile working set), unary and
+  broadcast-B forms, COMPUTE operations carrying their full operand
+  dependency sets (resolving #139 for the elementwise family), and
+  envelope checks/stamping per the #90/#91 discipline.
+  `emit_broadcast_tile()` delivers a resident operand once with a seeded
+  consumer count (the #100 1:1:k mechanism) - the broadcast form executes
+  end-to-end (one MOVE, n feeds, one credit), regression-tested with and
+  without partitioned credits. Coverage: elementwise/broadcast generator
+  cells -> done (11/105).
+
 - **VE_ELEMENTWISE functional semantics + broadcast ref-count seeding
   (#100, epic E2 broadcast/elementwise).** `VEOperands` gives
   VE_ELEMENTWISE real operands (14 op kinds: binary/unary/scalar forms,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   envelope checks/stamping per the #90/#91 discipline.
   `emit_broadcast_tile()` delivers a resident operand once with a seeded
   consumer count (the #100 1:1:k mechanism) - the broadcast form executes
-  end-to-end (one MOVE, n feeds, one credit), regression-tested with and
-  without partitioned credits. Coverage: elementwise/broadcast generator
-  cells -> done (11/105).
+  end-to-end (one MOVE, n feeds, one credit). All three forms are
+  regression-tested with and without partitioned credits; non-tile-aligned
+  tensors clamp the trailing tile's footprint (full-tile stride preserved).
+  Coverage: elementwise/broadcast generator cells -> done (11/105).
 
 - **VE_ELEMENTWISE functional semantics + broadcast ref-count seeding
   (#100, epic E2 broadcast/elementwise).** `VEOperands` gives

--- a/docs/sessions/2026-07-12_v0.9_e2_elementwise_generator.md
+++ b/docs/sessions/2026-07-12_v0.9_e2_elementwise_generator.md
@@ -1,0 +1,77 @@
+# v0.9 E2-T3: ElementwiseScheduleGenerator Decision Log
+
+**Date:** 2026-07-12
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 101/101 suites passing (new: 5 generator sections, 4 execution
+sections incl. partitioned credits)
+**Issues:** #101 (done); #139 partially resolved (elementwise family)
+
+## 1. Summary
+
+Implemented E2-T3 per the approved design: ElementwiseScheduleGenerator
+with paired two-stream emission (P6), unary and broadcast-B forms, and -
+a first for the schedule generators - COMPUTE operations that carry their
+full operand dependency sets, making every emitted schedule executable.
+The broadcast form exercises the #100 1:1:k mechanism end-to-end: one
+MOVE with a seeded consumer count, n feeds, exactly one credit, verified
+by execution (a wrong seed would stall the later feeds forever).
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| ElementwiseScheduleGenerator (BINARY / UNARY / BROADCAST_B) | Done |
+| Paired interleaved emission (max consecutive same-matrix <= 2) | Done |
+| COMPUTE with both-operand deps (executable; #139 for this family) | Done |
+| emit_broadcast_tile() helper (load + move with consumer_count) | Done |
+| Envelope working-set check + metadata stamping (#90/#91) | Done |
+| Structure tests (pairing, deps, broadcast counts, refusal) | Done |
+| Execution regression (4 forms, incl. partitioned credits) | Done |
+| Coverage rows: elementwise.generator, broadcast.generator -> done | Done |
+
+Files:
+- `include/sw/kpu/timing/schedule/elementwise_schedule_generator.hpp` (new)
+- `tests/timing/test_schedule_generators.cpp`
+- `tests/timing/test_multi_tile_execution.cpp`
+- `tests/coverage/pattern_coverage.json`
+- `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: broadcast dependency via per-instance feed counts.**
+- **Choice:** COMPUTE i depends on the broadcast tile; the executor's
+  required count is the number of broadcast feeds scheduled so far (i+1),
+  so consumption order is enforced without new executor machinery.
+- **Alternatives considered:** resident_tiles on a compute spec - that is
+  the CSP FunctionalComputeSpec surface (T4 scope), not the schedule tier.
+
+**Decision 2: index tiles on ti only (1-D tiling).**
+- **Choice:** elementwise tensors are flattened; tile index rides
+  TileID.ti with Tj=Tk=0.
+- **Rationale:** matches the streaming-op tiling of the #142 kernel
+  compilers and keeps TileID uniqueness trivial per matrix.
+
+## 4. Issues Encountered
+
+1. Missing generate_name() definition on first compile (-Werror caught).
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                          # 101/101
+./build/tests/timing/test_multi_tile_execution  # incl. broadcast form
+./build/tests/coverage/test_pattern_coverage    # 11/105, gates hold
+```
+
+## 7. Next Steps
+
+- E2-T4 (#102): CSP functional execution with host oracles (flips the
+  elementwise/broadcast functional cells; M2 gate requirement).
+- E2-T5 (#103): op x shape x envelope regression + characterization,
+  then the epic closes.

--- a/docs/sessions/2026-07-12_v0.9_e2_elementwise_generator.md
+++ b/docs/sessions/2026-07-12_v0.9_e2_elementwise_generator.md
@@ -3,8 +3,9 @@
 **Date:** 2026-07-12
 **Version:** v0.9
 **Status:** Complete
-**Tests:** 101/101 suites passing (new: 5 generator sections, 4 execution
-sections incl. partitioned credits)
+**Tests:** 101/101 suites passing (new: 5 generator structure sections,
+7 execution sections - every form with and without partitioned credits,
+plus a non-aligned trailing-tile run)
 **Issues:** #101 (done); #139 partially resolved (elementwise family)
 
 ## 1. Summary
@@ -55,6 +56,16 @@ Files:
 ## 4. Issues Encountered
 
 1. Missing generate_name() definition on first compile (-Werror caught).
+2. Review (CodeRabbit, PR #146) caught a real defect: make_tile() sized
+   every tile as a full tile, so a non-tile-aligned num_elements produced
+   a trailing tile whose footprint reached past the tensor. Fixed by
+   clamping the trailing tile's element count/size_bytes while keeping
+   the inter-tile DRAM stride full-tile; structure test asserts both.
+3. Review also caught two documentation inaccuracies: the changelog
+   claimed partitioned-credit coverage the tests did not yet have
+   (resolved by adding the missing broadcast/unary partitioned sections
+   rather than weakening the claim), and this log initially miscounted
+   the test sections.
 
 ## 5. Wrong Decisions (CRITICAL)
 

--- a/docs/sessions/2026-07-12_v0.9_e2_elementwise_generator.md
+++ b/docs/sessions/2026-07-12_v0.9_e2_elementwise_generator.md
@@ -28,7 +28,7 @@ by execution (a wrong seed would stall the later feeds forever).
 | emit_broadcast_tile() helper (load + move with consumer_count) | Done |
 | Envelope working-set check + metadata stamping (#90/#91) | Done |
 | Structure tests (pairing, deps, broadcast counts, refusal) | Done |
-| Execution regression (4 forms, incl. partitioned credits) | Done |
+| Execution regression (all 3 forms with and without partitioned credits, plus non-aligned trailing tile) | Done |
 | Coverage rows: elementwise.generator, broadcast.generator -> done | Done |
 
 Files:

--- a/include/sw/kpu/timing/schedule/elementwise_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/elementwise_schedule_generator.hpp
@@ -1,0 +1,241 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/elementwise_schedule_generator.hpp
+// Elementwise schedule generator for CSP-style timing model (issue #101)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/schedule/schedule_generator_interface.hpp>
+
+#include <sstream>
+#include <string>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief Emit a broadcast tile delivery: one LOAD + one MOVE feeding k
+ *        consumers (pattern P5, issue #100/#101)
+ *
+ * The MOVE carries the consumer count, so the BlockMover seeds the L2
+ * TagCAM reference count with k on arrival (the 1:1:k discipline from
+ * docs/plans/e2_broadcast_elementwise_pattern.md). The caller emits the
+ * k FEED operations at their consumption points; the tile holds exactly
+ * one L2 credit for its whole consumer span, released after the k-th
+ * feed. Usable by the norm/epilogue generators for resident parameters.
+ */
+inline void emit_broadcast_tile(ScheduleResult& result,
+                                TileDescriptor tile, Size consumers) {
+    tile.consumer_count = consumers > 0 ? consumers : 1;
+    result.operations.push_back(ScheduleOperation::load(tile));
+    result.operations.push_back(ScheduleOperation::move(tile));
+}
+
+/**
+ * @brief Elementwise schedule generator: C = op(A, B), op(A), or
+ *        op(A, broadcast B)
+ *
+ * Pattern P6 (two-operand aligned streaming): the binary form emits
+ * paired A/B tile streams (load A[i], load B[i], ... interleaved per the
+ * #67 discipline) so neither stream can monopolize the credit pools, and
+ * COMPUTE for C[i] depends on BOTH operand feeds - the per-instance feed
+ * accounting fires it only when the pair has arrived. There is no tile
+ * reuse: the working set is one A + one B + one C tile in flight
+ * regardless of tensor size.
+ *
+ * The broadcast form (P5) streams A against a single resident B tile
+ * (e.g. a bias vector) delivered once via emit_broadcast_tile.
+ *
+ * Unlike the earlier multi-pass generators, every emitted schedule is
+ * EXECUTABLE: COMPUTE operations carry their full dependency sets
+ * (resolving #139 for the elementwise family).
+ */
+class ElementwiseScheduleGenerator : public IScheduleGenerator {
+public:
+    enum class Form {
+        BINARY,      ///< C[i] = op(A[i], B[i]) - paired streams
+        UNARY,       ///< C[i] = op(A[i]) - single stream
+        BROADCAST_B  ///< C[i] = op(A[i], B) - A streams, B resident
+    };
+
+    struct Config {
+        Size num_elements = 4096;   ///< Total elements per tensor
+        Size tile_elems = 256;      ///< Elements per tile
+        Form form = Form::BINARY;
+        std::string op_name = "ADD";  ///< For naming/metadata only
+
+        Size element_size = 4;
+
+        // Resource envelope (issue #90 discipline)
+        Size l3_buffer_count = 32;
+        Size l2_bank_count = 64;
+
+        Address a_base = 0;
+        Address b_base = 0;
+        Address c_base = 0;
+
+        [[nodiscard]] Size data_tiles() const {
+            return (num_elements + tile_elems - 1) / tile_elems;
+        }
+
+        [[nodiscard]] Size max_burst_tiles() const {
+            return per_matrix_burst_share(l3_buffer_count, l2_bank_count);
+        }
+
+        /**
+         * @brief Peak tile residency: one tile per active stream plus the
+         *        pending output, plus the resident broadcast operand
+         */
+        [[nodiscard]] Size required_working_set() const {
+            switch (form) {
+                case Form::BINARY:      return 3;
+                case Form::UNARY:       return 2;
+                case Form::BROADCAST_B: return 3;  // A + resident B + C
+            }
+            return 3;
+        }
+    };
+
+    explicit ElementwiseScheduleGenerator(const Config& config)
+        : config_(config) {}
+
+    ScheduleResult generate() override {
+        ScheduleResult result;
+
+        if (config_.num_elements == 0 || config_.tile_elems == 0) {
+            result.valid = false;
+            result.error_message = "Elementwise dimensions must be non-zero";
+            return result;
+        }
+
+        if (config_.required_working_set() > config_.max_burst_tiles()) {
+            result.valid = false;
+            result.error_message =
+                "elementwise schedule requires a working set of " +
+                std::to_string(config_.required_working_set()) +
+                " tiles but the resource envelope share is " +
+                std::to_string(config_.max_burst_tiles()) +
+                "; enlarge l3_buffer_count/l2_bank_count";
+            return result;
+        }
+
+        Size n = config_.data_tiles();
+
+        // Resident broadcast operand delivered once, consumed n times
+        TileDescriptor b_broadcast;
+        if (config_.form == Form::BROADCAST_B) {
+            b_broadcast = make_tile(isa::MatrixID::B, 0);
+            emit_broadcast_tile(result, b_broadcast, n);
+        }
+
+        for (Size i = 0; i < n; ++i) {
+            auto a_tile = make_tile(isa::MatrixID::A, i);
+
+            std::vector<TileID> deps;
+            if (config_.form == Form::BINARY) {
+                auto b_tile = make_tile(isa::MatrixID::B, i);
+                // Paired interleaved emission: A and B advance together
+                result.operations.push_back(ScheduleOperation::load(a_tile));
+                result.operations.push_back(ScheduleOperation::load(b_tile));
+                result.operations.push_back(ScheduleOperation::move(a_tile));
+                result.operations.push_back(ScheduleOperation::move(b_tile));
+                result.operations.push_back(ScheduleOperation::feed(a_tile));
+                result.operations.push_back(ScheduleOperation::feed(b_tile));
+                deps = {a_tile.tile_id, b_tile.tile_id};
+            } else {
+                result.operations.push_back(ScheduleOperation::load(a_tile));
+                result.operations.push_back(ScheduleOperation::move(a_tile));
+                result.operations.push_back(ScheduleOperation::feed(a_tile));
+                deps = {a_tile.tile_id};
+                if (config_.form == Form::BROADCAST_B) {
+                    // The i-th consumption of the resident broadcast tile
+                    result.operations.push_back(
+                        ScheduleOperation::feed(b_broadcast));
+                    deps.push_back(b_broadcast.tile_id);
+                }
+            }
+
+            auto c_tile = make_tile(isa::MatrixID::C, i);
+            result.operations.push_back(
+                ScheduleOperation::compute(c_tile, std::move(deps)));
+            result.operations.push_back(ScheduleOperation::drain(c_tile));
+            result.operations.push_back(ScheduleOperation::writeback(c_tile));
+            result.operations.push_back(ScheduleOperation::store(c_tile));
+        }
+
+        result.metadata.name = generate_name();
+        result.metadata.generator = name();
+        result.metadata.M = config_.num_elements;
+        result.metadata.N = 1;
+        result.metadata.K = 1;
+        result.metadata.Ti = config_.tile_elems;
+        result.metadata.Tj = 1;
+        result.metadata.Tk = 1;
+        result.metadata.a_tiles = n;
+        result.metadata.b_tiles =
+            config_.form == Form::BINARY ? n
+            : config_.form == Form::BROADCAST_B ? 1 : 0;
+        result.metadata.c_tiles = n;
+        result.metadata.strategy = form_name(config_.form);
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
+
+        result.valid = true;
+        return result;
+    }
+
+    [[nodiscard]] std::string name() const override {
+        return "ElementwiseScheduleGenerator";
+    }
+
+    [[nodiscard]] std::string description() const override {
+        std::ostringstream ss;
+        ss << "Elementwise " << config_.op_name << " [" << config_.num_elements
+           << "] (" << form_name(config_.form) << ")";
+        return ss.str();
+    }
+
+    [[nodiscard]] const Config& config() const { return config_; }
+
+private:
+    Config config_;
+
+    TileDescriptor make_tile(isa::MatrixID matrix, Size index) const {
+        TileDescriptor tile;
+        tile.tile_id.matrix = matrix;
+        tile.tile_id.ti = index;
+        tile.tile_id.tj = 0;
+        tile.tile_id.tk = 0;
+        tile.height = config_.tile_elems;
+        tile.width = 1;
+        tile.element_size = config_.element_size;
+        tile.size_bytes = config_.tile_elems * config_.element_size;
+
+        Address base = matrix == isa::MatrixID::A ? config_.a_base
+                     : matrix == isa::MatrixID::B ? config_.b_base
+                                                  : config_.c_base;
+        tile.dram_address = base + index * tile.size_bytes;
+        tile.matrix_base_address = base;
+        return tile;
+    }
+
+    static const char* form_name(Form form) {
+        switch (form) {
+            case Form::BINARY:      return "binary_paired";
+            case Form::UNARY:       return "unary_stream";
+            case Form::BROADCAST_B: return "broadcast_b";
+        }
+        return "unknown";
+    }
+
+    std::string generate_name() const {
+        std::ostringstream ss;
+        ss << "elementwise_" << config_.op_name << "_" << config_.num_elements
+           << "_" << form_name(config_.form);
+        return ss.str();
+    }
+};
+
+} // namespace sw::kpu::timing::schedule

--- a/include/sw/kpu/timing/schedule/elementwise_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/elementwise_schedule_generator.hpp
@@ -208,15 +208,24 @@ private:
         tile.tile_id.ti = index;
         tile.tile_id.tj = 0;
         tile.tile_id.tk = 0;
-        tile.height = config_.tile_elems;
+        // Trailing tile of a non-aligned tensor is partial; clamp its
+        // footprint so no load/store reaches past num_elements
+        Size elems = config_.tile_elems;
+        Size offset = index * config_.tile_elems;
+        if (offset + elems > config_.num_elements) {
+            elems = config_.num_elements - offset;
+        }
+        tile.height = elems;
         tile.width = 1;
         tile.element_size = config_.element_size;
-        tile.size_bytes = config_.tile_elems * config_.element_size;
+        tile.size_bytes = elems * config_.element_size;
 
         Address base = matrix == isa::MatrixID::A ? config_.a_base
                      : matrix == isa::MatrixID::B ? config_.b_base
                                                   : config_.c_base;
-        tile.dram_address = base + index * tile.size_bytes;
+        // Stride between tiles stays full-tile; only the last footprint shrinks
+        tile.dram_address =
+            base + offset * config_.element_size;
         tile.matrix_base_address = base;
         return tile;
     }

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -197,11 +197,11 @@
       "stages": {
         "design": "missing",
         "isa_closure": "done",
-        "generator": "partial",
+        "generator": "done",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "VE_ELEMENTWISE has full operand encoding (VEOperands, format v2), assembler/serializer round-trip, and functional semantics in the behavioral executor (#100); CSP functional path rides FunctionalComputeSpec. Two-operand aligned streaming schedule is E2-T3."
+      "notes": "VE_ELEMENTWISE fully encoded + behavioral semantics (#100); ElementwiseScheduleGenerator with paired two-stream emission, executable COMPUTEs, envelope checks (#101). CSP functional oracle path is E2-T4."
     },
     {
       "name": "epilogue_fused",
@@ -278,11 +278,11 @@
       "stages": {
         "design": "missing",
         "isa_closure": "partial",
-        "generator": "missing",
+        "generator": "done",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "STR_BROADCAST_ROW/COL opcodes timed in ConcurrentExecutor; broadcast ref-count seeding (1:1:k via TileDescriptor.consumer_count, #100) in the CSP tier. Behavioral STR_BROADCAST semantics + resident-operand realization land with E2-T4."
+      "notes": "Ref-count seeding (1:1:k) in CSP tier (#100); emit_broadcast_tile helper + BROADCAST_B form executes end-to-end (#101). Behavioral STR_BROADCAST semantics + resident-operand functional path are E2-T4."
     },
     {
       "name": "online_reduction",

--- a/tests/timing/test_multi_tile_execution.cpp
+++ b/tests/timing/test_multi_tile_execution.cpp
@@ -384,7 +384,17 @@ TEST_CASE("Elementwise schedules execute to completion",
     SECTION("broadcast B: one move, sixteen feeds, one credit") {
         run(ElementwiseScheduleGenerator::Form::BROADCAST_B, false);
     }
+    SECTION("broadcast B under partitioned credits") {
+        run(ElementwiseScheduleGenerator::Form::BROADCAST_B, true);
+    }
     SECTION("unary stream") {
         run(ElementwiseScheduleGenerator::Form::UNARY, false);
+    }
+    SECTION("unary stream under partitioned credits") {
+        run(ElementwiseScheduleGenerator::Form::UNARY, true);
+    }
+    SECTION("non-aligned tensor with clamped trailing tile") {
+        gen_config.num_elements = 4000;   // 16 tiles, last one 160 elems
+        run(ElementwiseScheduleGenerator::Form::BINARY, false);
     }
 }

--- a/tests/timing/test_multi_tile_execution.cpp
+++ b/tests/timing/test_multi_tile_execution.cpp
@@ -16,6 +16,7 @@
 
 #include <sw/kpu/timing/concurrent_timing_executor.hpp>
 #include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/elementwise_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/schedule_executor.hpp>
 #include <sw/kpu/timing/schedule/schedule_validator.hpp>
 
@@ -334,4 +335,56 @@ TEST_CASE("Compute latency scales with the K-slice count",
         }
     }
     REQUIRE(complete_events == 4);  // 2x2 C tiles
+}
+
+// ============================================================================
+// Elementwise execution (issue #101, epic E2): paired streams and the
+// broadcast 1:1:k discipline execute to completion - if the ref seeding
+// were wrong, the broadcast form's later feeds would stall forever
+// ============================================================================
+
+TEST_CASE("Elementwise schedules execute to completion",
+          "[timing][executor][regression][elementwise]") {
+    ElementwiseScheduleGenerator::Config gen_config;
+    gen_config.num_elements = 4096;
+    gen_config.tile_elems = 256;   // 16 data tiles
+
+    auto run = [&](ElementwiseScheduleGenerator::Form form, bool partitioned) {
+        gen_config.form = form;
+        ElementwiseScheduleGenerator gen(gen_config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        auto exec_config = make_executor_config();
+        exec_config.partition_l3_credits = partitioned;
+        exec_config.partition_l2_credits = partitioned;
+        ConcurrentTimingExecutor executor(exec_config);
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(schedule);
+
+        INFO("form=" << static_cast<int>(form)
+             << " partitioned=" << partitioned
+             << " cycles=" << result.total_cycles
+             << " error=" << result.error_message);
+        REQUIRE(result.success);
+        REQUIRE_FALSE(result.livelock_detected);
+
+        auto stats = executor.get_statistics();
+        REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+        REQUIRE(stats.tiles_drained ==
+                schedule.count_ops(ScheduleOpType::DRAIN));
+    };
+
+    SECTION("binary paired streams") {
+        run(ElementwiseScheduleGenerator::Form::BINARY, false);
+    }
+    SECTION("binary paired streams under partitioned credits") {
+        run(ElementwiseScheduleGenerator::Form::BINARY, true);
+    }
+    SECTION("broadcast B: one move, sixteen feeds, one credit") {
+        run(ElementwiseScheduleGenerator::Form::BROADCAST_B, false);
+    }
+    SECTION("unary stream") {
+        run(ElementwiseScheduleGenerator::Form::UNARY, false);
+    }
 }

--- a/tests/timing/test_schedule_generators.cpp
+++ b/tests/timing/test_schedule_generators.cpp
@@ -856,4 +856,27 @@ TEST_CASE("ElementwiseScheduleGenerator emits paired executable schedules",
         REQUIRE_FALSE(schedule.valid);
         REQUIRE(schedule.error_message.find("working set") != std::string::npos);
     }
+
+    SECTION("non-aligned tensor clamps the trailing tile footprint") {
+        config.form = ElementwiseScheduleGenerator::Form::BINARY;
+        config.num_elements = 1000;   // 4 tiles: 256+256+256+232
+        ElementwiseScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+        REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) == 4);
+
+        // Every load footprint stays within num_elements; the last tile of
+        // each stream shrinks to the remainder while the stride between
+        // tiles stays full-tile
+        const Size full_bytes = 256 * 4;
+        const Size tail_bytes = 232 * 4;
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::LOAD) continue;
+            const auto& t = op.tile;
+            REQUIRE(t.dram_address - t.matrix_base_address ==
+                    t.tile_id.ti * full_bytes);
+            REQUIRE(t.size_bytes ==
+                    (t.tile_id.ti == 3 ? tail_bytes : full_bytes));
+        }
+    }
 }

--- a/tests/timing/test_schedule_generators.cpp
+++ b/tests/timing/test_schedule_generators.cpp
@@ -10,6 +10,7 @@
 
 #include <sw/kpu/timing/schedule/schedule_generator_interface.hpp>
 #include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/elementwise_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/conv2d_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/softmax_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/layernorm_schedule_generator.hpp>
@@ -760,5 +761,99 @@ TEST_CASE("VAL-007 flags envelope disagreement in validation", "[timing][schedul
             }
         }
         REQUIRE(found);
+    }
+}
+
+// ============================================================================
+// ElementwiseScheduleGenerator (issue #101, epic E2): paired two-stream
+// emission, broadcast delivery, and executable COMPUTEs (resolves #139
+// for the elementwise family)
+// ============================================================================
+
+TEST_CASE("ElementwiseScheduleGenerator emits paired executable schedules",
+          "[timing][schedule][elementwise]") {
+    ElementwiseScheduleGenerator::Config config;
+    config.num_elements = 1024;
+    config.tile_elems = 256;   // 4 data tiles
+
+    SECTION("binary form pairs the streams and carries both-operand deps") {
+        config.form = ElementwiseScheduleGenerator::Form::BINARY;
+        ElementwiseScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == 8);   // 4 A + 4 B
+        REQUIRE(schedule.count_ops(ScheduleOpType::MOVE) == 8);
+        REQUIRE(schedule.count_ops(ScheduleOpType::FEED) == 8);
+        REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) == 4);
+
+        // Paired interleave: no same-matrix monopolization
+        auto analysis = ScheduleAnalysis::analyze(schedule);
+        REQUIRE(analysis.max_consecutive_a <= 2);
+        REQUIRE(analysis.max_consecutive_b <= 2);
+        REQUIRE(is_livelock_safe(schedule, config.l3_buffer_count,
+                                 config.l2_bank_count));
+
+        // Every COMPUTE depends on exactly its A and B pair (executable,
+        // unlike the #139-affected generators)
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::COMPUTE) continue;
+            REQUIRE(op.dependency_tiles.size() == 2);
+            REQUIRE(op.dependency_tiles[0].matrix == MatrixID::A);
+            REQUIRE(op.dependency_tiles[1].matrix == MatrixID::B);
+            REQUIRE(op.dependency_tiles[0].ti == op.tile.tile_id.ti);
+        }
+
+        // Envelope stamped (issue #91)
+        REQUIRE(schedule.metadata.l3_buffer_count == 32);
+        REQUIRE(schedule.metadata.l2_bank_count == 64);
+    }
+
+    SECTION("broadcast form delivers B once with a seeded consumer count") {
+        config.form = ElementwiseScheduleGenerator::Form::BROADCAST_B;
+        ElementwiseScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        // One B load/move; four B feeds (one per consumer)
+        size_t b_loads = 0, b_moves = 0, b_feeds = 0;
+        for (const auto& op : schedule.operations) {
+            if (op.tile.tile_id.matrix != MatrixID::B) continue;
+            if (op.type == ScheduleOpType::LOAD) ++b_loads;
+            if (op.type == ScheduleOpType::MOVE) {
+                ++b_moves;
+                REQUIRE(op.tile.consumer_count == 4);  // 1:1:k discipline
+            }
+            if (op.type == ScheduleOpType::FEED) ++b_feeds;
+        }
+        REQUIRE(b_loads == 1);
+        REQUIRE(b_moves == 1);
+        REQUIRE(b_feeds == 4);
+
+        // Every COMPUTE depends on its A tile AND the broadcast tile
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::COMPUTE) continue;
+            REQUIRE(op.dependency_tiles.size() == 2);
+            REQUIRE(op.dependency_tiles[1].matrix == MatrixID::B);
+        }
+    }
+
+    SECTION("unary form streams a single operand") {
+        config.form = ElementwiseScheduleGenerator::Form::UNARY;
+        ElementwiseScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+        REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == 4);
+        REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) == 4);
+    }
+
+    SECTION("degenerate envelope is refused a priori") {
+        config.form = ElementwiseScheduleGenerator::Form::BINARY;
+        config.l3_buffer_count = 4;
+        config.l2_bank_count = 4;   // share 1 < working set 3
+        ElementwiseScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE_FALSE(schedule.valid);
+        REQUIRE(schedule.error_message.find("working set") != std::string::npos);
     }
 }


### PR DESCRIPTION
Fixes #101 — E2-T3 of the broadcast/elementwise epic (#71). **Partially resolves #139**: the elementwise family is the first generator whose every emitted schedule is executable (COMPUTE ops carry full operand dependency sets).

## What

- **BINARY form** (`C = op(A, B)`, pattern P6): paired two-stream emission — `load A[i], load B[i]` interleaved per the #67 discipline, so neither stream can monopolize the credit pools; constant 3-tile working set regardless of tensor size; COMPUTE for `C[i]` depends on **both** operand feeds through the per-instance accounting.
- **BROADCAST_B form + `emit_broadcast_tile()`** (pattern P5): the resident operand is delivered once — one LOAD + one MOVE carrying `consumer_count` (the #100 1:1:k seeding) — and consumed by every compute. The execution test is the proof: one credit outstanding, n feeds, and a wrong seed would stall the later feeds into livelock. The helper is reusable by the norm/epilogue generators for resident parameters.
- **UNARY form**: single-stream.
- Envelope working-set refusal + metadata stamping per the #90/#91 discipline.

## Verification

- Structure tests: stream pairing (max consecutive same-matrix ≤ 2), dependency sets, broadcast op counts (1 load / 1 move with `consumer_count=4` / 4 feeds), a-priori envelope refusal.
- Execution regression: all four form/config combinations through the CSP executor, including under **partitioned credits** — success, no livelock, exact per-stage tile accounting.
- Full suite: **101/101 pass**. Coverage matrix: `elementwise.generator` and `broadcast.generator` → done (**11/105 cells**, up from 9).
- Session log: `docs/sessions/2026-07-12_v0.9_e2_elementwise_generator.md`

Next: E2-T4 (#102) — CSP functional execution with host oracles, flipping the functional cells that milestone M2's gate requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an elementwise timing schedule generator supporting **binary**, **unary**, and **broadcast-B**, including dependency-aware executable compute.
  * Implemented paired/interleaved A/B emission and **resident broadcast delivery** with per-consumer tracking for end-to-end execution.
* **Bug Fixes**
  * Improved handling of non-aligned tensors by **clamping trailing tile footprints** while keeping full-tile stride.
* **Tests**
  * Added unit and end-to-end coverage for multiple forms, **shared vs partitioned credits**, envelope validation failures, and tail-tile scenarios.
* **Documentation**
  * Updated changelog, session decision log, and operator coverage status for elementwise and broadcast generation completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->