### PR TITLE
feat(timing): value-producing elementwise/broadcast + host oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Value-producing elementwise/broadcast execution + host oracles (#102,
+  epic E2).** `FunctionalElementwiseExecutor` bridges the #101 generator to
+  the #66 payload machinery: input tensors ride the real CSP data path
+  (DRAM->L3->L2->L1->compute), every COMPUTE applies real VEOp semantics,
+  and results drain back to DRAM - verified elementwise against an
+  independent host oracle for all 14 VEOps across binary, broadcast-bias,
+  unary, scalar, non-aligned, and partitioned-credit configurations
+  (12k+ assertions). `ScheduleExecutor` gains an opt-in
+  `FunctionalComputeBinder` so ANY generated schedule can run
+  value-producing without touching the timing path. Behavioral
+  STR_BROADCAST_ROW/COL get real resident-operand semantics (deliver L2->L1
+  once, consume many, never fires a compute) with `str_broadcast_row/col`
+  factories - closing the broadcast isa_closure gap. Coverage: 16/105
+  (elementwise+broadcast design/functional cells, broadcast isa_closure).
+
 - **ElementwiseScheduleGenerator + broadcast emission (#101, epic E2).**
   The first generator whose every schedule is executable: paired
   two-stream emission for `C = op(A, B)` (P6 - interleaved A/B pairs, no

--- a/docs/sessions/2026-07-12_v0.9_e2_functional_oracle.md
+++ b/docs/sessions/2026-07-12_v0.9_e2_functional_oracle.md
@@ -1,0 +1,95 @@
+# v0.9 E2-T4: Functional Elementwise Execution + Host Oracles Decision Log
+
+**Date:** 2026-07-12
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 102/102 suites passing (new suite: test_functional_elementwise,
+6 cases / 12k+ oracle assertions; behavioral suite +1 broadcast test)
+**Issues:** #102 (done)
+
+## 1. Summary
+
+Implemented E2-T4: value-producing elementwise and broadcast execution on
+the CSP executor, verified elementwise against an independent host oracle.
+The #101 generator supplies the credit-safe movement plan; the #66 payload
+machinery carries values along the same events; a new opt-in
+FunctionalComputeBinder on ScheduleExecutor binds each COMPUTE to real
+VEOp semantics. Also gave behavioral STR_BROADCAST_ROW/COL real
+resident-operand semantics (deliver once, consume many), closing the
+broadcast isa_closure gap flagged in the coverage matrix.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| ScheduleExecutor::FunctionalComputeBinder (opt-in value plane) | Done |
+| FunctionalElementwiseExecutor (seed/bind/gather, all 3 forms) | Done |
+| apply_ve_op: all 14 VEOps, IEEE semantics matching behavioral ISA | Done |
+| Host-oracle tests: binary(6 ops), broadcast bias, unary(5)+scalar, non-aligned tail, partitioned credits, input contracts | Done |
+| Behavioral STR_BROADCAST resident-operand semantics + factories | Done |
+| ISA deliver-once/consume-many test (BehavioralProgramExecutor) | Done |
+| Coverage rows: elementwise/broadcast design+functional, broadcast isa_closure -> done (16/105) | Done |
+
+Files:
+- `include/sw/kpu/timing/schedule/functional_elementwise_executor.hpp` (new)
+- `include/sw/kpu/timing/schedule/schedule_executor.hpp` (binder hook)
+- `include/sw/kpu/isa/data_movement_isa.hpp` + `src/software/isa/data_movement_isa.cpp` (str_broadcast_row/col factories)
+- `include/sw/kpu/isa/behavioral_program_executor.hpp` + `src/software/isa/behavioral_program_executor.cpp` (dispatch_str_broadcast)
+- `tests/timing/test_functional_elementwise.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/isa/test_behavioral_program_executor.cpp`
+- `tests/coverage/pattern_coverage.json`
+
+## 3. Technical Decisions
+
+**Decision 1: binder hook on ScheduleExecutor instead of a parallel executor.**
+- **Choice:** optional `FunctionalComputeBinder` callback; COMPUTE ops the
+  binder accepts dispatch as `schedule_functional_compute`, others keep the
+  timing-only path. Timing is identical either way because the functional
+  path derives dependencies from the same scheduled-feed counts.
+- **Alternatives considered:** a FunctionalScheduleExecutor subclass
+  (duplicates enqueue logic); baking specs into ScheduleOperation (bloats
+  the schedule IR with std::function, breaks serialization).
+- **Consequence:** ANY generator's schedule can run value-producing; the
+  matmul/norm epics get this for free.
+
+**Decision 2: broadcast ISA semantics = feed-copy WITHOUT compute pairing.**
+- **Choice:** `dispatch_str_broadcast` copies L2->L1 like a feed but never
+  sets the a_fed_/b_fed_ pairing flags - a broadcast can never fire a
+  compute. Validated by a deliver-once/consume-many test: one broadcast
+  program, then three consumer programs VE-ADD against the resident tile
+  with the bias never re-delivered.
+- **Rationale:** matches the CSP-tier meaning (resident operand, 1:1:k)
+  and the credit model: delivery is a movement, consumption is compute's
+  business. The full streaming elementwise ISA program (LOOP-based, #142
+  emission) stays out of scope: the behavioral executor's feed pairing is
+  matmul-coupled; per-op VE semantics are already validated (#100) and the
+  end-to-end pattern is validated on the CSP tier here.
+
+**Decision 3: oracle independence.**
+- **Choice:** test oracles are plain host loops written per-case, not calls
+  to `apply_ve_op` - a semantic error in the simulator kernel cannot hide
+  by matching itself.
+
+## 4. Issues Encountered
+
+None - build and all tests passed on the first run.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                              # 102/102
+./build/tests/timing/test_functional_elementwise    # 12305 assertions
+./build/tests/isa/test_behavioral_program_executor  # 34 passed
+./build/tests/coverage/test_pattern_coverage        # 16/105, gates hold
+```
+
+## 7. Next Steps
+
+- E2-T5 (#103): op x shape x envelope regression + characterization
+  (incl. constrained envelopes), stall/credit invariants, flips the
+  regression cells and closes epic #71; #18's elementwise half closes.

--- a/include/sw/kpu/isa/behavioral_program_executor.hpp
+++ b/include/sw/kpu/isa/behavioral_program_executor.hpp
@@ -138,6 +138,7 @@ private:
     void dispatch_bm_writeback(const BlockMoverOperands& ops);
     void dispatch_str_feed_rows(const StreamerOperands& ops);
     void dispatch_str_feed_cols(const StreamerOperands& ops);
+    void dispatch_str_broadcast(const StreamerOperands& ops);
     void dispatch_str_drain(const StreamerOperands& ops);
     void dispatch_barrier();
 

--- a/include/sw/kpu/isa/data_movement_isa.hpp
+++ b/include/sw/kpu/isa/data_movement_isa.hpp
@@ -492,6 +492,25 @@ struct DMInstruction {
                                        Address l2_addr, Address l1_addr,
                                        Size height, Size width, Size fabric_size);
 
+    /**
+     * @brief Broadcast a resident operand from L2 into an L1 buffer
+     *
+     * Delivers the operand ONCE for consumption by any number of subsequent
+     * compute/VE operations (the ISA-level counterpart of the CSP tier's
+     * 1:1:k seeded delivery, issues #100/#102). Unlike str_feed_rows/cols,
+     * a broadcast does not participate in feed pairing - it never triggers
+     * a compute by itself.
+     */
+    static DMInstruction str_broadcast_row(MatrixID mat, TileCoord tile,
+                                           uint8_t l2_bank, uint8_t l1_buf,
+                                           Address l2_addr, Address l1_addr,
+                                           Size height, Size width, Size fabric_size);
+
+    static DMInstruction str_broadcast_col(MatrixID mat, TileCoord tile,
+                                           uint8_t l2_bank, uint8_t l1_buf,
+                                           Address l2_addr, Address l1_addr,
+                                           Size height, Size width, Size fabric_size);
+
     static DMInstruction str_drain(TileCoord tile,
                                    uint8_t l2_bank, uint8_t l1_buf,
                                    Address l2_addr, Address l1_addr,

--- a/include/sw/kpu/timing/schedule/functional_elementwise_executor.hpp
+++ b/include/sw/kpu/timing/schedule/functional_elementwise_executor.hpp
@@ -1,0 +1,247 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/functional_elementwise_executor.hpp
+// Value-producing elementwise execution on the CSP timing model (issue #102)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/schedule/elementwise_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+#include <sw/kpu/isa/data_movement_isa.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief Apply a VEOp to one element (same IEEE semantics as
+ *        BehavioralProgramExecutor::execute_ve_elementwise)
+ *
+ * Binary ops read both operands; unary ops read `a`; scalar-broadcast ops
+ * read `a` and `scalar`. Division by zero, sqrt of negatives, and log of
+ * non-positives follow IEEE-754 (inf/NaN propagate to the output, matching
+ * the behavioral ISA executor so oracles can compare bit-for-bit).
+ */
+inline float apply_ve_op(isa::VEOp op, float a, float b, float scalar) {
+    using isa::VEOp;
+    switch (op) {
+        case VEOp::ADD:   return a + b;
+        case VEOp::SUB:   return a - b;
+        case VEOp::MUL:   return a * b;
+        case VEOp::DIV:   return a / b;
+        case VEOp::MAX:   return a > b ? a : b;
+        case VEOp::MIN:   return a < b ? a : b;
+        case VEOp::NEG:   return -a;
+        case VEOp::ABS:   return std::fabs(a);
+        case VEOp::SQRT:  return std::sqrt(a);
+        case VEOp::EXP:   return std::exp(a);
+        case VEOp::LOG:   return std::log(a);
+        case VEOp::ADD_S: return a + scalar;
+        case VEOp::MUL_S: return a * scalar;
+        case VEOp::POW_S: return std::pow(a, scalar);
+    }
+    throw std::invalid_argument("Unknown VEOp");
+}
+
+/**
+ * @brief Value-producing elementwise execution over the real CSP data path
+ *
+ * Bridges the #101 ElementwiseScheduleGenerator to the #66 payload
+ * machinery: the generator's schedule provides the credit-safe movement
+ * plan (paired streams / broadcast delivery), input payloads ride
+ * DRAM->L3->L2->L1->compute through the normal LOAD/MOVE/FEED path, each
+ * COMPUTE is bound to a FunctionalComputeSpec applying `op`, and results
+ * drain back to DRAM through DRAIN/WRITEBACK/STORE. Timing is identical to
+ * the timing-only path - the value plane rides the same events.
+ *
+ * The trailing tile of a non-tile-aligned tensor is partial (the #101
+ * clamp); payload slicing and result assembly honor the per-tile footprint.
+ */
+class FunctionalElementwiseExecutor {
+public:
+    using Form = ElementwiseScheduleGenerator::Form;
+
+    struct Result {
+        ExecutionResult execution;      ///< Timing/completion status
+        std::vector<float> values;      ///< C tensor gathered from DRAM stores
+    };
+
+    FunctionalElementwiseExecutor(ElementwiseScheduleGenerator::Config generator_config,
+                                  ConcurrentTimingExecutor::Config executor_config = {})
+        : generator_config_(std::move(generator_config)),
+          executor_config_(std::move(executor_config)) {}
+
+    /**
+     * @brief Execute C = op(A[, B]) end-to-end on the CSP executor
+     *
+     * @param op      VEOp consistent with the configured form: binary ops for
+     *                BINARY/BROADCAST_B, unary and scalar ops for UNARY
+     * @param a       A tensor, num_elements values
+     * @param b       B tensor: num_elements (BINARY), one tile of
+     *                min(tile_elems, num_elements) values (BROADCAST_B),
+     *                empty (UNARY)
+     * @param scalar  Operand for ADD_S / MUL_S / POW_S
+     */
+    Result run(isa::VEOp op, const std::vector<float>& a,
+               const std::vector<float>& b = {}, float scalar = 0.0f) {
+        validate_inputs(op, a, b);
+
+        ElementwiseScheduleGenerator generator(generator_config_);
+        auto schedule = generator.generate();
+
+        Result result;
+        if (!schedule.valid) {
+            result.execution.error_message =
+                "Schedule generation refused: " + schedule.error_message;
+            return result;
+        }
+
+        ConcurrentTimingExecutor executor(executor_config_);
+        seed_input_payloads(executor, schedule, a, b);
+
+        ScheduleExecutor sched_exec(executor);
+        sched_exec.set_functional_compute_binder(
+            [op, scalar](const ScheduleOperation& compute_op)
+                -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+                ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+                spec.input_tiles = compute_op.dependency_tiles;
+                spec.operation =
+                    [op, scalar](const std::vector<TilePayload>& inputs) {
+                        return apply_elementwise(op, scalar, inputs);
+                    };
+                return spec;
+            });
+
+        result.execution = sched_exec.execute(schedule);
+        if (result.execution.success) {
+            result.values = gather_output(executor, schedule);
+        }
+        return result;
+    }
+
+    [[nodiscard]] const ElementwiseScheduleGenerator::Config& generator_config() const {
+        return generator_config_;
+    }
+
+private:
+    ElementwiseScheduleGenerator::Config generator_config_;
+    ConcurrentTimingExecutor::Config executor_config_;
+
+    void validate_inputs(isa::VEOp op, const std::vector<float>& a,
+                         const std::vector<float>& b) const {
+        const auto& cfg = generator_config_;
+        if (a.size() != cfg.num_elements) {
+            throw std::invalid_argument("A tensor size does not match num_elements");
+        }
+        const bool binary_op = static_cast<uint8_t>(op) <=
+                               static_cast<uint8_t>(isa::VEOp::MIN);
+        switch (cfg.form) {
+            case Form::BINARY:
+                if (!binary_op) {
+                    throw std::invalid_argument("BINARY form requires a binary VEOp");
+                }
+                if (b.size() != cfg.num_elements) {
+                    throw std::invalid_argument("B tensor size does not match num_elements");
+                }
+                break;
+            case Form::BROADCAST_B: {
+                if (!binary_op) {
+                    throw std::invalid_argument("BROADCAST_B form requires a binary VEOp");
+                }
+                const Size b_elems = std::min(cfg.tile_elems, cfg.num_elements);
+                if (b.size() != b_elems) {
+                    throw std::invalid_argument(
+                        "Broadcast B must be one tile (" + std::to_string(b_elems) +
+                        " values)");
+                }
+                break;
+            }
+            case Form::UNARY:
+                if (binary_op) {
+                    throw std::invalid_argument("UNARY form requires a unary or scalar VEOp");
+                }
+                if (!b.empty()) {
+                    throw std::invalid_argument("UNARY form takes no B tensor");
+                }
+                break;
+        }
+    }
+
+    /**
+     * @brief Seed DRAM payloads for every LOAD in the schedule, sliced by the
+     *        tile's own footprint (partial trailing tiles included)
+     */
+    void seed_input_payloads(ConcurrentTimingExecutor& executor,
+                             const ScheduleResult& schedule,
+                             const std::vector<float>& a,
+                             const std::vector<float>& b) const {
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::LOAD) continue;
+            const auto& tile = op.tile;
+            const std::vector<float>& source =
+                tile.tile_id.matrix == isa::MatrixID::A ? a : b;
+            const Size offset = tile.tile_id.ti * generator_config_.tile_elems;
+            const Size elems = tile.height;
+            TilePayload payload{elems, 1,
+                                std::vector<float>(source.begin() + offset,
+                                                   source.begin() + offset + elems)};
+            executor.set_tile_payload(tile.tile_id, std::move(payload));
+        }
+    }
+
+    /**
+     * @brief Elementwise kernel over the fed input payloads
+     *
+     * Inputs arrive in COMPUTE dependency order: {A} (unary/scalar) or
+     * {A, B} (binary/broadcast). A partial trailing A tile pairs with the
+     * leading elements of a full broadcast B tile.
+     */
+    static TilePayload apply_elementwise(isa::VEOp op, float scalar,
+                                         const std::vector<TilePayload>& inputs) {
+        if (inputs.empty()) {
+            throw std::invalid_argument("Elementwise compute received no inputs");
+        }
+        const auto& a = inputs.front();
+        const TilePayload* b = inputs.size() > 1 ? &inputs[1] : nullptr;
+        if (b != nullptr && b->values.size() < a.values.size()) {
+            throw std::invalid_argument("Elementwise B operand is smaller than A");
+        }
+        TilePayload out{a.rows, a.cols, std::vector<float>(a.values.size())};
+        for (size_t i = 0; i < a.values.size(); ++i) {
+            out.values[i] = apply_ve_op(op, a.values[i],
+                                        b != nullptr ? b->values[i] : 0.0f, scalar);
+        }
+        return out;
+    }
+
+    /**
+     * @brief Reassemble the C tensor from the per-tile DRAM store payloads
+     */
+    std::vector<float> gather_output(const ConcurrentTimingExecutor& executor,
+                                     const ScheduleResult& schedule) const {
+        std::vector<float> output(generator_config_.num_elements, 0.0f);
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::STORE) continue;
+            const auto& tile = op.tile;
+            const auto& payload =
+                executor.tile_payload_at(MemoryLevel::DRAM, tile.tile_id);
+            const Size offset = tile.tile_id.ti * generator_config_.tile_elems;
+            if (payload.values.size() != tile.height) {
+                throw std::runtime_error("Stored payload size does not match tile " +
+                                         tile.tile_id.to_string());
+            }
+            std::copy(payload.values.begin(), payload.values.end(),
+                      output.begin() + offset);
+        }
+        return output;
+    }
+};
+
+} // namespace sw::kpu::timing::schedule

--- a/include/sw/kpu/timing/schedule/schedule_executor.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_executor.hpp
@@ -109,6 +109,20 @@ public:
     using ProgressCallback = std::function<void(size_t current, size_t total)>;
 
     /**
+     * @brief Optional value-plane binding for COMPUTE operations
+     *
+     * When set, each COMPUTE operation is offered to the binder; returning a
+     * FunctionalComputeSpec dispatches it as a value-producing compute (the
+     * #66 payload machinery) instead of a timing-only compute. Returning
+     * nullopt keeps the timing-only path for that operation. Timing behavior
+     * is identical either way: the functional path derives its dependency
+     * accounting from the same scheduled-feed counts.
+     */
+    using FunctionalComputeBinder =
+        std::function<std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec>(
+            const ScheduleOperation&)>;
+
+    /**
      * @brief Construct executor with a timing executor reference
      * @param executor The ConcurrentTimingExecutor to use
      */
@@ -126,6 +140,13 @@ public:
      */
     void set_progress_callback(ProgressCallback callback) {
         progress_callback_ = std::move(callback);
+    }
+
+    /**
+     * @brief Install a value-plane binder for COMPUTE operations
+     */
+    void set_functional_compute_binder(FunctionalComputeBinder binder) {
+        functional_binder_ = std::move(binder);
     }
 
     /**
@@ -234,6 +255,7 @@ private:
     ConcurrentTimingExecutor& executor_;
     Config config_;
     ProgressCallback progress_callback_;
+    FunctionalComputeBinder functional_binder_;
 
     /**
      * @brief Warn when the schedule's generation envelope differs from the
@@ -301,6 +323,12 @@ private:
                 break;
 
             case ScheduleOpType::COMPUTE:
+                if (functional_binder_) {
+                    if (auto spec = functional_binder_(op)) {
+                        executor_.schedule_functional_compute(op.tile, *spec);
+                        break;
+                    }
+                }
                 if (!op.dependency_tiles.empty()) {
                     executor_.schedule_compute(op.tile, op.dependency_tiles);
                 } else {

--- a/src/software/isa/behavioral_program_executor.cpp
+++ b/src/software/isa/behavioral_program_executor.cpp
@@ -219,11 +219,16 @@ void BehavioralProgramExecutor::dispatch(const DMInstruction& instr, [[maybe_unu
         dispatch_str_drain_auto(std::get<AutoStreamerOperands>(instr.operands));
         break;
 
-    // Broadcast — treat as a streamer feed for now
+    // Broadcast: deliver a resident operand L2 -> L1 exactly once, for
+    // consumption by any number of subsequent VE/compute ops (the ISA-level
+    // counterpart of the CSP 1:1:k seeded delivery, issues #100/#102).
+    // Unlike a feed, a broadcast never participates in the A/B feed pairing
+    // and never fires a compute. Legacy monostate markers remain no-ops.
     case DMOpcode::STR_BROADCAST_ROW:
     case DMOpcode::STR_BROADCAST_COL:
-        // Behavioral: broadcast is a no-op annotation
-        // (data already in L2, compute reads it directly in softmax path)
+        if (std::holds_alternative<StreamerOperands>(instr.operands)) {
+            dispatch_str_broadcast(std::get<StreamerOperands>(instr.operands));
+        }
         break;
 
     case DMOpcode::VE_ELEMENTWISE:
@@ -483,6 +488,24 @@ void BehavioralProgramExecutor::dispatch_str_feed_cols(const StreamerOperands& o
         a_fed_ = false;
         b_fed_ = false;
     }
+}
+
+void BehavioralProgramExecutor::dispatch_str_broadcast(const StreamerOperands& ops) {
+    // L2 bank -> L1 buffer, resident-operand delivery: copied once, then
+    // read in place by any number of VE/compute ops. Does NOT set the
+    // a_fed_/b_fed_ pairing flags - a broadcast can never fire a compute.
+    uint8_t l2_id = ops.l2_bank_id;
+    Size bytes = ops.height * ops.width * 4;  // float32
+
+    if (bytes == 0) return;
+    if (l2_id >= hw_.l2_banks.size()) return;
+    if (ops.l1_buffer_id >= hw_.l1_buffers.size()) return;
+
+    std::vector<uint8_t> buf(bytes);
+    hw_.l2_banks[l2_id].read(ops.l2_addr, buf.data(), bytes);
+    hw_.l1_buffers[ops.l1_buffer_id].write(ops.l1_addr, buf.data(), bytes);
+
+    stats_.str_feeds++;
 }
 
 void BehavioralProgramExecutor::dispatch_str_drain(const StreamerOperands& ops) {

--- a/src/software/isa/data_movement_isa.cpp
+++ b/src/software/isa/data_movement_isa.cpp
@@ -175,6 +175,68 @@ DMInstruction DMInstruction::str_feed_cols(MatrixID mat, TileCoord tile,
     return instr;
 }
 
+namespace {
+
+DMInstruction make_str_broadcast(DMOpcode opcode, const char* mnemonic,
+                                 MatrixID mat, TileCoord tile,
+                                 uint8_t l2_bank, uint8_t l1_buf,
+                                 Address l2_addr, Address l1_addr,
+                                 Size height, Size width, Size fabric_size) {
+    DMInstruction instr;
+    instr.opcode = opcode;
+
+    StreamerOperands ops;
+    ops.matrix = mat;
+    ops.tile = tile;
+    ops.l2_bank_id = l2_bank;
+    ops.l1_buffer_id = l1_buf;
+    ops.l2_addr = l2_addr;
+    ops.l1_addr = l1_addr;
+    ops.height = height;
+    ops.width = width;
+    ops.fabric_size = fabric_size;
+    ops.buffer = BufferSlot::AUTO;
+
+    instr.operands = ops;
+
+    std::ostringstream oss;
+    oss << mnemonic << " ";
+    switch (mat) {
+        case MatrixID::A:
+            oss << "A_tile[" << tile.ti << "," << tile.tk << "]";
+            break;
+        case MatrixID::B:
+            oss << "B_tile[" << tile.tk << "," << tile.tj << "]";
+            break;
+        case MatrixID::C:
+            oss << "C_tile[" << tile.ti << "," << tile.tj << "]";
+            break;
+    }
+    instr.label = oss.str();
+
+    return instr;
+}
+
+} // namespace
+
+DMInstruction DMInstruction::str_broadcast_row(MatrixID mat, TileCoord tile,
+                                               uint8_t l2_bank, uint8_t l1_buf,
+                                               Address l2_addr, Address l1_addr,
+                                               Size height, Size width, Size fabric_size) {
+    return make_str_broadcast(DMOpcode::STR_BROADCAST_ROW, "STR_BCAST_ROW",
+                              mat, tile, l2_bank, l1_buf, l2_addr, l1_addr,
+                              height, width, fabric_size);
+}
+
+DMInstruction DMInstruction::str_broadcast_col(MatrixID mat, TileCoord tile,
+                                               uint8_t l2_bank, uint8_t l1_buf,
+                                               Address l2_addr, Address l1_addr,
+                                               Size height, Size width, Size fabric_size) {
+    return make_str_broadcast(DMOpcode::STR_BROADCAST_COL, "STR_BCAST_COL",
+                              mat, tile, l2_bank, l1_buf, l2_addr, l1_addr,
+                              height, width, fabric_size);
+}
+
 DMInstruction DMInstruction::str_drain(TileCoord tile,
                                        uint8_t l2_bank, uint8_t l1_buf,
                                        Address l2_addr, Address l1_addr,

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -195,13 +195,13 @@
         "jepa"
       ],
       "stages": {
-        "design": "missing",
+        "design": "done",
         "isa_closure": "done",
         "generator": "done",
-        "functional": "missing",
+        "functional": "done",
         "regression": "missing"
       },
-      "notes": "VE_ELEMENTWISE fully encoded + behavioral semantics (#100); ElementwiseScheduleGenerator with paired two-stream emission, executable COMPUTEs, envelope checks (#101). CSP functional oracle path is E2-T4."
+      "notes": "VE_ELEMENTWISE fully encoded + behavioral semantics (#100); ElementwiseScheduleGenerator with paired two-stream emission, executable COMPUTEs, envelope checks (#101); value-producing CSP execution via FunctionalElementwiseExecutor verified against host oracle across all ops/forms incl. partitioned credits (#102). Design: docs/plans/e2_broadcast_elementwise_pattern.md (#99). Regression matrix is E2-T5."
     },
     {
       "name": "epilogue_fused",
@@ -276,13 +276,13 @@
         "jepa"
       ],
       "stages": {
-        "design": "missing",
-        "isa_closure": "partial",
+        "design": "done",
+        "isa_closure": "done",
         "generator": "done",
-        "functional": "missing",
+        "functional": "done",
         "regression": "missing"
       },
-      "notes": "Ref-count seeding (1:1:k) in CSP tier (#100); emit_broadcast_tile helper + BROADCAST_B form executes end-to-end (#101). Behavioral STR_BROADCAST semantics + resident-operand functional path are E2-T4."
+      "notes": "Ref-count seeding 1:1:k in CSP tier (#100); emit_broadcast_tile + BROADCAST_B form (#101); CSP functional broadcast vs host oracle + behavioral STR_BROADCAST resident-operand delivery semantics with deliver-once/consume-many ISA test (#102). Design: docs/plans/e2_broadcast_elementwise_pattern.md (#99). Regression matrix is E2-T5."
     },
     {
       "name": "online_reduction",

--- a/tests/isa/test_behavioral_program_executor.cpp
+++ b/tests/isa/test_behavioral_program_executor.cpp
@@ -641,6 +641,84 @@ void test_ve_elementwise() {
 }
 
 // ============================================================================
+// Test: STR_BROADCAST resident-operand delivery + repeated VE consumption
+// (issue #102, epic E2)
+// ============================================================================
+
+void test_str_broadcast_resident_operand() {
+    std::cout << "\n=== Test: STR_BROADCAST delivers once, VE consumes many ===\n";
+
+    const Size Ti = 16, Tj = 16;
+    const Size elems = Ti * Tj;
+    const Size bytes = elems * sizeof(float);
+
+    // Three L1 buffers: streamed A (0), resident broadcast B (1), dst (2)
+    TestHardware hw(16, 4, 256, 8, 128, /*num_l1=*/3, 64);
+
+    // Resident bias tile staged in L2 bank 0
+    std::vector<float> bias(elems);
+    for (Size i = 0; i < elems; ++i) {
+        bias[i] = -4.0f + static_cast<float>(i % 13) * 0.5f;
+    }
+    hw.l2_banks[0].write(0, bias.data(), bytes);
+
+    // Delivery program: ONE broadcast, then halt. The operand must remain
+    // resident in L1 for every later consumer without re-delivery.
+    {
+        DMProgram program;
+        program.name = "broadcast_delivery";
+        program.Ti = Ti;
+        program.Tj = Tj;
+        program.Tk = 1;
+        program.instructions.push_back(DMInstruction::str_broadcast_col(
+            MatrixID::B, TileCoord{0, 0, 0}, /*l2_bank=*/0, /*l1_buf=*/1,
+            /*l2_addr=*/0, /*l1_addr=*/0, Ti, Tj, 16));
+        program.instructions.push_back(DMInstruction::halt());
+
+        BehavioralProgramExecutor executor(hw.context());
+        executor.load_program(program, 0, 0, 0);
+        bool ran = executor.run();
+        check(ran, "broadcast delivery program runs");
+        check(executor.statistics().str_feeds == 1, "broadcast counts one delivery");
+    }
+
+    // Three consumer tiles, each a separate program run: stream A into L1[0],
+    // VE ADD against the resident B, read the result. B is NEVER re-delivered.
+    for (int tile = 0; tile < 3; ++tile) {
+        std::vector<float> a(elems);
+        for (Size i = 0; i < elems; ++i) {
+            a[i] = static_cast<float>(tile + 1) + static_cast<float>(i % 7) * 0.25f;
+        }
+        hw.l1_buffers[0].write(0, a.data(), bytes);
+
+        DMProgram program;
+        program.name = "broadcast_consume";
+        program.Ti = Ti;
+        program.Tj = Tj;
+        program.Tk = 1;
+        program.instructions.push_back(
+            DMInstruction::ve_elementwise(VEOp::ADD, 0, 1, 2));
+        program.instructions.push_back(DMInstruction::halt());
+
+        BehavioralProgramExecutor executor(hw.context());
+        executor.load_program(program, 0, 0, 0);
+        bool ran = executor.run();
+
+        std::vector<float> out(elems, -1.0f);
+        hw.l1_buffers[2].read(0, out.data(), bytes);
+
+        float max_err = 0.0f;
+        for (Size i = 0; i < elems; ++i) {
+            max_err = std::max(max_err, std::fabs(out[i] - (a[i] + bias[i])));
+        }
+        check(ran && max_err == 0.0f,
+              "consumer tile " + std::to_string(tile) +
+              " reads resident broadcast exactly (max err " +
+              std::to_string(max_err) + ")");
+    }
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
@@ -657,6 +735,7 @@ int main() {
     test_execution_statistics();
     test_loop_machinery();
     test_ve_elementwise();
+    test_str_broadcast_resident_operand();
 
     std::cout << "\n" << std::string(60, '*') << "\n";
     std::cout << "Results: " << passed << " passed, " << failed << " failed\n";

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -128,3 +128,13 @@ kpu_add_component_test(test_multi_tile_execution "timing"
 set_tests_properties(test_multi_tile_execution PROPERTIES
     LABELS "timing;executor;regression;v0.9"
 )
+
+# Functional elementwise execution with host oracle (issue #102, epic E2):
+# value-producing elementwise/broadcast on the CSP data path
+kpu_add_component_test(test_functional_elementwise "timing"
+    test_functional_elementwise.cpp
+)
+
+set_tests_properties(test_functional_elementwise PROPERTIES
+    LABELS "timing;functional;elementwise;v0.9"
+)

--- a/tests/timing/test_functional_elementwise.cpp
+++ b/tests/timing/test_functional_elementwise.cpp
@@ -1,0 +1,227 @@
+// ============================================================================
+// tests/timing/test_functional_elementwise.cpp
+// Value-producing elementwise execution on the CSP executor, verified
+// elementwise against an independent host oracle (issue #102, epic E2).
+//
+// The oracle is computed with a plain host loop - a deliberately separate
+// path from apply_ve_op - so a semantic error in the simulator kernel cannot
+// hide by matching itself.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <sw/kpu/timing/schedule/functional_elementwise_executor.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::VEOp;
+
+namespace {
+
+using Form = ElementwiseScheduleGenerator::Form;
+
+ElementwiseScheduleGenerator::Config make_generator_config(Size num_elements,
+                                                           Form form) {
+    ElementwiseScheduleGenerator::Config config;
+    config.num_elements = num_elements;
+    config.tile_elems = 256;
+    config.form = form;
+    config.a_base = 0x100000;
+    config.b_base = 0x200000;
+    config.c_base = 0x300000;
+    return config;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.max_cycles = 2'000'000;
+    return config;
+}
+
+// Deterministic non-trivial test vectors (no RNG in tests)
+std::vector<float> make_tensor(Size count, float base, float step) {
+    std::vector<float> values(count);
+    for (Size i = 0; i < count; ++i) {
+        values[i] = base + step * static_cast<float>(i);
+    }
+    return values;
+}
+
+void require_elementwise_match(const std::vector<float>& actual,
+                               const std::vector<float>& expected) {
+    REQUIRE(actual.size() == expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        INFO("element " << i);
+        if (std::isnan(expected[i])) {
+            REQUIRE(std::isnan(actual[i]));
+        } else {
+            REQUIRE(actual[i] == Catch::Approx(expected[i]).margin(1e-6f));
+        }
+    }
+}
+
+} // namespace
+
+TEST_CASE("Binary elementwise CSP execution matches the host oracle",
+          "[timing][functional][elementwise]") {
+    const Size n = 1024;   // 4 tiles
+    auto a = make_tensor(n, -3.0f, 0.25f);
+    auto b = make_tensor(n, 2.0f, -0.125f);
+
+    struct Case {
+        VEOp op;
+        float (*oracle)(float, float);
+    };
+    const Case cases[] = {
+        {VEOp::ADD, [](float x, float y) { return x + y; }},
+        {VEOp::SUB, [](float x, float y) { return x - y; }},
+        {VEOp::MUL, [](float x, float y) { return x * y; }},
+        {VEOp::DIV, [](float x, float y) { return x / y; }},
+        {VEOp::MAX, [](float x, float y) { return x > y ? x : y; }},
+        {VEOp::MIN, [](float x, float y) { return x < y ? x : y; }},
+    };
+
+    for (const auto& c : cases) {
+        INFO("op=" << static_cast<int>(c.op));
+        FunctionalElementwiseExecutor executor(
+            make_generator_config(n, Form::BINARY), make_executor_config());
+        auto result = executor.run(c.op, a, b);
+        REQUIRE(result.execution.success);
+        REQUIRE_FALSE(result.execution.livelock_detected);
+
+        std::vector<float> expected(n);
+        for (Size i = 0; i < n; ++i) expected[i] = c.oracle(a[i], b[i]);
+        require_elementwise_match(result.values, expected);
+    }
+}
+
+TEST_CASE("Broadcast-B CSP execution matches the host oracle",
+          "[timing][functional][elementwise][broadcast]") {
+    const Size n = 1024;   // 4 A tiles against 1 resident B tile
+    auto a = make_tensor(n, 1.0f, 0.5f);
+    auto bias = make_tensor(256, -8.0f, 0.0625f);
+
+    FunctionalElementwiseExecutor executor(
+        make_generator_config(n, Form::BROADCAST_B), make_executor_config());
+    auto result = executor.run(VEOp::ADD, a, bias);
+    REQUIRE(result.execution.success);
+    REQUIRE_FALSE(result.execution.livelock_detected);
+
+    // Every A tile pairs against the SAME resident bias tile: a value error
+    // here would also implicate the 1:1:k feed accounting, not just the op
+    std::vector<float> expected(n);
+    for (Size i = 0; i < n; ++i) expected[i] = a[i] + bias[i % 256];
+    require_elementwise_match(result.values, expected);
+}
+
+TEST_CASE("Unary and scalar CSP execution matches the host oracle",
+          "[timing][functional][elementwise]") {
+    const Size n = 512;   // 2 tiles
+    auto a = make_tensor(n, 0.25f, 0.03125f);   // positive domain for sqrt/log
+
+    SECTION("unary chain ops") {
+        struct Case {
+            VEOp op;
+            float (*oracle)(float);
+        };
+        const Case cases[] = {
+            {VEOp::NEG,  [](float x) { return -x; }},
+            {VEOp::ABS,  [](float x) { return std::fabs(x); }},
+            {VEOp::SQRT, [](float x) { return std::sqrt(x); }},
+            {VEOp::EXP,  [](float x) { return std::exp(x); }},
+            {VEOp::LOG,  [](float x) { return std::log(x); }},
+        };
+        for (const auto& c : cases) {
+            INFO("op=" << static_cast<int>(c.op));
+            FunctionalElementwiseExecutor executor(
+                make_generator_config(n, Form::UNARY), make_executor_config());
+            auto result = executor.run(c.op, a);
+            REQUIRE(result.execution.success);
+
+            std::vector<float> expected(n);
+            for (Size i = 0; i < n; ++i) expected[i] = c.oracle(a[i]);
+            require_elementwise_match(result.values, expected);
+        }
+    }
+
+    SECTION("scalar-broadcast ops") {
+        const float scalar = 1.75f;
+        FunctionalElementwiseExecutor executor(
+            make_generator_config(n, Form::UNARY), make_executor_config());
+        auto result = executor.run(VEOp::MUL_S, a, {}, scalar);
+        REQUIRE(result.execution.success);
+
+        std::vector<float> expected(n);
+        for (Size i = 0; i < n; ++i) expected[i] = a[i] * scalar;
+        require_elementwise_match(result.values, expected);
+    }
+}
+
+TEST_CASE("Non-aligned functional elementwise clamps the trailing tile",
+          "[timing][functional][elementwise]") {
+    const Size n = 1000;   // 4 tiles: 256+256+256+232 (the #101 clamp)
+    auto a = make_tensor(n, -1.0f, 0.01f);
+    auto b = make_tensor(n, 4.0f, -0.02f);
+
+    FunctionalElementwiseExecutor executor(
+        make_generator_config(n, Form::BINARY), make_executor_config());
+    auto result = executor.run(VEOp::MUL, a, b);
+    REQUIRE(result.execution.success);
+
+    std::vector<float> expected(n);
+    for (Size i = 0; i < n; ++i) expected[i] = a[i] * b[i];
+    require_elementwise_match(result.values, expected);
+}
+
+TEST_CASE("Functional elementwise under partitioned credits",
+          "[timing][functional][elementwise][partition]") {
+    const Size n = 1024;
+    auto a = make_tensor(n, 0.0f, 0.5f);
+    auto b = make_tensor(n, 100.0f, -0.5f);
+
+    auto exec_config = make_executor_config();
+    exec_config.partition_l3_credits = true;
+    exec_config.partition_l2_credits = true;
+
+    FunctionalElementwiseExecutor executor(
+        make_generator_config(n, Form::BINARY), exec_config);
+    auto result = executor.run(VEOp::MAX, a, b);
+    REQUIRE(result.execution.success);
+    REQUIRE_FALSE(result.execution.livelock_detected);
+
+    std::vector<float> expected(n);
+    for (Size i = 0; i < n; ++i) expected[i] = a[i] > b[i] ? a[i] : b[i];
+    require_elementwise_match(result.values, expected);
+}
+
+TEST_CASE("Functional elementwise input contract is enforced",
+          "[timing][functional][elementwise]") {
+    const Size n = 512;
+    auto a = make_tensor(n, 1.0f, 1.0f);
+
+    SECTION("wrong A size") {
+        FunctionalElementwiseExecutor executor(
+            make_generator_config(n, Form::UNARY), make_executor_config());
+        REQUIRE_THROWS_AS(executor.run(VEOp::NEG, std::vector<float>(n - 1)),
+                          std::invalid_argument);
+    }
+    SECTION("binary op on unary form") {
+        FunctionalElementwiseExecutor executor(
+            make_generator_config(n, Form::UNARY), make_executor_config());
+        REQUIRE_THROWS_AS(executor.run(VEOp::ADD, a), std::invalid_argument);
+    }
+    SECTION("broadcast B must be one tile") {
+        FunctionalElementwiseExecutor executor(
+            make_generator_config(n, Form::BROADCAST_B), make_executor_config());
+        REQUIRE_THROWS_AS(executor.run(VEOp::ADD, a, std::vector<float>(n)),
+                          std::invalid_argument);
+    }
+}


### PR DESCRIPTION
Fixes #102 — E2-T4 of the broadcast/elementwise epic (#71). Milestone relevance: flips the elementwise/broadcast **functional** cells that M2 ResNet's (#130) gate requires.

## What

- **`ScheduleExecutor::FunctionalComputeBinder`** (opt-in): COMPUTE ops the binder accepts dispatch as `schedule_functional_compute` — the #66 payload machinery — while everything else keeps the timing-only path. Timing is identical either way because the functional path derives its dependency accounting from the same scheduled-feed counts. Any generator's schedule can now run value-producing; the matmul/norm epics get this for free.
- **`FunctionalElementwiseExecutor`**: bridges the #101 generator to the value plane. Input tensors are sliced per-tile (partial trailing tiles honored — the #101 clamp), ride DRAM→L3→L2→L1→compute through the normal LOAD/MOVE/FEED path, each COMPUTE applies `apply_ve_op` (all 14 VEOps, IEEE semantics matching the behavioral ISA executor), results drain back through DRAIN/WRITEBACK/STORE and are gathered from DRAM.
- **Behavioral STR_BROADCAST_ROW/COL semantics** (was a no-op annotation): deliver a resident operand L2→L1 exactly once for consumption by any number of VE/compute ops; never participates in A/B feed pairing, never fires a compute — the ISA-level counterpart of the CSP 1:1:k discipline. `str_broadcast_row/col` factories added. This closes the broadcast `isa_closure` gap flagged in the coverage matrix.

## Verification

- New suite `test_functional_elementwise` (**12,305 assertions**): binary ADD/SUB/MUL/DIV/MAX/MIN, broadcast bias (every A tile against the same resident B — a value error would implicate the 1:1:k feed accounting itself), unary NEG/ABS/SQRT/EXP/LOG + scalar MUL_S, non-aligned trailing tile, partitioned credits, input-contract enforcement. Oracles are independent plain host loops, not `apply_ve_op` calls.
- Behavioral ISA test: one broadcast delivery, three consumer programs VE-ADD against the resident tile, bias never re-delivered — exact match each time.
- Full suite: **102/102 pass**. Coverage: **16/105** (elementwise/broadcast design+functional, broadcast isa_closure). Gates hold.
- Session log: `docs/sessions/2026-07-12_v0.9_e2_functional_oracle.md`

## Scope note

The full LOOP-based streaming elementwise ISA program stays out of behavioral scope: the behavioral executor's feed pairing is matmul-coupled, per-op VE semantics are already validated (#100), and the end-to-end pattern is validated on the CSP tier here.

Next: E2-T5 (#103) — op × shape × envelope regression matrix, closes epic #71 and #18's elementwise half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added value-producing elementwise execution for binary, unary, and broadcast operations.
  * Added support for row and column operand broadcasting.
  * Added optional functional compute execution for generated schedules while preserving existing timing behavior.
  * Added support for additional arithmetic and mathematical operations, including scalar broadcasts.

* **Bug Fixes**
  * Corrected broadcast execution so resident operands are delivered and consumed correctly.

* **Tests**
  * Added comprehensive correctness coverage, including non-aligned inputs, partitioned execution, and invalid input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->