### PR TITLE
feat(schedule): OnlineReductionScheduleGenerator (reduce-T3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OnlineReductionScheduleGenerator (#106, epic E3).** Streaming-reduction
+  schedules for pattern class P3, all executable (the #101 discipline):
+  `FULL_REDUCE` and `ROW_STATS` model the accumulation matmul-shaped - a
+  single COMPUTE depends on every streamed input feed with K-scaled
+  latency, so no resident-accumulator chain is needed at the schedule
+  tier and the stats pass has a constant working set of 2 regardless of
+  stream length. `ROW_NORMALIZE` is the two-phase form (stats then apply)
+  whose realization is chosen a priori from the envelope -
+  `ROW_RESIDENT` (row delivered once with `consumer_count=2`, the E2
+  1:1:k discipline) when `reduction_tiles + 2 <= per-matrix burst share`,
+  else `RESTREAMED` (row re-read from DRAM, constant working set 3); the
+  per-row stat round-trips through DRAM and is broadcast to the apply
+  computes via a distinct reload tile. Coverage: online_reduction
+  generator -> done (21/105).
+
 - **VE_REDUCE numerical semantics + ISA closure (#105, epic E3).**
   `VEReduceOperands` gives the previously annotation-only VE_REDUCE real
   encoding: MAX/MIN/SUM scalar accumulators and MEAN/VAR moment triplets

--- a/docs/sessions/2026-07-13_v0.9_e3_reduction_generator.md
+++ b/docs/sessions/2026-07-13_v0.9_e3_reduction_generator.md
@@ -1,0 +1,91 @@
+# v0.9 E3-T3: OnlineReductionScheduleGenerator Decision Log
+
+**Date:** 2026-07-13
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 104/104 suites passing (new: test_reduction_generator, 4 cases /
+43 assertions - structure + execution across all forms and realizations)
+**Issues:** #106 (done)
+
+## 1. Summary
+
+Implemented E3-T3: OnlineReductionScheduleGenerator for pattern class P3,
+with FULL_REDUCE, ROW_STATS, and ROW_NORMALIZE forms. The key modelling
+decision - reduction as a single K-scaled compute rather than a resident
+accumulator chain - keeps the schedule tier unchanged (no new
+ScheduleOperation field) and the stats working set constant at 2.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| FULL_REDUCE (one stat over the whole stream) | Done |
+| ROW_STATS (per-row stats, batched) | Done |
+| ROW_NORMALIZE (two-phase) + envelope-derived realization | Done |
+| Envelope refusal + metadata/realization stamping | Done |
+| Structure tests (op counts, dep sets, realization selection, refusal) | Done |
+| Execution tests (all forms + both realizations to completion) | Done |
+| Coverage: online_reduction generator -> done (21/105) | Done |
+
+Files:
+- `include/sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp` (new)
+- `tests/timing/test_reduction_generator.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: single K-scaled compute, not a resident-accumulator chain.**
+- **Choice:** FULL_REDUCE/ROW_STATS emit one COMPUTE whose dependency set
+  is every streamed input feed; the executor's existing K-scaled latency
+  models the sequential combine (the design's matmul-shaped latency).
+- **Rationale:** the chained-accumulator model (validated in T2's CSP
+  test) is equivalent but would need a resident-dependency field on
+  ScheduleOperation. The single-compute form reuses the matmul compute
+  path unchanged and keeps the stats working set at 2 - tiles stream
+  through and recycle credits while the compute waits on cumulative feed
+  counts.
+
+**Decision 2: stat round-trips through DRAM with a distinct reload tile.**
+- **Choice:** in ROW_NORMALIZE the per-row stat is computed, drained,
+  written back, and stored; the apply phase reloads it under a DISTINCT
+  tile id (tk=1, same DRAM slot) delivered as a broadcast
+  (`emit_broadcast_tile`, consumer_count = reduction_tiles).
+- **Alternatives considered:** (a) feed the stat directly from L2 after
+  drain - needs ref-count seeding on drained tiles, which the executor
+  does not support; (b) a resident-dep schedule field carrying the stat
+  as a compute-resident input - a larger executor/schedule change. The
+  DRAM round-trip reuses the E2-validated MOVE-based broadcast path
+  unchanged and avoids reusing the stat's compute-target tile id.
+
+**Decision 3: ROW_NORMALIZE realization chosen a priori (#67).**
+- ROW_RESIDENT when `reduction_tiles + 2 <= per_matrix_burst_share`,
+  else RESTREAMED; stamped in metadata.strategy. Both execute; the
+  difference is whether the row is delivered once (consumer_count=2) or
+  re-read.
+
+## 4. Issues Encountered
+
+None blocking. The stat-delivery mechanics (Decision 2) were the main
+design consideration; the DRAM round-trip resolved it without executor
+changes.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                          # 104/104
+./build/tests/timing/test_reduction_generator   # 43 assertions
+./build/tests/coverage/test_pattern_coverage    # 21/105, gates hold
+```
+
+## 7. Next Steps
+
+- E3-T4 (#107): value-producing reduction via FunctionalComputeBinder,
+  verified against host oracles (Kahan reference for long SUM; relative
+  tolerance for MEAN/VAR) - flips online_reduction.functional (M4 gate).
+- E3-T5 (#108): op x stream-length x envelope regression -> closes epic
+  #72 and #18 entirely.

--- a/include/sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp
@@ -1,0 +1,388 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp
+// Online/streaming reduction schedule generator (issue #106, epic E3)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/schedule/elementwise_schedule_generator.hpp>  // emit_broadcast_tile
+#include <sw/kpu/timing/schedule/schedule_generator_interface.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief Streaming reduction schedule generator (pattern class P3)
+ *
+ * A reduction consumes N input tiles and produces ONE running statistic
+ * (max/min/sum/mean/var). Per the E3 design
+ * (docs/plans/e3_online_reduction_pattern.md) the accumulation is modelled
+ * matmul-shaped: a single COMPUTE depends on every streamed input feed and
+ * its latency scales with the stream length (the executor's K-scaled
+ * latency), so no resident-accumulator chain is needed at the schedule
+ * tier and the stats pass has a constant working set of 2 (one streaming
+ * tile in flight + the output stat) regardless of stream length.
+ *
+ * Forms:
+ *  - FULL_REDUCE   : one stat over the whole stream (global pooling, losses)
+ *  - ROW_STATS     : per-row stats over the reduction dim (softmax max/sum,
+ *                    norm mean/var), rows batched
+ *  - ROW_NORMALIZE : ROW_STATS + an apply phase (softmax/layernorm
+ *                    substrate). The data is seen twice; the realization is
+ *                    chosen a priori from the envelope:
+ *                      ROW_RESIDENT (row delivered once, consumer_count=2)
+ *                        when reduction_tiles + 2 <= per-matrix burst share,
+ *                      RESTREAMED (re-read the row from DRAM, constant
+ *                        working set 3) otherwise.
+ *
+ * Every emitted schedule is executable: COMPUTE operations carry their full
+ * feed-dependency sets (the #101 discipline).
+ */
+class OnlineReductionScheduleGenerator : public IScheduleGenerator {
+public:
+    enum class Form { FULL_REDUCE, ROW_STATS, ROW_NORMALIZE };
+    enum class Realization { ROW_RESIDENT, RESTREAMED };
+    enum class ReduceOp { MAX, MIN, SUM, MEAN, VAR };
+
+    struct Config {
+        Size num_rows = 1;            ///< Row batch (FULL_REDUCE uses 1)
+        Size reduction_elems = 4096;  ///< Elements per row along the reduction dim
+        Size tile_elems = 256;        ///< Elements per tile
+        Form form = Form::FULL_REDUCE;
+        ReduceOp op = ReduceOp::SUM;
+
+        Size element_size = 4;
+
+        // Resource envelope (issue #90 discipline)
+        Size l3_buffer_count = 32;
+        Size l2_bank_count = 64;
+
+        Address in_base = 0;
+        Address stat_base = 0;
+        Address out_base = 0;
+
+        [[nodiscard]] Size reduction_tiles() const {
+            return (reduction_elems + tile_elems - 1) / tile_elems;
+        }
+
+        [[nodiscard]] Size max_burst_tiles() const {
+            return per_matrix_burst_share(l3_buffer_count, l2_bank_count);
+        }
+
+        /**
+         * @brief Realization chosen a priori for ROW_NORMALIZE (the #67
+         *        constructive-safety discipline); other forms are single-pass
+         */
+        [[nodiscard]] Realization realization() const {
+            return reduction_tiles() + 2 <= max_burst_tiles()
+                ? Realization::ROW_RESIDENT
+                : Realization::RESTREAMED;
+        }
+
+        /**
+         * @brief Peak tile residency
+         *
+         * Stats passes stream one tile at a time against a resident stat
+         * (working set 2). ROW_NORMALIZE in ROW_RESIDENT holds the whole row
+         * resident across its two phases (reduction_tiles + stat + output);
+         * RESTREAMED re-reads the row so only 3 tiles are ever in flight.
+         */
+        [[nodiscard]] Size required_working_set() const {
+            switch (form) {
+                case Form::FULL_REDUCE:
+                case Form::ROW_STATS:
+                    return 2;
+                case Form::ROW_NORMALIZE:
+                    return realization() == Realization::ROW_RESIDENT
+                        ? reduction_tiles() + 2
+                        : 3;
+            }
+            return 2;
+        }
+    };
+
+    explicit OnlineReductionScheduleGenerator(const Config& config)
+        : config_(config) {}
+
+    ScheduleResult generate() override {
+        ScheduleResult result;
+
+        if (config_.reduction_elems == 0 || config_.tile_elems == 0 ||
+            config_.num_rows == 0) {
+            result.valid = false;
+            result.error_message = "Reduction dimensions must be non-zero";
+            return result;
+        }
+        if (config_.required_working_set() > config_.max_burst_tiles()) {
+            result.valid = false;
+            result.error_message =
+                "reduction schedule requires a working set of " +
+                std::to_string(config_.required_working_set()) +
+                " tiles but the resource envelope share is " +
+                std::to_string(config_.max_burst_tiles()) +
+                "; enlarge l3_buffer_count/l2_bank_count";
+            return result;
+        }
+
+        const Size rows = config_.form == Form::FULL_REDUCE ? 1 : config_.num_rows;
+        for (Size r = 0; r < rows; ++r) {
+            switch (config_.form) {
+                case Form::FULL_REDUCE:
+                case Form::ROW_STATS:
+                    emit_stats_row(result, r);
+                    break;
+                case Form::ROW_NORMALIZE:
+                    if (config_.realization() == Realization::ROW_RESIDENT) {
+                        emit_normalize_row_resident(result, r);
+                    } else {
+                        emit_normalize_restreamed(result, r);
+                    }
+                    break;
+            }
+        }
+
+        stamp_metadata(result, rows);
+        result.valid = true;
+        return result;
+    }
+
+    [[nodiscard]] std::string name() const override {
+        return "OnlineReductionScheduleGenerator";
+    }
+
+    [[nodiscard]] std::string description() const override {
+        std::ostringstream ss;
+        ss << "Reduction " << op_name(config_.op) << " ["
+           << config_.num_rows << "x" << config_.reduction_elems << "] ("
+           << form_name(config_.form) << ")";
+        return ss.str();
+    }
+
+    [[nodiscard]] const Config& config() const { return config_; }
+
+private:
+    Config config_;
+
+    // ------------------------------------------------------------------
+    // Stats-only row (FULL_REDUCE / ROW_STATS): stream the row's tiles, one
+    // COMPUTE over all their feeds, drain/store the stat.
+    // ------------------------------------------------------------------
+    void emit_stats_row(ScheduleResult& result, Size row) {
+        const Size rt = config_.reduction_tiles();
+        std::vector<TileID> deps;
+        deps.reserve(rt);
+        for (Size t = 0; t < rt; ++t) {
+            auto in = make_input_tile(row, t);
+            result.operations.push_back(ScheduleOperation::load(in));
+            result.operations.push_back(ScheduleOperation::move(in));
+            result.operations.push_back(ScheduleOperation::feed(in));
+            deps.push_back(in.tile_id);
+        }
+        auto stat = make_stat_tile(row);
+        result.operations.push_back(ScheduleOperation::compute(stat, std::move(deps)));
+        result.operations.push_back(ScheduleOperation::drain(stat));
+        result.operations.push_back(ScheduleOperation::writeback(stat));
+        result.operations.push_back(ScheduleOperation::store(stat));
+    }
+
+    // ------------------------------------------------------------------
+    // ROW_NORMALIZE, ROW_RESIDENT: the row fits the L2 share, so each tile
+    // is delivered ONCE with consumer_count=2 (the E2 1:1:k discipline,
+    // k=2): fed first to accumulate the stat, fed again to normalize. The
+    // stat produced by the stats compute is drained to L2 and broadcast to
+    // every apply compute.
+    // ------------------------------------------------------------------
+    void emit_normalize_row_resident(ScheduleResult& result, Size row) {
+        const Size rt = config_.reduction_tiles();
+
+        // Deliver each row tile once, to be consumed twice
+        std::vector<TileDescriptor> row_tiles;
+        row_tiles.reserve(rt);
+        for (Size t = 0; t < rt; ++t) {
+            auto in = make_input_tile(row, t);
+            in.consumer_count = 2;
+            result.operations.push_back(ScheduleOperation::load(in));
+            result.operations.push_back(ScheduleOperation::move(in));
+            row_tiles.push_back(in);
+        }
+
+        // Phase 1: stats over the first consumption of every tile, then the
+        // stat round-trips to DRAM (compute -> drain -> writeback -> store)
+        std::vector<TileID> stat_deps;
+        stat_deps.reserve(rt);
+        for (const auto& in : row_tiles) {
+            result.operations.push_back(ScheduleOperation::feed(in));
+            stat_deps.push_back(in.tile_id);
+        }
+        emit_stat_compute_and_store(result, row, std::move(stat_deps));
+
+        // Phase 2: reload the stat as a broadcast operand (a distinct tile
+        // id, delivered once, consumed by every apply), and apply against
+        // the row tiles' second consumption
+        auto stat_op = make_stat_operand_tile(row);
+        emit_broadcast_tile(result, stat_op, rt);
+        for (Size t = 0; t < rt; ++t) {
+            result.operations.push_back(ScheduleOperation::feed(row_tiles[t]));
+            result.operations.push_back(ScheduleOperation::feed(stat_op));
+            emit_apply_output(result, row, t, row_tiles[t].tile_id, stat_op.tile_id);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // ROW_NORMALIZE, RESTREAMED: the row does not fit, so it is read twice
+    // from DRAM. Phase 1 streams for the stat (working set 2); phase 2
+    // re-streams and applies with the stat as a resident (broadcast)
+    // operand. Constant working set 3.
+    // ------------------------------------------------------------------
+    void emit_normalize_restreamed(ScheduleResult& result, Size row) {
+        const Size rt = config_.reduction_tiles();
+
+        // Phase 1: stats (fresh delivery, consumed once), stat -> DRAM
+        std::vector<TileID> stat_deps;
+        stat_deps.reserve(rt);
+        for (Size t = 0; t < rt; ++t) {
+            auto in = make_input_tile(row, t);
+            result.operations.push_back(ScheduleOperation::load(in));
+            result.operations.push_back(ScheduleOperation::move(in));
+            result.operations.push_back(ScheduleOperation::feed(in));
+            stat_deps.push_back(in.tile_id);
+        }
+        emit_stat_compute_and_store(result, row, std::move(stat_deps));
+
+        // Phase 2: reload the stat as a broadcast operand, re-stream the row
+        // (second DRAM read), and apply
+        auto stat_op = make_stat_operand_tile(row);
+        emit_broadcast_tile(result, stat_op, rt);
+        for (Size t = 0; t < rt; ++t) {
+            auto in = make_input_tile(row, t);
+            result.operations.push_back(ScheduleOperation::load(in));
+            result.operations.push_back(ScheduleOperation::move(in));
+            result.operations.push_back(ScheduleOperation::feed(in));
+            result.operations.push_back(ScheduleOperation::feed(stat_op));
+            emit_apply_output(result, row, t, in.tile_id, stat_op.tile_id);
+        }
+    }
+
+    // Stat compute over the given feed deps, then round-trip to DRAM so a
+    // distinct reload tile can broadcast it to the apply phase.
+    void emit_stat_compute_and_store(ScheduleResult& result, Size row,
+                                     std::vector<TileID> deps) {
+        auto stat = make_stat_tile(row);
+        result.operations.push_back(ScheduleOperation::compute(stat, std::move(deps)));
+        result.operations.push_back(ScheduleOperation::drain(stat));
+        result.operations.push_back(ScheduleOperation::writeback(stat));
+        result.operations.push_back(ScheduleOperation::store(stat));
+    }
+
+    void emit_apply_output(ScheduleResult& result, Size row, Size t,
+                           const TileID& in_id, const TileID& stat_id) {
+        auto out = make_output_tile(row, t);
+        result.operations.push_back(ScheduleOperation::compute(out, {in_id, stat_id}));
+        result.operations.push_back(ScheduleOperation::drain(out));
+        result.operations.push_back(ScheduleOperation::writeback(out));
+        result.operations.push_back(ScheduleOperation::store(out));
+    }
+
+    // ------------------------------------------------------------------
+    // Tile descriptors
+    // ------------------------------------------------------------------
+    TileDescriptor make_input_tile(Size row, Size t) const {
+        // Input rides matrix A; index encodes (row, reduction-tile)
+        return make_tile(isa::MatrixID::A, row, t, config_.in_base);
+    }
+    TileDescriptor make_stat_tile(Size row) const {
+        // Stat rides matrix B (an intermediate); one per row, tk=0
+        return make_tile(isa::MatrixID::B, row, 0, config_.stat_base);
+    }
+    TileDescriptor make_stat_operand_tile(Size row) const {
+        // Distinct tile id (tk=1) reading the SAME DRAM slot as the stored
+        // stat, so the apply phase can broadcast it without reusing the
+        // stat's compute-target tile id
+        auto tile = make_tile(isa::MatrixID::B, row, 0, config_.stat_base);
+        tile.tile_id.tk = 1;
+        return tile;
+    }
+    TileDescriptor make_output_tile(Size row, Size t) const {
+        return make_tile(isa::MatrixID::C, row, t, config_.out_base);
+    }
+
+    TileDescriptor make_tile(isa::MatrixID matrix, Size row, Size t,
+                             Address base) const {
+        TileDescriptor tile;
+        tile.tile_id.matrix = matrix;
+        tile.tile_id.ti = row;
+        tile.tile_id.tj = t;
+        tile.tile_id.tk = 0;
+        tile.height = config_.tile_elems;
+        tile.width = 1;
+        tile.element_size = config_.element_size;
+        tile.size_bytes = config_.tile_elems * config_.element_size;
+        // Row-major over (row, reduction-tile); stat tiles are one per row
+        const Size linear = matrix == isa::MatrixID::B
+            ? row
+            : row * config_.reduction_tiles() + t;
+        tile.dram_address = base + linear * tile.size_bytes;
+        tile.matrix_base_address = base;
+        return tile;
+    }
+
+    void stamp_metadata(ScheduleResult& result, Size rows) const {
+        const Size rt = config_.reduction_tiles();
+        result.metadata.name = generate_name();
+        result.metadata.generator = name();
+        result.metadata.M = config_.num_rows;
+        result.metadata.N = config_.reduction_elems;
+        result.metadata.K = 1;
+        result.metadata.Ti = config_.tile_elems;
+        result.metadata.Tj = 1;
+        result.metadata.Tk = 1;
+        result.metadata.a_tiles = rows * rt;
+        result.metadata.b_tiles = rows;  // one stat per row
+        result.metadata.c_tiles =
+            config_.form == Form::ROW_NORMALIZE ? rows * rt : 0;
+        result.metadata.strategy = strategy_name();
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
+    }
+
+    static const char* form_name(Form form) {
+        switch (form) {
+            case Form::FULL_REDUCE:   return "full_reduce";
+            case Form::ROW_STATS:     return "row_stats";
+            case Form::ROW_NORMALIZE: return "row_normalize";
+        }
+        return "unknown";
+    }
+    static const char* op_name(ReduceOp op) {
+        switch (op) {
+            case ReduceOp::MAX:  return "MAX";
+            case ReduceOp::MIN:  return "MIN";
+            case ReduceOp::SUM:  return "SUM";
+            case ReduceOp::MEAN: return "MEAN";
+            case ReduceOp::VAR:  return "VAR";
+        }
+        return "?";
+    }
+    std::string strategy_name() const {
+        std::string s = form_name(config_.form);
+        if (config_.form == Form::ROW_NORMALIZE) {
+            s += config_.realization() == Realization::ROW_RESIDENT
+                ? "_resident" : "_restreamed";
+        }
+        return s;
+    }
+    std::string generate_name() const {
+        std::ostringstream ss;
+        ss << "reduction_" << op_name(config_.op) << "_" << config_.num_rows
+           << "x" << config_.reduction_elems << "_" << strategy_name();
+        return ss.str();
+    }
+};
+
+} // namespace sw::kpu::timing::schedule

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -298,11 +298,11 @@
       "stages": {
         "design": "done",
         "isa_closure": "done",
-        "generator": "missing",
+        "generator": "done",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "VEReduceOperands full encoding (MAX/MIN/SUM scalar + MEAN/VAR moment triplet, INIT/ACCUMULATE/FINALIZE phase flags) with assembler/serializer round-trip (format v3) and behavioral running-combine semantics incl. edge cases; CSP chained-accumulator validated on existing resident-dep machinery (#105). Design #104. Generator/functional/regression are E3-T3/T4/T5."
+      "notes": "VEReduceOperands + behavioral running-combine + CSP chained-accumulator (#105); OnlineReductionScheduleGenerator FULL_REDUCE/ROW_STATS (single K-scaled compute over all streamed feeds, working set 2) + ROW_NORMALIZE (two-phase, envelope-derived ROW_RESIDENT vs RESTREAMED realization, stat round-trips DRAM + broadcast reload) with executable COMPUTEs (#106). Design #104. Functional/regression are E3-T4/T5."
     },
     {
       "name": "layout_transform",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -148,3 +148,13 @@ kpu_add_component_test(test_elementwise_regression "timing"
 set_tests_properties(test_elementwise_regression PROPERTIES
     LABELS "timing;regression;elementwise;v0.9"
 )
+
+# Online reduction schedule generator (issue #106, epic E3): FULL_REDUCE /
+# ROW_STATS / ROW_NORMALIZE with envelope-derived realization
+kpu_add_component_test(test_reduction_generator "timing"
+    test_reduction_generator.cpp
+)
+
+set_tests_properties(test_reduction_generator PROPERTIES
+    LABELS "timing;schedule;reduction;v0.9"
+)

--- a/tests/timing/test_reduction_generator.cpp
+++ b/tests/timing/test_reduction_generator.cpp
@@ -1,0 +1,183 @@
+// ============================================================================
+// tests/timing/test_reduction_generator.cpp
+// OnlineReductionScheduleGenerator structure + execution (issue #106, epic E3)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+#include <string>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+using Form = OnlineReductionScheduleGenerator::Form;
+using Realization = OnlineReductionScheduleGenerator::Realization;
+using ReduceOp = OnlineReductionScheduleGenerator::ReduceOp;
+
+OnlineReductionScheduleGenerator::Config base_config() {
+    OnlineReductionScheduleGenerator::Config c;
+    c.num_rows = 1;
+    c.reduction_elems = 1024;   // 4 reduction tiles at tile_elems=256
+    c.tile_elems = 256;
+    c.op = ReduceOp::SUM;
+    c.in_base = 0x100000;
+    c.stat_base = 0x200000;
+    c.out_base = 0x300000;
+    return c;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.max_cycles = 2'000'000;
+    return config;
+}
+
+} // namespace
+
+TEST_CASE("FULL_REDUCE emits one compute over all streamed feeds",
+          "[timing][schedule][reduction]") {
+    auto config = base_config();
+    config.form = Form::FULL_REDUCE;
+    OnlineReductionScheduleGenerator gen(config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    const Size rt = config.reduction_tiles();  // 4
+    REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == rt);
+    REQUIRE(schedule.count_ops(ScheduleOpType::FEED) == rt);
+    REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) == 1);
+    REQUIRE(schedule.count_ops(ScheduleOpType::DRAIN) == 1);
+    REQUIRE(schedule.count_ops(ScheduleOpType::STORE) == 1);
+
+    // The single compute depends on every streamed tile
+    size_t compute_deps = 0;
+    for (const auto& op : schedule.operations) {
+        if (op.type == ScheduleOpType::COMPUTE) compute_deps = op.dependency_tiles.size();
+    }
+    REQUIRE(compute_deps == rt);
+    REQUIRE(config.required_working_set() == 2);
+}
+
+TEST_CASE("ROW_STATS emits one compute per row",
+          "[timing][schedule][reduction]") {
+    auto config = base_config();
+    config.form = Form::ROW_STATS;
+    config.num_rows = 3;
+    OnlineReductionScheduleGenerator gen(config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    const Size rt = config.reduction_tiles();
+    REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) == config.num_rows);
+    REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == config.num_rows * rt);
+    REQUIRE(schedule.count_ops(ScheduleOpType::STORE) == config.num_rows);  // one stat/row
+}
+
+TEST_CASE("ROW_NORMALIZE selects realization from the envelope a priori",
+          "[timing][schedule][reduction][envelope]") {
+    SECTION("row fits the share -> ROW_RESIDENT, delivered once") {
+        auto config = base_config();
+        config.form = Form::ROW_NORMALIZE;
+        config.num_rows = 1;
+        // share = min(l3,l2)/4; with defaults 32/64 -> 8 >= rt(4)+2
+        REQUIRE(config.realization() == Realization::ROW_RESIDENT);
+        OnlineReductionScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        const Size rt = config.reduction_tiles();
+        // Row tiles delivered once (rt), stat operand once (1) = rt+1 loads;
+        // RESTREAMED would load the row twice.
+        REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == rt + 1);
+        // Two compute phases: 1 stat + rt apply
+        REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) == 1 + rt);
+    }
+
+    SECTION("row exceeds the share -> RESTREAMED, row read twice") {
+        auto config = base_config();
+        config.form = Form::ROW_NORMALIZE;
+        config.reduction_elems = 4096;   // rt=16
+        config.l3_buffer_count = 16;     // share = 4 < rt+2
+        config.l2_bank_count = 16;
+        REQUIRE(config.realization() == Realization::RESTREAMED);
+        OnlineReductionScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        const Size rt = config.reduction_tiles();
+        // Row read twice (2*rt) + stat operand (1)
+        REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == 2 * rt + 1);
+    }
+
+    SECTION("degenerate envelope is refused a priori") {
+        auto config = base_config();
+        config.form = Form::FULL_REDUCE;
+        config.l3_buffer_count = 4;
+        config.l2_bank_count = 4;   // share = 1 < working set 2
+        OnlineReductionScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE_FALSE(schedule.valid);
+        REQUIRE(schedule.error_message.find("working set") != std::string::npos);
+    }
+}
+
+TEST_CASE("Reduction schedules execute to completion",
+          "[timing][executor][regression][reduction]") {
+    auto run = [](const OnlineReductionScheduleGenerator::Config& config) {
+        OnlineReductionScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        ConcurrentTimingExecutor executor(make_executor_config());
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(schedule);
+
+        INFO("strategy=" << schedule.metadata.strategy
+             << " cycles=" << result.total_cycles
+             << " error=" << result.error_message);
+        REQUIRE(result.success);
+        REQUIRE_FALSE(result.livelock_detected);
+
+        auto stats = executor.get_statistics();
+        REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+        REQUIRE(stats.tiles_drained == schedule.count_ops(ScheduleOpType::DRAIN));
+    };
+
+    SECTION("FULL_REDUCE") {
+        auto c = base_config();
+        c.form = Form::FULL_REDUCE;
+        c.reduction_elems = 4096;   // 16 tiles
+        run(c);
+    }
+    SECTION("ROW_STATS batched rows") {
+        auto c = base_config();
+        c.form = Form::ROW_STATS;
+        c.num_rows = 4;
+        run(c);
+    }
+    SECTION("ROW_NORMALIZE row-resident") {
+        auto c = base_config();
+        c.form = Form::ROW_NORMALIZE;
+        c.num_rows = 2;
+        REQUIRE(c.realization() == Realization::ROW_RESIDENT);
+        run(c);
+    }
+    SECTION("ROW_NORMALIZE restreamed") {
+        auto c = base_config();
+        c.form = Form::ROW_NORMALIZE;
+        c.reduction_elems = 4096;   // rt=16
+        c.l3_buffer_count = 16;
+        c.l2_bank_count = 16;
+        REQUIRE(c.realization() == Realization::RESTREAMED);
+        run(c);
+    }
+}


### PR DESCRIPTION
Fixes #106 — E3-T3 of the online-reduction epic (#72). Streaming-reduction schedules for pattern class P3 (`docs/plans/e3_online_reduction_pattern.md`), all executable.

## What

- **`FULL_REDUCE` / `ROW_STATS`** model the accumulation **matmul-shaped**: a single COMPUTE depends on every streamed input feed, and the executor's existing K-scaled latency models the sequential combine. This is the design's key simplification — the chained-resident-accumulator model (validated in T2's CSP test) is *equivalent* but would require a resident-dependency field on `ScheduleOperation`; the single-compute form reuses the matmul compute path unchanged and keeps the stats **working set constant at 2** regardless of stream length (tiles stream through and recycle credits while the compute waits on cumulative feed counts).
- **`ROW_NORMALIZE`** is the two-phase form (stats → apply) whose realization is chosen **a priori** from the envelope (the #67 discipline): `ROW_RESIDENT` (row delivered once with `consumer_count=2`) when `reduction_tiles + 2 <= per_matrix_burst_share`, else `RESTREAMED` (row re-read from DRAM, working set 3). The per-row stat round-trips through DRAM and is broadcast to the apply computes via a **distinct reload tile** — reusing the E2-validated MOVE-based broadcast path, which sidesteps both drained-tile ref-count seeding and compute-target tile-id reuse.
- Envelope refusal + realization stamped in metadata.

## Verification

- Structure tests: op counts, the single-compute dependency set (= all streamed tiles), realization selection (fits → ROW_RESIDENT delivered once; exceeds → RESTREAMED read twice), a-priori refusal.
- Execution tests: all forms + **both** ROW_NORMALIZE realizations run to completion with matching feed/drain accounting.
- Full suite: **104/104 pass**. Coverage: `online_reduction` generator → done (**21/105**). Gates hold.
- Session log: `docs/sessions/2026-07-13_v0.9_e3_reduction_generator.md`

Next: E3-T4 (#107) value-producing reduction + host oracles (flips `online_reduction.functional`, the M4 gate) → T5 (#108) regression, which closes epic #72 and #18 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streaming reduction schedule generation for full reductions, row statistics, and row normalization.
  - Supports row-resident and restreamed execution based on available buffering.
  - Validates configuration and working-set requirements before generating schedules.

- **Bug Fixes**
  - Rejects configurations that exceed the available resource envelope with a clear error.

- **Documentation**
  - Added release notes and technical session documentation covering supported modes, decisions, and verification.

- **Tests**
  - Added timing and execution coverage for generated reduction schedules, including invalid configurations and livelock checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->