### PR TITLE
feat(isa): VE_REDUCE operands + running-combine semantics (reduce-T2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VE_REDUCE numerical semantics + ISA closure (#105, epic E3).**
+  `VEReduceOperands` gives the previously annotation-only VE_REDUCE real
+  encoding: MAX/MIN/SUM scalar accumulators and MEAN/VAR moment triplets
+  `[count, sum, sumsq]`, gated by INIT/ACCUMULATE/FINALIZE phase flags,
+  over a fixed 3-lane fp32 accumulator ABI. Behavioral executor runs the
+  streaming combine with defined edge semantics (empty -> NaN, single
+  sample -> variance 0, population divisor, clamp so cancellation never
+  yields negative variance); assembler parses
+  `VE_REDUCE op, src, acc [, INIT] [, FINALIZE]`; serializer round-trips
+  at format v3 (variant 17 -> 18, guarded by static_asserts). The CSP
+  accumulator needs no executor change - a reduction is a chain of
+  functional computes targeting the accumulator tile with resident-dep
+  ordering, validated end-to-end. Closes the ISA half of #18 for
+  reductions. Coverage: online_reduction design + isa_closure -> done
+  (20/105).
+
 - **Elementwise/broadcast regression matrix + characterization (#103,
   epic E2 COMPLETE).** `test_elementwise_regression` executes the full
   form x size x envelope matrix (binary/broadcast/unary x 1/16/64-tile +

--- a/docs/sessions/2026-07-13_v0.9_e3_reduce_isa.md
+++ b/docs/sessions/2026-07-13_v0.9_e3_reduce_isa.md
@@ -1,0 +1,90 @@
+# v0.9 E3-T2: VE_REDUCE ISA/Executor Closure Decision Log
+
+**Date:** 2026-07-13
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 103/103 suites passing (new: reduce serialization + assembler
+round-trip, behavioral running-combine 43 assertions, CSP chained
+accumulator)
+**Issues:** #105 (done); ISA half of #18 for reductions
+
+## 1. Summary
+
+Implemented E3-T2 per the approved design: real VE_REDUCE operands
+(`VEReduceOperands`), behavioral running-combine semantics for all five
+ops with the defined edge cases, assembler/serializer round-trip at
+format v3, and validation that the CSP reduction chain runs on the
+existing #66 resident-dependency machinery with no executor-core change.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| VEReduceOp enum (MAX/MIN/SUM/MEAN/VAR) + VEReducePhase flags | Done |
+| VEReduceOperands + variant slot (index 17, size 18) + factory | Done |
+| to_string / ve_reduce_op_from_string helpers | Done |
+| Serializer write/read case 17, format v3, static_asserts | Done |
+| Assembler `VE_REDUCE op, src, acc [, INIT] [, FINALIZE]` | Done |
+| Behavioral running-combine (3-lane fp32 ABI, phase gating) | Done |
+| Edge cases: empty -> NaN, single -> var 0, clamp, population divisor | Done |
+| CSP chained-accumulator validation test (resident-dep ordering) | Done |
+| Coverage: online_reduction design + isa_closure -> done (20/105) | Done |
+
+Files:
+- `include/sw/kpu/isa/data_movement_isa.hpp` + `src/software/isa/data_movement_isa.cpp`
+- `include/sw/kpu/isa/program_serializer.hpp` (v3) + `src/software/isa/program_serializer.cpp`
+- `src/software/isa/assembler.cpp` (parse_ve_reduce)
+- `include/sw/kpu/isa/behavioral_program_executor.hpp` + `src/software/isa/behavioral_program_executor.cpp`
+- `tests/isa/test_serialization.cpp`, `tests/isa/test_behavioral_program_executor.cpp`,
+  `tests/timing/test_concurrent_timing_executor.cpp`
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: fixed 3-lane fp32 accumulator ABI (from the T1 review).**
+- MAX/MIN/SUM use lane 0; MEAN/VAR use [count, sum, sumsq]. FINALIZE
+  rewrites to [mean, count, sumsq] (MEAN) / [var, mean, count] (VAR) so a
+  single VAR reduction hands layernorm both moments. Raw lanes are
+  op-private pre-FINALIZE, which keeps a future Welford upgrade from
+  touching consumers.
+
+**Decision 2: MEAN/VAR local accumulation in double.**
+- The per-tile local sum/sumsq accumulate in double before folding into
+  the fp32 state - cheap robustness against long-stream cancellation
+  without changing the on-chip fp32 state ABI.
+
+**Decision 3: INIT as an explicit phase flag, not first-touch detection.**
+- The ISA never has to infer "is this the first tile"; the CSP first
+  compute carries the same INIT|ACCUMULATE meaning structurally (it omits
+  the accumulator from its input set, since required=max(1,0)=1 with zero
+  completions would deadlock - the design's load-bearing observation,
+  now covered by the chained-accumulator test).
+
+## 4. Issues Encountered
+
+1. Assembler parse test initially used `.name`/`.dimensions` directives
+   with the wrong grammar (`.name` wants a STRING token). Dropped the
+   directives - the parse test only inspects operands, not program
+   metadata.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                              # 103/103
+./build/tests/isa/serialization_test "[reduce]"      # 23 assertions
+./build/tests/isa/test_behavioral_program_executor   # 43 passed
+./build/tests/timing/test_concurrent_timing_executor "[reduction]"
+./build/tests/coverage/test_pattern_coverage         # 20/105, gates hold
+```
+
+## 7. Next Steps
+
+- E3-T3 (#106): OnlineReductionScheduleGenerator (FULL_REDUCE / ROW_STATS
+  / ROW_NORMALIZE) with envelope-derived realization selection.
+- Then T4 (#107) functional + oracles, T5 (#108) regression -> closes
+  epic #72 and #18 entirely.

--- a/include/sw/kpu/isa/behavioral_program_executor.hpp
+++ b/include/sw/kpu/isa/behavioral_program_executor.hpp
@@ -165,6 +165,7 @@ private:
      *        the program's Ti x Tj tile
      */
     void execute_ve_elementwise(const VEOperands& ops);
+    void execute_ve_reduce(const VEReduceOperands& ops);
 
     /**
      * @brief Resolve external memory address for a tile

--- a/include/sw/kpu/isa/data_movement_isa.hpp
+++ b/include/sw/kpu/isa/data_movement_isa.hpp
@@ -425,6 +425,46 @@ struct VEOperands {
 };
 
 /**
+ * @brief Vector Engine reduction operation kinds (VE_REDUCE)
+ *
+ * MAX/MIN/SUM carry a single scalar accumulator lane; MEAN/VAR carry a
+ * moment triplet [count, sum, sumsq]. See the accumulator ABI in
+ * docs/plans/e3_online_reduction_pattern.md (epic E3, issue #105).
+ */
+enum class VEReduceOp : uint8_t {
+    MAX = 0, MIN, SUM, MEAN, VAR
+};
+
+/**
+ * @brief VE_REDUCE phase flags (a set, not an enum)
+ *
+ * A streamed reduction is INIT|ACCUMULATE on the first tile, ACCUMULATE
+ * on the middle tiles, and FINALIZE (alone or fused) on the last; a
+ * single-tile reduction is INIT|ACCUMULATE|FINALIZE in one instruction.
+ */
+namespace VEReducePhase {
+constexpr uint8_t INIT       = 0x1;  // write the op identity into the state lanes
+constexpr uint8_t ACCUMULATE = 0x2;  // combine l1_src into the state
+constexpr uint8_t FINALIZE   = 0x4;  // convert state -> finalized stat lanes
+} // namespace VEReducePhase
+
+/**
+ * @brief Vector Engine reduction operands (VE_REDUCE)
+ *
+ * Gives VE_REDUCE real semantics (previously a monostate structural
+ * marker): fold `l1_src` into the 3-lane fp32 accumulator at offset 0 of
+ * `l1_acc` per `op`, gated by `phase`. The element count of l1_src rides
+ * the SET_TILE_DIM auto state, like VE_ELEMENTWISE; the accumulator is
+ * always three fp32 lanes regardless of the source element width.
+ */
+struct VEReduceOperands {
+    VEReduceOp op = VEReduceOp::SUM;
+    uint8_t phase = VEReducePhase::INIT | VEReducePhase::ACCUMULATE;
+    uint8_t l1_src = 0;         // L1 buffer of the tile being consumed
+    uint8_t l1_acc = 0;         // L1 buffer holding the accumulator state
+};
+
+/**
  * @brief A single data movement instruction
  *
  * Instructions are the units of the Data Movement ISA. They encode
@@ -454,7 +494,9 @@ struct DMInstruction {
         AutoBlockMoverOperands,     // BM_*_AUTO
         AutoStreamerOperands,       // STR_*_AUTO
         // Vector Engine operands (issue #100)
-        VEOperands                  // VE_ELEMENTWISE
+        VEOperands,                 // VE_ELEMENTWISE
+        // Vector Engine reduction operands (issue #105)
+        VEReduceOperands            // VE_REDUCE
     > operands;
 
     // Timing hints (from SURE analysis)
@@ -567,6 +609,11 @@ struct DMInstruction {
                                               uint8_t l1_src, uint8_t l1_dst);
     static DMInstruction ve_elementwise_scalar(VEOp op, float scalar,
                                                uint8_t l1_src, uint8_t l1_dst);
+
+    // Vector Engine reduction factory (issue #105)
+    static DMInstruction ve_reduce(
+        VEReduceOp op, uint8_t l1_src, uint8_t l1_acc,
+        uint8_t phase = VEReducePhase::INIT | VEReducePhase::ACCUMULATE);
 };
 
 /**
@@ -579,6 +626,17 @@ const char* to_string(VEOp op);
  * @return true and sets op on success
  */
 bool ve_op_from_string(const std::string& name, VEOp& op);
+
+/**
+ * @brief Name of a Vector Engine reduction operation (for labels/assembly)
+ */
+const char* to_string(VEReduceOp op);
+
+/**
+ * @brief Parse a Vector Engine reduction operation name (inverse of to_string)
+ * @return true and sets op on success
+ */
+bool ve_reduce_op_from_string(const std::string& name, VEReduceOp& op);
 
 // ============================================================================
 // Data Movement Program

--- a/include/sw/kpu/isa/program_serializer.hpp
+++ b/include/sw/kpu/isa/program_serializer.hpp
@@ -18,7 +18,8 @@ namespace sw::kpu::isa {
  * @brief Binary format magic number and version
  */
 constexpr uint32_t DMPROGRAM_MAGIC = 0x4B505544;  // "KPUD" in little-endian
-constexpr uint32_t DMPROGRAM_VERSION = 2;  // v2: VEOperands (issue #100)
+constexpr uint32_t DMPROGRAM_VERSION = 3;  // v3: VEReduceOperands (issue #105);
+                                           // v2: VEOperands (issue #100)
 
 /**
  * @brief Error thrown during serialization/deserialization

--- a/src/software/isa/assembler.cpp
+++ b/src/software/isa/assembler.cpp
@@ -808,10 +808,38 @@ DMInstruction Assembler::parse_ve_elementwise() {
 }
 
 DMInstruction Assembler::parse_ve_reduce() {
+    // VE_REDUCE <OP>, <l1_src>, <l1_acc> [, INIT] [, FINALIZE]
+    // ACCUMULATE is implied; INIT and FINALIZE are optional phase flags.
     DMInstruction instr;
     instr.opcode = DMOpcode::VE_REDUCE;
-    consume(TokenType::IDENTIFIER, "reduction operation");
-    instr.operands = std::monostate{};
+
+    Token op_tok = consume(TokenType::IDENTIFIER, "reduction operation");
+    VEReduceOp op;
+    if (!ve_reduce_op_from_string(op_tok.text, op)) {
+        error("Unknown VE reduction operation: " + op_tok.text);
+    }
+
+    VEReduceOperands ops;
+    ops.op = op;
+    ops.phase = VEReducePhase::ACCUMULATE;
+
+    match(TokenType::COMMA);
+    ops.l1_src = static_cast<uint8_t>(parse_number());
+    match(TokenType::COMMA);
+    ops.l1_acc = static_cast<uint8_t>(parse_number());
+
+    while (match(TokenType::COMMA)) {
+        Token flag = consume(TokenType::IDENTIFIER, "phase flag (INIT or FINALIZE)");
+        if (flag.text == "INIT") {
+            ops.phase |= VEReducePhase::INIT;
+        } else if (flag.text == "FINALIZE") {
+            ops.phase |= VEReducePhase::FINALIZE;
+        } else {
+            error("Unknown VE_REDUCE phase flag: " + flag.text);
+        }
+    }
+
+    instr.operands = ops;
     return instr;
 }
 

--- a/src/software/isa/behavioral_program_executor.cpp
+++ b/src/software/isa/behavioral_program_executor.cpp
@@ -10,6 +10,7 @@
 #include <sw/kpu/isa/behavioral_program_executor.hpp>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 #include <iostream>
@@ -239,11 +240,18 @@ void BehavioralProgramExecutor::dispatch(const DMInstruction& instr, [[maybe_unu
         }
         break;
 
-    // Gather/scatter, VE_REDUCE (E3 scope), and scratch opcodes —
-    // annotations, not functional in behavioral
+    case DMOpcode::VE_REDUCE:
+        // Functional when carrying VEReduceOperands (issue #105); legacy
+        // monostate markers remain no-ops
+        if (std::holds_alternative<VEReduceOperands>(instr.operands)) {
+            execute_ve_reduce(std::get<VEReduceOperands>(instr.operands));
+        }
+        break;
+
+    // Gather/scatter and scratch opcodes — annotations, not functional
+    // in behavioral
     case DMOpcode::DMA_LOAD_GATHER:
     case DMOpcode::DMA_STORE_SCATTER:
-    case DMOpcode::VE_REDUCE:
     case DMOpcode::L2_SCRATCH_WRITE:
     case DMOpcode::L2_SCRATCH_READ:
         break;
@@ -592,6 +600,101 @@ void BehavioralProgramExecutor::execute_ve_elementwise(const VEOperands& ops) {
     }
 
     hw_.l1_buffers[ops.l1_dst].write(0, out.data(), bytes);
+}
+
+void BehavioralProgramExecutor::execute_ve_reduce(const VEReduceOperands& ops) {
+    if (!program_) return;
+    if (ops.l1_acc >= hw_.l1_buffers.size()) return;
+
+    // The accumulator is three contiguous fp32 lanes at offset 0 of l1_acc,
+    // regardless of op (the E3 ABI). MAX/MIN/SUM use lane 0; MEAN/VAR use
+    // all three as [count, sum, sumsq] until FINALIZE.
+    constexpr Size kAccLanes = 3;
+    float state[kAccLanes];
+    hw_.l1_buffers[ops.l1_acc].read(0, state, kAccLanes * sizeof(float));
+
+    const bool do_init  = ops.phase & VEReducePhase::INIT;
+    const bool do_accum = ops.phase & VEReducePhase::ACCUMULATE;
+    const bool do_final = ops.phase & VEReducePhase::FINALIZE;
+
+    if (do_init) {
+        switch (ops.op) {
+            case VEReduceOp::MAX: state[0] = -std::numeric_limits<float>::infinity(); break;
+            case VEReduceOp::MIN: state[0] =  std::numeric_limits<float>::infinity(); break;
+            case VEReduceOp::SUM: state[0] = 0.0f; break;
+            case VEReduceOp::MEAN:
+            case VEReduceOp::VAR: state[0] = 0.0f; state[1] = 0.0f; state[2] = 0.0f; break;
+        }
+    }
+
+    if (do_accum) {
+        Size elems = program_->Ti * program_->Tj;
+        if (elems > 0 && ops.l1_src < hw_.l1_buffers.size()) {
+            std::vector<float> src(elems);
+            hw_.l1_buffers[ops.l1_src].read(0, src.data(), elems * sizeof(float));
+            // Local reduce over the tile, then combine into the running state
+            switch (ops.op) {
+                case VEReduceOp::MAX:
+                    for (Size i = 0; i < elems; ++i)
+                        if (src[i] > state[0]) state[0] = src[i];
+                    break;
+                case VEReduceOp::MIN:
+                    for (Size i = 0; i < elems; ++i)
+                        if (src[i] < state[0]) state[0] = src[i];
+                    break;
+                case VEReduceOp::SUM:
+                    for (Size i = 0; i < elems; ++i) state[0] += src[i];
+                    break;
+                case VEReduceOp::MEAN:
+                case VEReduceOp::VAR: {
+                    double sum = 0.0, sumsq = 0.0;  // double local accum, fp32 state
+                    for (Size i = 0; i < elems; ++i) {
+                        sum += src[i];
+                        sumsq += static_cast<double>(src[i]) * src[i];
+                    }
+                    state[0] += static_cast<float>(elems);
+                    state[1] += static_cast<float>(sum);
+                    state[2] += static_cast<float>(sumsq);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (do_final) {
+        const float nan = std::numeric_limits<float>::quiet_NaN();
+        switch (ops.op) {
+            case VEReduceOp::MAX:
+            case VEReduceOp::MIN:
+            case VEReduceOp::SUM:
+                // state[0] is already the stat
+                break;
+            case VEReduceOp::MEAN: {
+                const float count = state[0], sum = state[1], sumsq = state[2];
+                const float mean = count > 0.0f ? sum / count : nan;
+                // Finalized layout: [mean, count, sumsq]
+                state[0] = mean; state[1] = count; state[2] = sumsq;
+                break;
+            }
+            case VEReduceOp::VAR: {
+                const float count = state[0], sum = state[1], sumsq = state[2];
+                float mean = nan, var = nan;
+                if (count > 0.0f) {
+                    mean = sum / count;
+                    // Population variance; clamp so cancellation never yields
+                    // a negative value (single sample is exactly 0)
+                    var = count == 1.0f
+                        ? 0.0f
+                        : std::max(0.0f, sumsq / count - mean * mean);
+                }
+                // Finalized layout: [var, mean, count]
+                state[0] = var; state[1] = mean; state[2] = count;
+                break;
+            }
+        }
+    }
+
+    hw_.l1_buffers[ops.l1_acc].write(0, state, kAccLanes * sizeof(float));
 }
 
 void BehavioralProgramExecutor::fire_compute() {

--- a/src/software/isa/data_movement_isa.cpp
+++ b/src/software/isa/data_movement_isa.cpp
@@ -753,6 +753,54 @@ DMInstruction DMInstruction::ve_elementwise_scalar(VEOp op, float scalar,
     return instr;
 }
 
+const char* to_string(VEReduceOp op) {
+    switch (op) {
+        case VEReduceOp::MAX:  return "MAX";
+        case VEReduceOp::MIN:  return "MIN";
+        case VEReduceOp::SUM:  return "SUM";
+        case VEReduceOp::MEAN: return "MEAN";
+        case VEReduceOp::VAR:  return "VAR";
+    }
+    return "UNKNOWN";
+}
+
+bool ve_reduce_op_from_string(const std::string& name, VEReduceOp& op) {
+    static const std::pair<const char*, VEReduceOp> kMap[] = {
+        {"MAX", VEReduceOp::MAX},   {"MIN", VEReduceOp::MIN},
+        {"SUM", VEReduceOp::SUM},   {"MEAN", VEReduceOp::MEAN},
+        {"VAR", VEReduceOp::VAR},
+    };
+    for (const auto& [key, value] : kMap) {
+        if (name == key) {
+            op = value;
+            return true;
+        }
+    }
+    return false;
+}
+
+DMInstruction DMInstruction::ve_reduce(VEReduceOp op, uint8_t l1_src,
+                                       uint8_t l1_acc, uint8_t phase) {
+    DMInstruction instr;
+    instr.opcode = DMOpcode::VE_REDUCE;
+
+    VEReduceOperands ops;
+    ops.op = op;
+    ops.phase = phase;
+    ops.l1_src = l1_src;
+    ops.l1_acc = l1_acc;
+    instr.operands = ops;
+
+    std::ostringstream oss;
+    oss << "VE_REDUCE " << to_string(op)
+        << ", L1[" << static_cast<int>(l1_src) << "]"
+        << " -> acc L1[" << static_cast<int>(l1_acc) << "]";
+    if (phase & VEReducePhase::INIT)     oss << " +INIT";
+    if (phase & VEReducePhase::FINALIZE) oss << " +FINALIZE";
+    instr.label = oss.str();
+    return instr;
+}
+
 // ============================================================================
 // DMProgram Statistics
 // ============================================================================

--- a/src/software/isa/program_serializer.cpp
+++ b/src/software/isa/program_serializer.cpp
@@ -246,6 +246,11 @@ void ProgramSerializer::write_instruction(std::vector<uint8_t>& buffer, const DM
             write_value(buffer, arg.l1_src_a);
             write_value(buffer, arg.l1_src_b);
             write_value(buffer, arg.l1_dst);
+        } else if constexpr (std::is_same_v<T, VEReduceOperands>) {
+            write_value(buffer, static_cast<uint8_t>(arg.op));
+            write_value(buffer, arg.phase);
+            write_value(buffer, arg.l1_src);
+            write_value(buffer, arg.l1_acc);
         }
         // NOTE: register-file config (SET_BASE family) and AUTO operand
         // types are not yet serialized - pre-existing gap, tracked
@@ -396,6 +401,15 @@ size_t ProgramSerializer::read_instruction(const std::vector<uint8_t>& data, siz
             instr.operands = ops;
             break;
         }
+        case 17: { // VEReduceOperands (issue #105, format v3)
+            VEReduceOperands ops;
+            ops.op = static_cast<VEReduceOp>(read_value<uint8_t>(data, offset));
+            ops.phase = read_value<uint8_t>(data, offset);
+            ops.l1_src = read_value<uint8_t>(data, offset);
+            ops.l1_acc = read_value<uint8_t>(data, offset);
+            instr.operands = ops;
+            break;
+        }
         default:
             throw SerializationError("Unknown operand type: " + std::to_string(operand_type));
     }
@@ -403,15 +417,20 @@ size_t ProgramSerializer::read_instruction(const std::vector<uint8_t>& data, siz
     return offset;
 }
 
-// Guard against variant drift: VEOperands must stay at index 16 (the
-// serialized operand-type tag) unless the format version is bumped again
-static_assert(std::variant_size_v<decltype(DMInstruction::operands)> == 17,
+// Guard against variant drift: the serialized operand-type tag is the
+// variant index, so VEOperands must stay at 16 and VEReduceOperands at 17
+// unless the format version is bumped again
+static_assert(std::variant_size_v<decltype(DMInstruction::operands)> == 18,
               "DMInstruction operand variant changed - update the serializer "
               "cases and bump DMPROGRAM_VERSION");
 static_assert(std::is_same_v<
                   std::variant_alternative_t<16, decltype(DMInstruction::operands)>,
                   VEOperands>,
               "VEOperands moved in the operand variant - update case 16");
+static_assert(std::is_same_v<
+                  std::variant_alternative_t<17, decltype(DMInstruction::operands)>,
+                  VEReduceOperands>,
+              "VEReduceOperands moved in the operand variant - update case 17");
 
 // ============================================================================
 // Memory Map Serialization

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -296,13 +296,13 @@
         "jepa"
       ],
       "stages": {
-        "design": "missing",
-        "isa_closure": "partial",
+        "design": "done",
+        "isa_closure": "done",
         "generator": "missing",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "VE_REDUCE opcode is a structural marker; running max/sum/mean/var semantics are the epic's core (enables online softmax and flash attention)."
+      "notes": "VEReduceOperands full encoding (MAX/MIN/SUM scalar + MEAN/VAR moment triplet, INIT/ACCUMULATE/FINALIZE phase flags) with assembler/serializer round-trip (format v3) and behavioral running-combine semantics incl. edge cases; CSP chained-accumulator validated on existing resident-dep machinery (#105). Design #104. Generator/functional/regression are E3-T3/T4/T5."
     },
     {
       "name": "layout_transform",

--- a/tests/isa/test_behavioral_program_executor.cpp
+++ b/tests/isa/test_behavioral_program_executor.cpp
@@ -729,6 +729,7 @@ void test_ve_reduce() {
     const Size Ti = 16, Tj = 16;
     const Size elems = Ti * Tj;
     const Size bytes = elems * sizeof(float);
+    const Size acc_bytes = 3 * sizeof(float);   // 3-lane fp32 accumulator
     const int n_tiles = 3;
 
     // Deterministic multi-tile stream (both signs, non-trivial for VAR)
@@ -778,7 +779,7 @@ void test_ve_reduce() {
             run_reduce(hw, op, phase, Ti, Tj);
         }
         std::vector<float> acc(3, -1.0f);
-        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        hw.l1_buffers[1].read(0, acc.data(), acc_bytes);
         return acc;
     };
 
@@ -819,7 +820,7 @@ void test_ve_reduce() {
                    VEReducePhase::INIT | VEReducePhase::ACCUMULATE |
                    VEReducePhase::FINALIZE, Ti, Tj);
         std::vector<float> acc(3);
-        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        hw.l1_buffers[1].read(0, acc.data(), acc_bytes);
         double t0 = 0.0; for (Size i = 0; i < elems; ++i) t0 += tiles[0][i];
         check(approx(acc[0], t0), "VE_REDUCE single-shot SUM (all phases fused)");
     }
@@ -830,7 +831,7 @@ void test_ve_reduce() {
         run_reduce(hw, VEReduceOp::MEAN, VEReducePhase::INIT, Ti, Tj);
         run_reduce(hw, VEReduceOp::MEAN, VEReducePhase::FINALIZE, Ti, Tj);
         std::vector<float> acc(3);
-        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        hw.l1_buffers[1].read(0, acc.data(), acc_bytes);
         check(std::isnan(acc[0]), "VE_REDUCE MEAN of empty stream -> NaN");
     }
     {
@@ -838,7 +839,7 @@ void test_ve_reduce() {
         run_reduce(hw, VEReduceOp::VAR, VEReducePhase::INIT, Ti, Tj);
         run_reduce(hw, VEReduceOp::VAR, VEReducePhase::FINALIZE, Ti, Tj);
         std::vector<float> acc(3);
-        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        hw.l1_buffers[1].read(0, acc.data(), acc_bytes);
         check(std::isnan(acc[0]), "VE_REDUCE VAR of empty stream -> NaN");
     }
 
@@ -846,12 +847,12 @@ void test_ve_reduce() {
     {
         TestHardware hw(16, 4, 256, 8, 128, 3, 64);
         float one = 42.5f;
-        hw.l1_buffers[0].write(0, &one, sizeof(float));
+        hw.l1_buffers[0].write(0, &one, static_cast<Size>(sizeof(float)));
         run_reduce(hw, VEReduceOp::VAR,
                    VEReducePhase::INIT | VEReducePhase::ACCUMULATE |
                    VEReducePhase::FINALIZE, 1, 1);
         std::vector<float> acc(3);
-        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        hw.l1_buffers[1].read(0, acc.data(), acc_bytes);
         check(acc[0] == 0.0f && acc[1] == 42.5f,
               "VE_REDUCE VAR of single sample -> var 0, mean = sample");
     }

--- a/tests/isa/test_behavioral_program_executor.cpp
+++ b/tests/isa/test_behavioral_program_executor.cpp
@@ -719,6 +719,145 @@ void test_str_broadcast_resident_operand() {
 }
 
 // ============================================================================
+// Test: VE_REDUCE streaming semantics + phase flags + edge cases
+// (issue #105, epic E3)
+// ============================================================================
+
+void test_ve_reduce() {
+    std::cout << "\n=== Test: VE_REDUCE streaming semantics (3 tiles) ===\n";
+
+    const Size Ti = 16, Tj = 16;
+    const Size elems = Ti * Tj;
+    const Size bytes = elems * sizeof(float);
+    const int n_tiles = 3;
+
+    // Deterministic multi-tile stream (both signs, non-trivial for VAR)
+    std::vector<std::vector<float>> tiles(n_tiles, std::vector<float>(elems));
+    for (int k = 0; k < n_tiles; ++k) {
+        for (Size i = 0; i < elems; ++i) {
+            tiles[k][i] = static_cast<float>(k * 100) - 128.0f
+                        + static_cast<float>((i * 7 + k) % 251) * 0.5f;
+        }
+    }
+
+    // Independent host oracle over the whole stream
+    double total_sum = 0.0, total_sumsq = 0.0;
+    double omax = -1e30, omin = 1e30;
+    size_t total_count = 0;
+    for (int k = 0; k < n_tiles; ++k) {
+        for (Size i = 0; i < elems; ++i) {
+            double v = tiles[k][i];
+            total_sum += v; total_sumsq += v * v;
+            omax = std::max(omax, v); omin = std::min(omin, v);
+            ++total_count;
+        }
+    }
+    const double omean = total_sum / total_count;
+    const double ovar = std::max(0.0, total_sumsq / total_count - omean * omean);
+
+    // Run one VE_REDUCE instruction against a persistent accumulator buffer.
+    // Streaming = one instruction per tile (l1[0]=src, l1[1]=acc); the
+    // accumulator persists across program runs because hw owns the buffers.
+    auto run_reduce = [](TestHardware& hw, VEReduceOp op, uint8_t phase,
+                         Size ti, Size tj) {
+        DMProgram p; p.name = "reduce"; p.Ti = ti; p.Tj = tj; p.Tk = 1;
+        p.instructions.push_back(DMInstruction::ve_reduce(op, 0, 1, phase));
+        p.instructions.push_back(DMInstruction::halt());
+        BehavioralProgramExecutor ex(hw.context());
+        ex.load_program(p, 0, 0, 0);
+        ex.run();
+    };
+
+    auto stream_reduce = [&](VEReduceOp op) {
+        TestHardware hw(16, 4, 256, 8, 128, /*num_l1=*/3, 64);
+        for (int k = 0; k < n_tiles; ++k) {
+            hw.l1_buffers[0].write(0, tiles[k].data(), bytes);
+            uint8_t phase = VEReducePhase::ACCUMULATE;
+            if (k == 0) phase |= VEReducePhase::INIT;
+            if (k == n_tiles - 1) phase |= VEReducePhase::FINALIZE;  // fuse finalize
+            run_reduce(hw, op, phase, Ti, Tj);
+        }
+        std::vector<float> acc(3, -1.0f);
+        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        return acc;
+    };
+
+    auto approx = [](double a, double b) {
+        return std::fabs(a - b) <= 1e-3 * (1.0 + std::fabs(b));
+    };
+
+    {
+        auto acc = stream_reduce(VEReduceOp::MAX);
+        check(static_cast<double>(acc[0]) == omax, "VE_REDUCE MAX over 3 tiles");
+    }
+    {
+        auto acc = stream_reduce(VEReduceOp::MIN);
+        check(static_cast<double>(acc[0]) == omin, "VE_REDUCE MIN over 3 tiles");
+    }
+    {
+        auto acc = stream_reduce(VEReduceOp::SUM);
+        check(approx(acc[0], total_sum), "VE_REDUCE SUM over 3 tiles");
+    }
+    {
+        // Finalized MEAN layout: [mean, count, sumsq]
+        auto acc = stream_reduce(VEReduceOp::MEAN);
+        check(approx(acc[0], omean) && acc[1] == static_cast<float>(total_count),
+              "VE_REDUCE MEAN over 3 tiles (mean + count exposed)");
+    }
+    {
+        // Finalized VAR layout: [var, mean, count]
+        auto acc = stream_reduce(VEReduceOp::VAR);
+        check(approx(acc[0], ovar) && approx(acc[1], omean),
+              "VE_REDUCE VAR over 3 tiles (var + mean exposed)");
+    }
+
+    // Single-shot: one tile, INIT|ACCUMULATE|FINALIZE fused
+    {
+        TestHardware hw(16, 4, 256, 8, 128, 3, 64);
+        hw.l1_buffers[0].write(0, tiles[0].data(), bytes);
+        run_reduce(hw, VEReduceOp::SUM,
+                   VEReducePhase::INIT | VEReducePhase::ACCUMULATE |
+                   VEReducePhase::FINALIZE, Ti, Tj);
+        std::vector<float> acc(3);
+        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        double t0 = 0.0; for (Size i = 0; i < elems; ++i) t0 += tiles[0][i];
+        check(approx(acc[0], t0), "VE_REDUCE single-shot SUM (all phases fused)");
+    }
+
+    // Edge: empty reduction (INIT then FINALIZE, no ACCUMULATE) -> NaN
+    {
+        TestHardware hw(16, 4, 256, 8, 128, 3, 64);
+        run_reduce(hw, VEReduceOp::MEAN, VEReducePhase::INIT, Ti, Tj);
+        run_reduce(hw, VEReduceOp::MEAN, VEReducePhase::FINALIZE, Ti, Tj);
+        std::vector<float> acc(3);
+        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        check(std::isnan(acc[0]), "VE_REDUCE MEAN of empty stream -> NaN");
+    }
+    {
+        TestHardware hw(16, 4, 256, 8, 128, 3, 64);
+        run_reduce(hw, VEReduceOp::VAR, VEReducePhase::INIT, Ti, Tj);
+        run_reduce(hw, VEReduceOp::VAR, VEReducePhase::FINALIZE, Ti, Tj);
+        std::vector<float> acc(3);
+        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        check(std::isnan(acc[0]), "VE_REDUCE VAR of empty stream -> NaN");
+    }
+
+    // Edge: single sample -> variance exactly 0
+    {
+        TestHardware hw(16, 4, 256, 8, 128, 3, 64);
+        float one = 42.5f;
+        hw.l1_buffers[0].write(0, &one, sizeof(float));
+        run_reduce(hw, VEReduceOp::VAR,
+                   VEReducePhase::INIT | VEReducePhase::ACCUMULATE |
+                   VEReducePhase::FINALIZE, 1, 1);
+        std::vector<float> acc(3);
+        hw.l1_buffers[1].read(0, acc.data(), 3 * sizeof(float));
+        check(acc[0] == 0.0f && acc[1] == 42.5f,
+              "VE_REDUCE VAR of single sample -> var 0, mean = sample");
+    }
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
@@ -736,6 +875,7 @@ int main() {
     test_loop_machinery();
     test_ve_elementwise();
     test_str_broadcast_resident_operand();
+    test_ve_reduce();
 
     std::cout << "\n" << std::string(60, '*') << "\n";
     std::cout << "Results: " << passed << " passed, " << failed << " failed\n";

--- a/tests/isa/test_serialization.cpp
+++ b/tests/isa/test_serialization.cpp
@@ -6,6 +6,7 @@
 
 #include <sw/kpu/isa/program_serializer.hpp>
 #include <sw/kpu/isa/data_movement_isa.hpp>
+#include <sw/kpu/isa/assembler.hpp>
 #include <sw/kpu/kernel_serializer.hpp>
 #include <sw/kpu/kernel.hpp>
 
@@ -706,4 +707,88 @@ TEST_CASE("ProgramSerializer round-trips VEOperands", "[serialization][ve]") {
     REQUIRE(scalar.scalar == 0.5f);
     REQUIRE(scalar.l1_src_a == 6);
     REQUIRE(scalar.l1_dst == 7);
+}
+
+// ============================================================================
+// VEReduceOperands round-trip (issue #105, format v3)
+// ============================================================================
+
+TEST_CASE("ProgramSerializer round-trips VEReduceOperands", "[serialization][ve][reduce]") {
+    ProgramSerializer serializer;
+
+    DMProgram program;
+    program.name = "ve_reduce_roundtrip";
+    program.Ti = 16; program.Tj = 16; program.Tk = 1;
+    // Streaming SUM: first tile INIT|ACCUMULATE, then a FINALIZE
+    program.instructions.push_back(DMInstruction::ve_reduce(
+        VEReduceOp::SUM, 0, 3,
+        VEReducePhase::INIT | VEReducePhase::ACCUMULATE));
+    program.instructions.push_back(DMInstruction::ve_reduce(
+        VEReduceOp::SUM, 0, 3, VEReducePhase::ACCUMULATE));
+    program.instructions.push_back(DMInstruction::ve_reduce(
+        VEReduceOp::SUM, 0, 3, VEReducePhase::FINALIZE));
+    // Single-shot VAR: all three phases fused
+    program.instructions.push_back(DMInstruction::ve_reduce(
+        VEReduceOp::VAR, 2, 5,
+        VEReducePhase::INIT | VEReducePhase::ACCUMULATE | VEReducePhase::FINALIZE));
+    program.instructions.push_back(DMInstruction::halt());
+
+    auto buffer = serializer.serialize(program);
+    DMProgram loaded = serializer.deserialize(buffer);
+
+    REQUIRE(loaded.instructions.size() == 5);
+
+    const auto& first = std::get<VEReduceOperands>(loaded.instructions[0].operands);
+    REQUIRE(first.op == VEReduceOp::SUM);
+    REQUIRE(first.phase == (VEReducePhase::INIT | VEReducePhase::ACCUMULATE));
+    REQUIRE(first.l1_src == 0);
+    REQUIRE(first.l1_acc == 3);
+
+    const auto& fin = std::get<VEReduceOperands>(loaded.instructions[2].operands);
+    REQUIRE(fin.op == VEReduceOp::SUM);
+    REQUIRE(fin.phase == VEReducePhase::FINALIZE);
+
+    const auto& var = std::get<VEReduceOperands>(loaded.instructions[3].operands);
+    REQUIRE(var.op == VEReduceOp::VAR);
+    REQUIRE(var.phase ==
+            (VEReducePhase::INIT | VEReducePhase::ACCUMULATE | VEReducePhase::FINALIZE));
+    REQUIRE(var.l1_src == 2);
+    REQUIRE(var.l1_acc == 5);
+}
+
+TEST_CASE("Assembler parses VE_REDUCE with phase flags", "[serialization][ve][reduce][asm]") {
+    Assembler assembler;
+    const std::string source =
+        "VE_REDUCE SUM, 0, 1, INIT\n"       // streaming first tile
+        "VE_REDUCE SUM, 0, 1\n"             // ACCUMULATE implied
+        "VE_REDUCE MEAN, 0, 1, FINALIZE\n"  // finalize only
+        "VE_REDUCE VAR, 2, 3, INIT, FINALIZE\n"
+        "HALT\n";
+
+    DMProgram program = assembler.assemble(source, "reduce_asm.kpuasm");
+
+    // Locate the four VE_REDUCE instructions (directives produce none)
+    std::vector<VEReduceOperands> reds;
+    for (const auto& instr : program.instructions) {
+        if (instr.opcode == DMOpcode::VE_REDUCE) {
+            reds.push_back(std::get<VEReduceOperands>(instr.operands));
+        }
+    }
+    REQUIRE(reds.size() == 4);
+
+    REQUIRE(reds[0].op == VEReduceOp::SUM);
+    REQUIRE(reds[0].phase == (VEReducePhase::INIT | VEReducePhase::ACCUMULATE));
+    REQUIRE(reds[0].l1_src == 0);
+    REQUIRE(reds[0].l1_acc == 1);
+
+    REQUIRE(reds[1].phase == VEReducePhase::ACCUMULATE);  // no flags -> accumulate only
+
+    REQUIRE(reds[2].op == VEReduceOp::MEAN);
+    REQUIRE(reds[2].phase == (VEReducePhase::ACCUMULATE | VEReducePhase::FINALIZE));
+
+    REQUIRE(reds[3].op == VEReduceOp::VAR);
+    REQUIRE(reds[3].phase ==
+            (VEReducePhase::INIT | VEReducePhase::ACCUMULATE | VEReducePhase::FINALIZE));
+    REQUIRE(reds[3].l1_src == 2);
+    REQUIRE(reds[3].l1_acc == 3);
 }

--- a/tests/timing/test_concurrent_timing_executor.cpp
+++ b/tests/timing/test_concurrent_timing_executor.cpp
@@ -369,7 +369,7 @@ TEST_CASE("Chained accumulator reduction runs on existing resident-dep machinery
 
     const std::vector<float> values = {2.0f, 4.0f, 6.0f, 8.0f, 10.0f};
     std::vector<TileDescriptor> x;
-    for (size_t k = 0; k < values.size(); ++k) {
+    for (Size k = 0; k < values.size(); ++k) {
         auto tile = make_tile(MatrixID::A, k, 0, 0, 4);
         tile.height = 1; tile.width = 1;
         runner.set_tile_payload(tile.tile_id, TilePayload{1, 1, {values[k]}});

--- a/tests/timing/test_concurrent_timing_executor.cpp
+++ b/tests/timing/test_concurrent_timing_executor.cpp
@@ -356,6 +356,68 @@ TEST_CASE("Functional Domain Flow executes an arbitrary branched DAG",
     REQUIRE(count_events(runner.executor().events(), EventType::DMA_LOAD_COMPLETE) == 2);
 }
 
+TEST_CASE("Chained accumulator reduction runs on existing resident-dep machinery",
+          "[timing][executor][functional][reduction]") {
+    // E3-T2 validation (issue #105): a streaming reduction is a chain of
+    // functional computes whose target IS the accumulator tile, each
+    // (except the first) taking the accumulator as a resident dependency.
+    // The #66 per-instance resident accounting enforces the chain order:
+    // COMPUTE_k requires k completed computes of the accumulator, so it
+    // cannot fire before COMPUTE_{k-1}. The first compute must NOT list the
+    // accumulator (required=max(1,0)=1 would deadlock) - init on first touch.
+    FunctionalDomainFlowExecutor runner(default_config());
+
+    const std::vector<float> values = {2.0f, 4.0f, 6.0f, 8.0f, 10.0f};
+    std::vector<TileDescriptor> x;
+    for (size_t k = 0; k < values.size(); ++k) {
+        auto tile = make_tile(MatrixID::A, k, 0, 0, 4);
+        tile.height = 1; tile.width = 1;
+        runner.set_tile_payload(tile.tile_id, TilePayload{1, 1, {values[k]}});
+        x.push_back(tile);
+    }
+    auto acc = make_tile(MatrixID::C, 0, 0, 0, 4);
+    acc.height = 1; acc.width = 1;
+
+    using Program = FunctionalDomainFlowProgram;
+    Program program;
+    size_t prev_compute = 0;
+    for (size_t k = 0; k < x.size(); ++k) {
+        const size_t load = program.add({Program::Operation::LOAD, x[k], {}, {}});
+        const size_t move = program.add({Program::Operation::MOVE, x[k], {}, {load}});
+        const size_t feed = program.add({Program::Operation::FEED, x[k], {}, {move}});
+
+        Program::Node compute;
+        compute.operation = Program::Operation::COMPUTE;
+        compute.tile = acc;
+        if (k == 0) {
+            // Init on first touch: input is X_0 only, no resident accumulator
+            compute.predecessors = {feed};
+            compute.compute.input_tiles = {x[k].tile_id};
+            compute.compute.operation = [](const std::vector<TilePayload>& in) {
+                return in.at(0);  // seed the accumulator
+            };
+        } else {
+            // Combine: accumulator (resident) + this tile
+            compute.predecessors = {feed, prev_compute};
+            compute.compute.input_tiles = {x[k].tile_id, acc.tile_id};
+            compute.compute.resident_tiles = {acc.tile_id};
+            compute.compute.operation = [](const std::vector<TilePayload>& in) {
+                TilePayload out = in.at(0);
+                out.values[0] += in.at(1).values[0];  // running sum
+                return out;
+            };
+        }
+        prev_compute = program.add(std::move(compute));
+    }
+    const size_t drain = program.add({Program::Operation::DRAIN, acc, {}, {prev_compute}});
+    const size_t wb = program.add({Program::Operation::WRITEBACK, acc, {}, {drain}});
+    program.add({Program::Operation::STORE, acc, {}, {wb}});
+
+    REQUIRE(runner.run(program));
+    REQUIRE(runner.executor().tile_payload_at(MemoryLevel::DRAM, acc.tile_id).values[0] ==
+            Catch::Approx(30.0f));  // 2+4+6+8+10
+}
+
 TEST_CASE("Repeated tile feeds cannot satisfy a later functional compute early",
           "[timing][executor][functional][dependency]") {
     auto config = default_config();


### PR DESCRIPTION
Fixes #105 — E3-T2 of the online-reduction epic (#72). Closes the **ISA half of #18** for reductions. Implements the ISA/executor closure per the approved design (`docs/plans/e3_online_reduction_pattern.md`).

## What

- **`VEReduceOperands`** gives the previously annotation-only `VE_REDUCE` real semantics: `MAX/MIN/SUM` scalar accumulators and `MEAN/VAR` moment triplets `[count, sum, sumsq]`, gated by `INIT`/`ACCUMULATE`/`FINALIZE` phase flags over the fixed **3-lane fp32 accumulator ABI** from the T1 review. FINALIZE rewrites the lanes so one VAR reduction hands layernorm both mean and variance; raw lanes stay op-private (Welford-upgradable without touching consumers).
- **Behavioral running-combine** for all five ops with the **defined edge semantics**: empty → NaN, single sample → variance 0 exactly, population divisor, and FINALIZE clamps `var = max(0, sumsq/count - mean²)` so cancellation can never produce a negative variance. MEAN/VAR local sums accumulate in double before folding into fp32 state.
- **Assembler**: `VE_REDUCE op, src, acc [, INIT] [, FINALIZE]` (ACCUMULATE implied). **Serializer**: round-trips at **format v3** (variant 17 → 18, `static_assert`s pin `VEOperands`@16 and `VEReduceOperands`@17; existing v2 `.kpubin` still readable).
- **CSP needs no executor-core change**: a reduction is a chain of functional computes targeting the accumulator tile with resident-dependency ordering. The design's load-bearing observation — the *first* compute must omit the accumulator (`required = max(1,0) = 1` with zero completions would deadlock; init on first touch) — is now covered by an end-to-end chained-accumulator test.

## Verification

- New tests: reduce serialization + assembler round-trip (`[reduce]`, 23 assertions), behavioral streaming semantics across all ops + phase flags + all three edge cases (43 assertions), CSP chained accumulator on the real executor.
- Full suite: **103/103 pass**. Coverage: `online_reduction` design + isa_closure → done (**20/105**). Gates hold.
- Session log: `docs/sessions/2026-07-13_v0.9_e3_reduce_isa.md`

Next: E3-T3 (#106) OnlineReductionScheduleGenerator → T4 (#107) functional+oracles → T5 (#108) regression, which closes epic #72 and #18 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added VE_REDUCE operations: MAX, MIN, SUM, MEAN, and VAR with INIT/ACCUMULATE/FINALIZE phases.
  - Supports streaming reductions over multiple tiles with a fixed accumulator ABI.
  - Extended assembler + binary serialization (format v3) for `VE_REDUCE op, src, acc` with optional phase flags.
- **Bug Fixes**
  - Corrected reduction accumulator chaining behavior across chained computations.
  - Added specified edge semantics (empty inputs → NaN; single-sample VAR → 0; variance clamping).
- **Documentation**
  - Updated release documentation covering reduction/ISA closure semantics and encoding.
- **Tests**
  - Added behavioral executor, serialization, and timing coverage for VE_REDUCE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->