### PR TITLE
test(timing): elementwise regression matrix + characterization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Elementwise/broadcast regression matrix + characterization (#103,
+  epic E2 COMPLETE).** `test_elementwise_regression` executes the full
+  form x size x envelope matrix (binary/broadcast/unary x 1/16/64-tile +
+  non-aligned x default/constrained-min/partitioned = 36 cells) with
+  invariants stronger than completion: exact per-stage tile accounting
+  (tiles reaching L3 = LOADs + WRITEBACKs, moves/feeds/drains/stores
+  exact) and full credit conservation (every L3/L2 credit returned).
+  The envelope refusal boundary is pinned exact (12 generates, 11
+  refuses), and functional values survive the minimum envelope under
+  partitioned credits on a non-aligned tensor. Characterization recorded
+  on epic #71: constrained-min triples stalls on binary 64-tile
+  (1166 -> 3707) yet costs only 6 extra cycles - the pipeline absorbs
+  envelope pressure; per-tile cost amortizes 242 -> 26 cycles from 1 to
+  64 tiles. Coverage: 18/105; elementwise and broadcast are the first
+  operators complete across all five stages after matmul.
+
 - **Value-producing elementwise/broadcast execution + host oracles (#102,
   epic E2).** `FunctionalElementwiseExecutor` bridges the #101 generator to
   the #66 payload machinery: input tensors ride the real CSP data path

--- a/docs/sessions/2026-07-13_v0.9_e2_regression_matrix.md
+++ b/docs/sessions/2026-07-13_v0.9_e2_regression_matrix.md
@@ -4,7 +4,7 @@
 **Version:** v0.9
 **Status:** Complete - closes epic E2 (#71)
 **Tests:** 103/103 suites passing (new suite: test_elementwise_regression,
-4 cases / 4475 assertions / 36 matrix cells)
+4 cases / 4511 assertions / 36 matrix cells)
 **Issues:** #103 (done); epic #71 complete; #18 elementwise half done
 
 ## 1. Summary
@@ -56,6 +56,13 @@ Files:
    writebacks (upstream C tiles). The invariant is LOAD + WRITEBACK, still
    exact. Earlier suites only asserted feeds/drains, so this counter
    semantics was previously untested.
+2. Review (CodeRabbit, PR #148) caught that the stall-sanity invariant
+   was documented but never asserted - run_cell computed stalls only for
+   the characterization row. Fixed with the correctly normalized bound:
+   stall counters aggregate across all components, so the "stalled every
+   cycle" ceiling is total_cycles x stall-capable components, not
+   total_cycles (aggregated stalls legitimately exceed total_cycles when
+   several engines wait concurrently).
 
 ## 5. Wrong Decisions (CRITICAL)
 

--- a/docs/sessions/2026-07-13_v0.9_e2_regression_matrix.md
+++ b/docs/sessions/2026-07-13_v0.9_e2_regression_matrix.md
@@ -1,0 +1,89 @@
+# v0.9 E2-T5: Elementwise Regression Matrix Decision Log
+
+**Date:** 2026-07-13
+**Version:** v0.9
+**Status:** Complete - closes epic E2 (#71)
+**Tests:** 103/103 suites passing (new suite: test_elementwise_regression,
+4 cases / 4475 assertions / 36 matrix cells)
+**Issues:** #103 (done); epic #71 complete; #18 elementwise half done
+
+## 1. Summary
+
+Implemented E2-T5: execution regression for elementwise/broadcast
+streaming across the full form x size x envelope matrix with invariants
+stronger than mere completion, plus performance characterization recorded
+on the epic. This closes epic E2 - elementwise and broadcast are now the
+first operators after matmul with all five lifecycle stages done.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| Matrix: {binary,broadcast_b,unary} x {1,16,64-tile,non-aligned} x {default,constrained-min,partitioned} = 36 cells | Done |
+| Per-stage tile accounting invariant (L3 arrivals = LOAD+WRITEBACK; moves/feeds/drains/writebacks/stores exact) | Done |
+| Credit conservation invariant (L3/L2 available == capacity post-run, both credit modes) | Done |
+| Envelope refusal boundary exact (min(l3,l2)=12 generates, 11 refuses) | Done |
+| Functional-under-pressure oracle (min envelope + partitioned + non-aligned, exact values) | Done |
+| Characterization table (cycles, cyc/tile, stalls, dma/str utilization) posted to epic #71 | Done |
+| Coverage rows: elementwise + broadcast regression -> done (18/105) | Done |
+
+Files:
+- `tests/timing/test_elementwise_regression.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/coverage/pattern_coverage.json`
+- `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: invariants stronger than completion.**
+- **Choice:** every cell asserts exact per-stage tile counts against the
+  schedule's op counts AND full credit return. A leaked credit or a
+  duplicate/dropped tile fails the cell even when execution completes.
+- **Rationale:** the #61 livelock hid behind "tests complete" for months;
+  conservation violations are the leading indicator, not hangs.
+
+**Decision 2: characterization via an always-run report test case.**
+- **Choice:** matrix cells append rows to a shared table; a final test
+  case prints it, so the numbers land in every CI log and were captured
+  once on the epic.
+- **Alternatives considered:** a separate benchmark binary (heavier,
+  would drift from the regression configs).
+
+## 4. Issues Encountered
+
+1. First matrix run failed 36/36 cells on `tiles_loaded == LOAD count`:
+   `Statistics::tiles_loaded` counts TILE_ARRIVED_L3 events, and a tile
+   reaches L3 from BOTH directions - DMA loads (downstream) and BlockMover
+   writebacks (upstream C tiles). The invariant is LOAD + WRITEBACK, still
+   exact. Earlier suites only asserted feeds/drains, so this counter
+   semantics was previously untested.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                            # 103/103
+./build/tests/timing/test_elementwise_regression  # 4475 assertions, 36 cells
+./build/tests/coverage/test_pattern_coverage      # 18/105, gates hold
+```
+
+## 7. Characterization Highlights (full table on epic #71)
+
+- Pipeline absorbs envelope pressure: binary 64-tile under constrained-min
+  (12/12) triples stall cycles (1166 -> 3707) but costs only 6 extra
+  cycles total (1672 -> 1678) - stalls overlap with useful work.
+- Per-tile cost amortizes 242 -> 26 cycles from 1 to 64 tiles.
+- Broadcast is cheaper than binary at equal tile counts (fewer loads:
+  1 B delivery vs 16/64): e.g. 16-tile stalls 385 vs 563.
+- Partitioned credits are neutral-to-mild on this pattern (same cycles,
+  slightly higher stalls under contention).
+
+## 8. Next Steps
+
+- Epic E2 (#71) closes with this PR; #18's elementwise half is done
+  (VE_REDUCE remainder belongs to E3 #72).
+- Next pattern epics per plan: E1 (#70) gather, E3 (#72) online-reduce,
+  E4 (#73) layout; Wave 1 E5-E7 feed milestone M2 ResNet (#130).

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -199,9 +199,9 @@
         "isa_closure": "done",
         "generator": "done",
         "functional": "done",
-        "regression": "missing"
+        "regression": "done"
       },
-      "notes": "VE_ELEMENTWISE fully encoded + behavioral semantics (#100); ElementwiseScheduleGenerator with paired two-stream emission, executable COMPUTEs, envelope checks (#101); value-producing CSP execution via FunctionalElementwiseExecutor verified against host oracle across all ops/forms incl. partitioned credits (#102). Design: docs/plans/e2_broadcast_elementwise_pattern.md (#99). Regression matrix is E2-T5."
+      "notes": "VE_ELEMENTWISE fully encoded + behavioral semantics (#100); ElementwiseScheduleGenerator with paired two-stream emission, executable COMPUTEs, envelope checks (#101); value-producing CSP execution via FunctionalElementwiseExecutor verified against host oracle across all ops/forms incl. partitioned credits (#102). Design: docs/plans/e2_broadcast_elementwise_pattern.md (#99). Regression: form x size x envelope matrix with credit/stall invariants + characterization (#103)."
     },
     {
       "name": "epilogue_fused",
@@ -280,9 +280,9 @@
         "isa_closure": "done",
         "generator": "done",
         "functional": "done",
-        "regression": "missing"
+        "regression": "done"
       },
-      "notes": "Ref-count seeding 1:1:k in CSP tier (#100); emit_broadcast_tile + BROADCAST_B form (#101); CSP functional broadcast vs host oracle + behavioral STR_BROADCAST resident-operand delivery semantics with deliver-once/consume-many ISA test (#102). Design: docs/plans/e2_broadcast_elementwise_pattern.md (#99). Regression matrix is E2-T5."
+      "notes": "Ref-count seeding 1:1:k in CSP tier (#100); emit_broadcast_tile + BROADCAST_B form (#101); CSP functional broadcast vs host oracle + behavioral STR_BROADCAST resident-operand delivery semantics with deliver-once/consume-many ISA test (#102). Design: docs/plans/e2_broadcast_elementwise_pattern.md (#99). Regression: form x size x envelope matrix with credit/stall invariants + characterization (#103)."
     },
     {
       "name": "online_reduction",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -138,3 +138,13 @@ kpu_add_component_test(test_functional_elementwise "timing"
 set_tests_properties(test_functional_elementwise PROPERTIES
     LABELS "timing;functional;elementwise;v0.9"
 )
+
+# Elementwise regression matrix (issue #103, epic E2): form x size x envelope
+# with credit/stall invariants and characterization
+kpu_add_component_test(test_elementwise_regression "timing"
+    test_elementwise_regression.cpp
+)
+
+set_tests_properties(test_elementwise_regression PROPERTIES
+    LABELS "timing;regression;elementwise;v0.9"
+)

--- a/tests/timing/test_elementwise_regression.cpp
+++ b/tests/timing/test_elementwise_regression.cpp
@@ -156,11 +156,22 @@ void run_cell(Form form, const SizeCase& size, const EnvelopeCase& env) {
     REQUIRE(executor.l3_credits().available() == env.l3);
     REQUIRE(executor.l2_credits().available() == env.l2);
 
-    // Stall sanity
+    // Stall sanity. Stall counters aggregate across ALL components, so
+    // they can legitimately exceed total_cycles (e.g. 3707 stalls in a
+    // 1678-cycle run when several engines wait concurrently); the true
+    // "stalled every cycle" ceiling is total_cycles x stall-capable
+    // components. Hitting it would mean no component ever did work.
     const Cycle stalls = stats.dma_credit_stalls + stats.bm_tag_stalls +
                          stats.bm_credit_stalls + stats.str_tag_stalls +
                          stats.str_credit_stalls;
+    const auto& exec_config = executor.config();
+    const Cycle stall_capable =
+        static_cast<Cycle>(exec_config.num_dma_engines +
+                           exec_config.num_block_movers +
+                           exec_config.num_row_streamers +
+                           exec_config.num_col_streamers);
     REQUIRE(result.total_cycles > 0);
+    REQUIRE(stalls < result.total_cycles * stall_capable);
 
     const Size tiles = gen_config.data_tiles();
     characterization().push_back(

--- a/tests/timing/test_elementwise_regression.cpp
+++ b/tests/timing/test_elementwise_regression.cpp
@@ -1,0 +1,255 @@
+// ============================================================================
+// tests/timing/test_elementwise_regression.cpp
+// Elementwise/broadcast execution regression: form x size x envelope matrix
+// with credit/stall invariants and performance characterization
+// (issue #103, epic E2).
+//
+// Every cell of the matrix must execute to completion with exact per-stage
+// tile accounting and full credit return - a leaked credit or an unconsumed
+// tile anywhere in the pipeline fails the cell, not just a livelock.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <sw/kpu/timing/schedule/functional_elementwise_executor.hpp>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::VEOp;
+
+namespace {
+
+using Form = ElementwiseScheduleGenerator::Form;
+
+struct EnvelopeCase {
+    const char* name;
+    Size l3;
+    Size l2;
+    bool partitioned;
+};
+
+// Default, the MINIMUM safe envelope (share = min(12,12)/4 = 3 = the
+// binary/broadcast working set - one tile less refuses generation), and
+// per-matrix partitioned credits.
+constexpr EnvelopeCase kEnvelopes[] = {
+    {"default",         32, 64, false},
+    {"constrained-min", 12, 12, false},
+    {"partitioned",     32, 64, true},
+};
+
+struct SizeCase {
+    const char* name;
+    Size num_elements;
+};
+
+constexpr SizeCase kSizes[] = {
+    {"single-tile", 256},
+    {"16-tile",     4096},
+    {"64-tile",     16384},
+    {"non-aligned", 4000},   // 16 tiles, 160-elem tail
+};
+
+constexpr Form kForms[] = {Form::BINARY, Form::BROADCAST_B, Form::UNARY};
+
+const char* form_name(Form form) {
+    switch (form) {
+        case Form::BINARY:      return "binary";
+        case Form::UNARY:       return "unary";
+        case Form::BROADCAST_B: return "broadcast_b";
+    }
+    return "?";
+}
+
+ElementwiseScheduleGenerator::Config make_generator_config(
+    Size num_elements, Form form, const EnvelopeCase& env) {
+    ElementwiseScheduleGenerator::Config config;
+    config.num_elements = num_elements;
+    config.tile_elems = 256;
+    config.form = form;
+    config.l3_buffer_count = env.l3;
+    config.l2_bank_count = env.l2;
+    config.a_base = 0x100000;
+    config.b_base = 0x200000;
+    config.c_base = 0x300000;
+    return config;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config(const EnvelopeCase& env) {
+    ConcurrentTimingExecutor::Config config;
+    config.l3_buffer_count = env.l3;
+    config.l2_bank_count = env.l2;
+    config.partition_l3_credits = env.partitioned;
+    config.partition_l2_credits = env.partitioned;
+    config.max_cycles = 5'000'000;
+    return config;
+}
+
+struct CellResult {
+    std::string form;
+    std::string size;
+    std::string envelope;
+    Size tiles = 0;
+    Cycle cycles = 0;
+    double cycles_per_tile = 0.0;
+    Cycle stall_cycles = 0;
+    double dma_util = 0.0;
+    double str_util = 0.0;
+};
+
+std::vector<CellResult>& characterization() {
+    static std::vector<CellResult> rows;
+    return rows;
+}
+
+/**
+ * @brief Execute one matrix cell and enforce the invariants
+ *
+ * Invariants (beyond completion):
+ *  - per-stage tile accounting: executor throughput counters equal the
+ *    schedule's op counts exactly (a duplicate or dropped tile at any
+ *    stage fails here even if execution completes)
+ *  - credit conservation: every L3/L2 credit is returned by the end
+ *    (#inserts == #invalidates end-to-end)
+ *  - stall sanity: the pipeline cannot have been stalled every cycle
+ */
+void run_cell(Form form, const SizeCase& size, const EnvelopeCase& env) {
+    auto gen_config = make_generator_config(size.num_elements, form, env);
+    ElementwiseScheduleGenerator gen(gen_config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor executor(make_executor_config(env));
+    ScheduleExecutor sched_exec(executor);
+    auto result = sched_exec.execute(schedule);
+
+    INFO("form=" << form_name(form) << " size=" << size.name
+         << " envelope=" << env.name << " cycles=" << result.total_cycles
+         << " error=" << result.error_message);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+    REQUIRE(result.warnings.empty());   // generation envelope == execution envelope
+
+    const auto stats = executor.get_statistics();
+
+    // Per-stage tile accounting. tiles_loaded counts TILE_ARRIVED_L3
+    // events, and a tile reaches L3 from BOTH directions: DMA loads
+    // (downstream) and BlockMover writebacks (upstream, C tiles) - so the
+    // invariant is LOAD + WRITEBACK, still exact.
+    REQUIRE(stats.tiles_loaded == schedule.count_ops(ScheduleOpType::LOAD) +
+                                  schedule.count_ops(ScheduleOpType::WRITEBACK));
+    REQUIRE(stats.tiles_moved == schedule.count_ops(ScheduleOpType::MOVE));
+    REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+    REQUIRE(stats.tiles_drained == schedule.count_ops(ScheduleOpType::DRAIN));
+    REQUIRE(stats.tiles_writeback == schedule.count_ops(ScheduleOpType::WRITEBACK));
+    REQUIRE(stats.tiles_stored == schedule.count_ops(ScheduleOpType::STORE));
+
+    // Credit conservation (works in both flat and partition mode:
+    // available() aggregates across partitions)
+    REQUIRE(executor.l3_credits().available() == env.l3);
+    REQUIRE(executor.l2_credits().available() == env.l2);
+
+    // Stall sanity
+    const Cycle stalls = stats.dma_credit_stalls + stats.bm_tag_stalls +
+                         stats.bm_credit_stalls + stats.str_tag_stalls +
+                         stats.str_credit_stalls;
+    REQUIRE(result.total_cycles > 0);
+
+    const Size tiles = gen_config.data_tiles();
+    characterization().push_back(
+        {form_name(form), size.name, env.name, tiles, result.total_cycles,
+         static_cast<double>(result.total_cycles) / static_cast<double>(tiles),
+         stalls, stats.dma_utilization(), stats.str_utilization()});
+}
+
+} // namespace
+
+TEST_CASE("Elementwise execution matrix: form x size x envelope",
+          "[timing][regression][elementwise][matrix]") {
+    for (Form form : kForms) {
+        for (const auto& size : kSizes) {
+            for (const auto& env : kEnvelopes) {
+                DYNAMIC_SECTION(form_name(form) << "/" << size.name << "/"
+                                                << env.name) {
+                    run_cell(form, size, env);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Envelope refusal boundary is exact",
+          "[timing][regression][elementwise][envelope]") {
+    // share = min(l3,l2)/4: 12 -> 3 (= working set, generates);
+    // 11 -> 2 (< working set, refused a priori)
+    EnvelopeCase safe{"boundary-safe", 12, 12, false};
+    EnvelopeCase unsafe{"boundary-unsafe", 11, 11, false};
+
+    auto safe_schedule = ElementwiseScheduleGenerator(
+        make_generator_config(4096, Form::BINARY, safe)).generate();
+    REQUIRE(safe_schedule.valid);
+
+    auto unsafe_schedule = ElementwiseScheduleGenerator(
+        make_generator_config(4096, Form::BINARY, unsafe)).generate();
+    REQUIRE_FALSE(unsafe_schedule.valid);
+    REQUIRE(unsafe_schedule.error_message.find("working set") != std::string::npos);
+}
+
+TEST_CASE("Functional correctness under credit pressure",
+          "[timing][regression][elementwise][functional]") {
+    // Values must survive the MINIMUM envelope with partitioned credits:
+    // 12 credits -> 4 per matrix, every tile contends for its partition.
+    // A credit bug that reorders or drops a tile shows up as a value error.
+    const Size n = 4000;   // non-aligned: 16 tiles, 160-elem tail
+    EnvelopeCase env{"constrained-partitioned", 12, 12, true};
+
+    std::vector<float> a(n), b(n);
+    for (Size i = 0; i < n; ++i) {
+        a[i] = -2.0f + 0.001f * static_cast<float>(i);
+        b[i] = 3.0f - 0.0005f * static_cast<float>(i);
+    }
+
+    FunctionalElementwiseExecutor executor(
+        make_generator_config(n, Form::BINARY, env), make_executor_config(env));
+    auto result = executor.run(VEOp::MUL, a, b);
+    REQUIRE(result.execution.success);
+    REQUIRE_FALSE(result.execution.livelock_detected);
+
+    REQUIRE(result.values.size() == n);
+    for (Size i = 0; i < n; ++i) {
+        INFO("element " << i);
+        REQUIRE(result.values[i] == Catch::Approx(a[i] * b[i]).margin(1e-6f));
+    }
+}
+
+// Runs last (alphabetical tags do not order; Catch2 runs in declaration
+// order within a file): prints the characterization table gathered by the
+// matrix test for recording in the epic.
+TEST_CASE("Elementwise characterization report",
+          "[timing][regression][elementwise][report]") {
+    const auto& rows = characterization();
+    if (rows.empty()) {
+        SUCCEED("matrix test did not run in this invocation");
+        return;
+    }
+    std::printf("\n%-12s %-12s %-16s %6s %9s %9s %8s %6s %6s\n",
+                "form", "size", "envelope", "tiles", "cycles", "cyc/tile",
+                "stalls", "dma%", "str%");
+    for (const auto& r : rows) {
+        std::printf("%-12s %-12s %-16s %6zu %9llu %9.1f %8llu %6.1f %6.1f\n",
+                    r.form.c_str(), r.size.c_str(), r.envelope.c_str(),
+                    static_cast<size_t>(r.tiles),
+                    static_cast<unsigned long long>(r.cycles),
+                    r.cycles_per_tile,
+                    static_cast<unsigned long long>(r.stall_cycles),
+                    100.0 * r.dma_util, 100.0 * r.str_util);
+    }
+    SUCCEED("characterization recorded");
+}


### PR DESCRIPTION
Fixes #103 — E2-T5, the final task of the broadcast/elementwise epic. **Completes epic #71**: elementwise and broadcast are the first operators after matmul with all five lifecycle stages (design/isa_closure/generator/functional/regression) done.

## What

- **`test_elementwise_regression`**: the full form × size × envelope execution matrix — {binary, broadcast_b, unary} × {1-tile, 16-tile, 64-tile, non-aligned 4000} × {default 32/64, constrained-min 12/12, partitioned} = **36 cells**. Every cell enforces invariants stronger than completion:
  - **Exact per-stage tile accounting** — executor throughput counters equal the schedule's op counts. (First matrix run caught an untested counter semantic: `tiles_loaded` counts `TILE_ARRIVED_L3` events, and tiles reach L3 from *both* directions — DMA loads downstream and BlockMover writebacks upstream — so the exact invariant is LOAD + WRITEBACK.)
  - **Full credit conservation** — every L3/L2 credit returned post-run, in both flat and partition mode. A leaked credit fails the cell even when execution completes; conservation violations are the leading indicator the #61 livelock taught us to watch.
- **Envelope refusal boundary pinned exact**: min(l3,l2)=12 (burst share 3 = working set) generates; 11 refuses a priori.
- **Functional-under-pressure**: values exact vs host oracle at the minimum envelope with partitioned credits on a non-aligned tensor — a credit bug that reorders or drops a tile shows up as a value error.
- **Characterization** recorded on epic #71 (and reprinted in every CI run of the suite): the pipeline absorbs envelope pressure (binary 64-tile constrained-min triples stalls 1166→3707 yet costs 6 extra cycles), per-tile cost amortizes 242→26 cycles from 1 to 64 tiles, broadcast is cheaper than binary at equal tile counts.

## Coverage

`elementwise` + `broadcast` regression cells → done: **18/105**. Gates hold. #18's elementwise half is complete with this (the VE_REDUCE remainder belongs to E3 #72).

## Verification

Full suite: **103/103 pass** (new suite: 4 cases, 4,475 assertions).
Session log: `docs/sessions/2026-07-13_v0.9_e2_regression_matrix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added `test_elementwise_regression` for elementwise/broadcast scheduling across form × size × envelope configurations, with per-stage tile accounting, exact credit conservation, livelock detection prevention, and generation/execution envelope consistency checks.
  - Included envelope-safety boundary validation and functional output verification for constrained/partitioned credit settings.
  - Added timing characterization reporting (cycles, stalls, DMA/stream utilization).
- **Documentation**
  - Updated the coverage report to mark elementwise and broadcast regression as complete, with expanded notes and added invariants.
  - Added a new session log and updated changelog entries with verification commands, results, and observed nuances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->