### PR TITLE
feat(timing): value-producing reduction + host oracles (reduce-T4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Value-producing streaming reduction + host oracles (#107, epic E3).**
+  `FunctionalReductionExecutor` bridges the #106 generator to the #66
+  payload machinery for the stats forms: input tiles ride the real CSP
+  data path, the per-row stat COMPUTE reduces every streamed feed to a
+  finalized statistic (MAX/MIN/SUM/MEAN/VAR, matching the VE_REDUCE ABI -
+  population variance, clamped, empty -> NaN), and the stat drains back to
+  DRAM. Verified against independent host oracles across all five ops,
+  batched rows, partitioned credits, and non-tile-aligned spans - flips
+  `online_reduction.functional` (an M4 gate cell, 22/105). ROW_NORMALIZE's
+  apply-phase numerics are deferred to E8/E9 (its stat needs
+  compute-resident delivery rather than a DRAM round-trip, which would
+  race in the value plane).
+
+### Fixed
+
+- **Reduction generator now clamps non-tile-aligned trailing tiles
+  (#107).** `OnlineReductionScheduleGenerator::make_tile` sized every A/C
+  tile as a full tile, so a `reduction_elems` not divisible by
+  `tile_elems` produced a trailing tile that read past the row end. The
+  trailing footprint is now clamped (inter-tile stride stays full-tile),
+  matching the elementwise generator; caught by the functional oracle.
+
 - **OnlineReductionScheduleGenerator (#106, epic E3).** Streaming-reduction
   schedules for pattern class P3, all executable (the #101 discipline):
   `FULL_REDUCE` and `ROW_STATS` model the accumulation matmul-shaped - a

--- a/docs/sessions/2026-07-14_v0.9_e3_reduction_functional.md
+++ b/docs/sessions/2026-07-14_v0.9_e3_reduction_functional.md
@@ -1,0 +1,84 @@
+# v0.9 E3-T4: Functional Reduction + Host Oracles Decision Log
+
+**Date:** 2026-07-14
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 105/105 suites passing (new: test_functional_reduction, 5 cases /
+49 assertions; +1 non-aligned generator structure test)
+**Issues:** #107 (done)
+
+## 1. Summary
+
+Implemented E3-T4: value-producing streaming reduction on the CSP executor
+for the stats forms (FULL_REDUCE, ROW_STATS), verified elementwise against
+independent host oracles for all five ops. Fixed a non-aligned trailing-tile
+bug in the #106 generator that the oracle surfaced.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| FunctionalReductionExecutor (seed/bind/gather, FULL_REDUCE + ROW_STATS) | Done |
+| reduce_payloads: MAX/MIN/SUM/MEAN/VAR matching the VE_REDUCE ABI | Done |
+| Host-oracle tests: 5 ops, batched rows, partitioned credits, non-aligned | Done |
+| ROW_NORMALIZE rejected with a clear message (deferred to E8/E9) | Done |
+| Generator fix: clamp non-aligned trailing A/C tiles | Done |
+| Coverage: online_reduction functional -> done (22/105) | Done |
+
+Files:
+- `include/sw/kpu/timing/schedule/functional_reduction_executor.hpp` (new)
+- `include/sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp` (clamp fix)
+- `tests/timing/test_functional_reduction.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/timing/test_reduction_generator.cpp` (non-aligned structure test)
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: T4 scope = stats forms only; ROW_NORMALIZE deferred.**
+- **Choice:** FunctionalReductionExecutor supports FULL_REDUCE and
+  ROW_STATS and rejects ROW_NORMALIZE.
+- **Rationale:** ROW_NORMALIZE's apply phase needs the per-row stat at the
+  apply computes. T3 delivers it via a DRAM round-trip (store then reload),
+  which is timing-correct but RACES in the value plane - nothing in the
+  schedule orders load(stat) after store(stat). The correct fix is to
+  deliver the stat as a compute-resident dependency (no round-trip), which
+  needs schedule-tier resident-dep support and lands naturally with the
+  softmax/layernorm generators (E8/E9). The stats forms - which have no
+  continuity issue and are exactly what the M4 online_reduction.functional
+  gate requires - are delivered here.
+
+**Decision 2: independent host oracle.**
+- Oracles are plain host loops in the test, separate from reduce_payloads,
+  so a kernel error cannot match itself. Exact compare for MAX/MIN,
+  relative tolerance for SUM/MEAN/VAR.
+
+## 4. Issues Encountered
+
+1. Non-aligned FULL_REDUCE SUM returned ~3x the oracle: the #106 generator
+   sized every A/C tile as a full tile, so the seeder read past the row end
+   for a non-tile-aligned reduction_elems (out-of-bounds -> garbage summed).
+   Fixed by clamping the trailing tile footprint in make_tile (full-tile
+   stride preserved), matching the elementwise generator; a structure test
+   now pins it. Found by the functional oracle - the exact value the
+   oracle is for.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session. (The T3 generator's
+non-aligned bug was a genuine defect, fixed here with a regression test,
+not worked around.)
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                             # 105/105
+./build/tests/timing/test_functional_reduction     # 49 assertions
+./build/tests/coverage/test_pattern_coverage       # 22/105, gates hold
+```
+
+## 7. Next Steps
+
+- E3-T5 (#108): op x stream-length x envelope regression matrix + credit
+  invariants + characterization -> flips online_reduction.regression,
+  closes epic #72 and #18 entirely.

--- a/include/sw/kpu/timing/schedule/functional_reduction_executor.hpp
+++ b/include/sw/kpu/timing/schedule/functional_reduction_executor.hpp
@@ -1,0 +1,196 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/functional_reduction_executor.hpp
+// Value-producing streaming reduction on the CSP timing model (issue #107)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief Reduce a set of streamed tile payloads to a finalized statistic
+ *
+ * Matches the VE_REDUCE behavioral ABI (issue #105): population variance,
+ * clamped so cancellation never yields a negative value; empty -> NaN. The
+ * result rides lane 0 of a payload sized to the stat tile footprint.
+ */
+inline TilePayload reduce_payloads(OnlineReductionScheduleGenerator::ReduceOp op,
+                                   const std::vector<TilePayload>& inputs) {
+    using ReduceOp = OnlineReductionScheduleGenerator::ReduceOp;
+    if (inputs.empty()) {
+        throw std::invalid_argument("Reduction compute received no inputs");
+    }
+
+    double acc_max = -std::numeric_limits<double>::infinity();
+    double acc_min =  std::numeric_limits<double>::infinity();
+    double sum = 0.0, sumsq = 0.0;
+    size_t count = 0;
+    for (const auto& tile : inputs) {
+        for (float v : tile.values) {
+            acc_max = v > acc_max ? v : acc_max;
+            acc_min = v < acc_min ? v : acc_min;
+            sum += v;
+            sumsq += static_cast<double>(v) * v;
+            ++count;
+        }
+    }
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    double stat = 0.0;
+    switch (op) {
+        case ReduceOp::MAX: stat = acc_max; break;
+        case ReduceOp::MIN: stat = acc_min; break;
+        case ReduceOp::SUM: stat = sum; break;
+        case ReduceOp::MEAN: stat = count > 0 ? sum / count : nan; break;
+        case ReduceOp::VAR: {
+            if (count == 0) { stat = nan; }
+            else if (count == 1) { stat = 0.0; }
+            else {
+                const double mean = sum / count;
+                stat = std::max(0.0, sumsq / count - mean * mean);
+            }
+            break;
+        }
+    }
+
+    // Size the payload to the stat tile footprint (lane 0 = stat, rest 0)
+    const Size lanes = inputs.front().values.empty()
+        ? 1 : static_cast<Size>(inputs.front().values.size());
+    TilePayload out{lanes, 1, std::vector<float>(lanes, 0.0f)};
+    out.values[0] = static_cast<float>(stat);
+    return out;
+}
+
+/**
+ * @brief Value-producing streaming reduction over the real CSP data path
+ *
+ * Bridges the #106 OnlineReductionScheduleGenerator to the #66 payload
+ * machinery for the stats-producing forms (FULL_REDUCE, ROW_STATS): input
+ * tiles ride DRAM->L3->L2->L1->compute, the per-row stat COMPUTE reduces
+ * every streamed feed to a finalized statistic, and the stat drains back to
+ * DRAM. Verified elementwise against a host oracle in the tests.
+ *
+ * ROW_NORMALIZE's apply phase is intentionally out of scope here: its stat
+ * must reach the apply computes as a compute-resident dependency (no DRAM
+ * round-trip race), which lands with the softmax/layernorm generators
+ * (E8/E9). This executor rejects ROW_NORMALIZE configs.
+ */
+class FunctionalReductionExecutor {
+public:
+    using ReduceOp = OnlineReductionScheduleGenerator::ReduceOp;
+    using Form = OnlineReductionScheduleGenerator::Form;
+
+    struct Result {
+        ExecutionResult execution;        ///< Timing/completion status
+        std::vector<float> stats;         ///< One finalized stat per row
+    };
+
+    FunctionalReductionExecutor(OnlineReductionScheduleGenerator::Config generator_config,
+                                ConcurrentTimingExecutor::Config executor_config = {})
+        : generator_config_(std::move(generator_config)),
+          executor_config_(std::move(executor_config)) {
+        if (generator_config_.form == Form::ROW_NORMALIZE) {
+            throw std::invalid_argument(
+                "FunctionalReductionExecutor supports FULL_REDUCE and ROW_STATS "
+                "only; ROW_NORMALIZE apply-phase numerics land with E8/E9");
+        }
+    }
+
+    /**
+     * @brief Reduce the input stream and return one stat per row
+     * @param data  row-major: num_rows x reduction_elems values
+     */
+    Result run(const std::vector<float>& data) {
+        const auto& cfg = generator_config_;
+        const Size rows = cfg.form == Form::FULL_REDUCE ? 1 : cfg.num_rows;
+        if (data.size() != static_cast<size_t>(rows) * cfg.reduction_elems) {
+            throw std::invalid_argument(
+                "input size does not match num_rows x reduction_elems");
+        }
+
+        OnlineReductionScheduleGenerator generator(cfg);
+        auto schedule = generator.generate();
+
+        Result result;
+        if (!schedule.valid) {
+            result.execution.error_message =
+                "Schedule generation refused: " + schedule.error_message;
+            return result;
+        }
+
+        ConcurrentTimingExecutor executor(executor_config_);
+        seed_input_payloads(executor, schedule, data);
+
+        ScheduleExecutor sched_exec(executor);
+        const ReduceOp op = cfg.op;
+        sched_exec.set_functional_compute_binder(
+            [op](const ScheduleOperation& compute_op)
+                -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+                ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+                spec.input_tiles = compute_op.dependency_tiles;
+                spec.operation = [op](const std::vector<TilePayload>& inputs) {
+                    return reduce_payloads(op, inputs);
+                };
+                return spec;
+            });
+
+        result.execution = sched_exec.execute(schedule);
+        if (result.execution.success) {
+            result.stats = gather_stats(executor, schedule, rows);
+        }
+        return result;
+    }
+
+private:
+    OnlineReductionScheduleGenerator::Config generator_config_;
+    ConcurrentTimingExecutor::Config executor_config_;
+
+    void seed_input_payloads(ConcurrentTimingExecutor& executor,
+                             const ScheduleResult& schedule,
+                             const std::vector<float>& data) const {
+        const Size rt = generator_config_.reduction_tiles();
+        const Size te = generator_config_.tile_elems;
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::LOAD) continue;
+            const auto& tile = op.tile;
+            // Input tiles ride matrix A; index is (row=ti, reduction-tile=tj)
+            const Size row = tile.tile_id.ti;
+            const Size t = tile.tile_id.tj;
+            const Size row_base = row * generator_config_.reduction_elems;
+            const Size offset = row_base + t * te;
+            const Size elems = tile.height;
+            (void)rt;
+            TilePayload payload{elems, 1,
+                                std::vector<float>(data.begin() + offset,
+                                                   data.begin() + offset + elems)};
+            executor.set_tile_payload(tile.tile_id, std::move(payload));
+        }
+    }
+
+    std::vector<float> gather_stats(const ConcurrentTimingExecutor& executor,
+                                    const ScheduleResult& schedule, Size rows) const {
+        std::vector<float> stats(rows, 0.0f);
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::STORE) continue;
+            const auto& tile = op.tile;
+            if (tile.tile_id.matrix != isa::MatrixID::B) continue;  // stat tile
+            const auto& payload =
+                executor.tile_payload_at(MemoryLevel::DRAM, tile.tile_id);
+            stats[tile.tile_id.ti] = payload.values.at(0);
+        }
+        return stats;
+    }
+};
+
+} // namespace sw::kpu::timing::schedule

--- a/include/sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/online_reduction_schedule_generator.hpp
@@ -319,15 +319,29 @@ private:
         tile.tile_id.ti = row;
         tile.tile_id.tj = t;
         tile.tile_id.tk = 0;
-        tile.height = config_.tile_elems;
+
+        // A/C tiles span the reduction dimension: the trailing tile of a
+        // non-tile-aligned row is partial, so clamp its footprint (the
+        // inter-tile stride stays full-tile). Stat tiles (B) are per-row.
+        Size elems = config_.tile_elems;
+        if (matrix != isa::MatrixID::B) {
+            const Size within_row = t * config_.tile_elems;
+            if (within_row + elems > config_.reduction_elems) {
+                elems = config_.reduction_elems - within_row;
+            }
+        }
+        tile.height = elems;
         tile.width = 1;
         tile.element_size = config_.element_size;
-        tile.size_bytes = config_.tile_elems * config_.element_size;
-        // Row-major over (row, reduction-tile); stat tiles are one per row
+        tile.size_bytes = elems * config_.element_size;
+
+        // Row-major over (row, reduction-tile) with a full-tile stride; stat
+        // tiles are one per row
+        const Size full_bytes = config_.tile_elems * config_.element_size;
         const Size linear = matrix == isa::MatrixID::B
             ? row
             : row * config_.reduction_tiles() + t;
-        tile.dram_address = base + linear * tile.size_bytes;
+        tile.dram_address = base + linear * full_bytes;
         tile.matrix_base_address = base;
         return tile;
     }

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -299,10 +299,10 @@
         "design": "done",
         "isa_closure": "done",
         "generator": "done",
-        "functional": "missing",
+        "functional": "done",
         "regression": "missing"
       },
-      "notes": "VEReduceOperands + behavioral running-combine + CSP chained-accumulator (#105); OnlineReductionScheduleGenerator FULL_REDUCE/ROW_STATS (single K-scaled compute over all streamed feeds, working set 2) + ROW_NORMALIZE (two-phase, envelope-derived ROW_RESIDENT vs RESTREAMED realization, stat round-trips DRAM + broadcast reload) with executable COMPUTEs (#106). Design #104. Functional/regression are E3-T4/T5."
+      "notes": "VEReduceOperands + behavioral combine + CSP chained accumulator (#105); OnlineReductionScheduleGenerator FULL_REDUCE/ROW_STATS/ROW_NORMALIZE (#106); FunctionalReductionExecutor value-produces FULL_REDUCE/ROW_STATS for all 5 ops vs host oracles incl. partitioned credits + non-aligned spans (#107). ROW_NORMALIZE apply-phase numerics deferred to E8/E9 (stat needs compute-resident delivery, not a DRAM round-trip). Design #104. Regression is E3-T5."
     },
     {
       "name": "layout_transform",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -158,3 +158,13 @@ kpu_add_component_test(test_reduction_generator "timing"
 set_tests_properties(test_reduction_generator PROPERTIES
     LABELS "timing;schedule;reduction;v0.9"
 )
+
+# Functional reduction with host oracle (issue #107, epic E3): value-producing
+# FULL_REDUCE / ROW_STATS on the CSP data path
+kpu_add_component_test(test_functional_reduction "timing"
+    test_functional_reduction.cpp
+)
+
+set_tests_properties(test_functional_reduction PROPERTIES
+    LABELS "timing;functional;reduction;v0.9"
+)

--- a/tests/timing/test_functional_reduction.cpp
+++ b/tests/timing/test_functional_reduction.cpp
@@ -1,0 +1,159 @@
+// ============================================================================
+// tests/timing/test_functional_reduction.cpp
+// Value-producing streaming reduction on the CSP executor, verified against
+// independent host oracles (issue #107, epic E3).
+//
+// Oracles are plain host loops, deliberately separate from reduce_payloads,
+// so a semantic error in the simulator kernel cannot match itself.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <sw/kpu/timing/schedule/functional_reduction_executor.hpp>
+
+#include <cmath>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+using Form = OnlineReductionScheduleGenerator::Form;
+using ReduceOp = OnlineReductionScheduleGenerator::ReduceOp;
+
+OnlineReductionScheduleGenerator::Config make_config(Size num_rows,
+                                                     Size reduction_elems,
+                                                     Form form, ReduceOp op) {
+    OnlineReductionScheduleGenerator::Config c;
+    c.num_rows = num_rows;
+    c.reduction_elems = reduction_elems;
+    c.tile_elems = 256;
+    c.form = form;
+    c.op = op;
+    c.in_base = 0x100000;
+    c.stat_base = 0x200000;
+    c.out_base = 0x300000;
+    return c;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.max_cycles = 2'000'000;
+    return config;
+}
+
+std::vector<float> make_stream(Size count, float base, float step) {
+    std::vector<float> v(count);
+    for (Size i = 0; i < count; ++i) v[i] = base + step * static_cast<float>(i);
+    return v;
+}
+
+// Independent host oracle over a contiguous span
+double oracle(ReduceOp op, const std::vector<float>& v, Size begin, Size end) {
+    double mx = -1e300, mn = 1e300, sum = 0.0, sumsq = 0.0;
+    size_t n = end - begin;
+    for (Size i = begin; i < end; ++i) {
+        mx = std::max(mx, static_cast<double>(v[i]));
+        mn = std::min(mn, static_cast<double>(v[i]));
+        sum += v[i]; sumsq += static_cast<double>(v[i]) * v[i];
+    }
+    switch (op) {
+        case ReduceOp::MAX: return mx;
+        case ReduceOp::MIN: return mn;
+        case ReduceOp::SUM: return sum;
+        case ReduceOp::MEAN: return sum / n;
+        case ReduceOp::VAR: return std::max(0.0, sumsq / n - (sum / n) * (sum / n));
+    }
+    return 0.0;
+}
+
+void require_close(ReduceOp op, float actual, double expected) {
+    if (op == ReduceOp::MAX || op == ReduceOp::MIN) {
+        REQUIRE(static_cast<double>(actual) == expected);  // exact
+    } else {
+        REQUIRE(actual == Catch::Approx(expected).epsilon(1e-4).margin(1e-4));
+    }
+}
+
+const ReduceOp kAllOps[] = {ReduceOp::MAX, ReduceOp::MIN, ReduceOp::SUM,
+                            ReduceOp::MEAN, ReduceOp::VAR};
+
+} // namespace
+
+TEST_CASE("FULL_REDUCE matches the host oracle for every op",
+          "[timing][functional][reduction]") {
+    const Size n = 4096;   // 16 tiles
+    auto data = make_stream(n, -5.0f, 0.013f);
+
+    for (ReduceOp op : kAllOps) {
+        INFO("op=" << static_cast<int>(op));
+        FunctionalReductionExecutor exec(
+            make_config(1, n, Form::FULL_REDUCE, op), make_executor_config());
+        auto result = exec.run(data);
+        REQUIRE(result.execution.success);
+        REQUIRE_FALSE(result.execution.livelock_detected);
+        REQUIRE(result.stats.size() == 1);
+        require_close(op, result.stats[0], oracle(op, data, 0, n));
+    }
+}
+
+TEST_CASE("ROW_STATS produces the right stat per row",
+          "[timing][functional][reduction]") {
+    const Size rows = 4, re = 1024;   // 4 rows x 4 tiles
+    auto data = make_stream(rows * re, 2.0f, -0.007f);
+
+    for (ReduceOp op : {ReduceOp::SUM, ReduceOp::MEAN, ReduceOp::VAR, ReduceOp::MAX}) {
+        INFO("op=" << static_cast<int>(op));
+        FunctionalReductionExecutor exec(
+            make_config(rows, re, Form::ROW_STATS, op), make_executor_config());
+        auto result = exec.run(data);
+        REQUIRE(result.execution.success);
+        REQUIRE(result.stats.size() == rows);
+        for (Size r = 0; r < rows; ++r) {
+            INFO("row=" << r);
+            require_close(op, result.stats[r], oracle(op, data, r * re, (r + 1) * re));
+        }
+    }
+}
+
+TEST_CASE("Reduction under partitioned credits stays correct",
+          "[timing][functional][reduction][partition]") {
+    const Size n = 4096;
+    auto data = make_stream(n, 0.0f, 0.5f);
+
+    auto exec_config = make_executor_config();
+    exec_config.partition_l3_credits = true;
+    exec_config.partition_l2_credits = true;
+
+    FunctionalReductionExecutor exec(
+        make_config(1, n, Form::FULL_REDUCE, ReduceOp::SUM), exec_config);
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+    require_close(ReduceOp::SUM, result.stats[0], oracle(ReduceOp::SUM, data, 0, n));
+}
+
+TEST_CASE("Non-aligned reduction span reduces every element",
+          "[timing][functional][reduction]") {
+    const Size n = 1000;   // 4 tiles: 256+256+256+232
+    auto data = make_stream(n, -1.0f, 0.011f);
+
+    FunctionalReductionExecutor exec(
+        make_config(1, n, Form::FULL_REDUCE, ReduceOp::SUM), make_executor_config());
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+    require_close(ReduceOp::SUM, result.stats[0], oracle(ReduceOp::SUM, data, 0, n));
+}
+
+TEST_CASE("ROW_NORMALIZE is rejected by the functional reduction executor",
+          "[timing][functional][reduction]") {
+    REQUIRE_THROWS_AS(
+        FunctionalReductionExecutor(
+            make_config(1, 1024, Form::ROW_NORMALIZE, ReduceOp::SUM),
+            make_executor_config()),
+        std::invalid_argument);
+}

--- a/tests/timing/test_reduction_generator.cpp
+++ b/tests/timing/test_reduction_generator.cpp
@@ -67,6 +67,26 @@ TEST_CASE("FULL_REDUCE emits one compute over all streamed feeds",
     REQUIRE(config.required_working_set() == 2);
 }
 
+TEST_CASE("Non-aligned reduction clamps the trailing tile footprint",
+          "[timing][schedule][reduction]") {
+    auto config = base_config();
+    config.form = Form::FULL_REDUCE;
+    config.reduction_elems = 1000;   // 4 tiles: 256+256+256+232
+    OnlineReductionScheduleGenerator gen(config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    const Size full = 256, tail = 232;
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        const auto& tile = op.tile;
+        // Full-tile stride, clamped trailing footprint
+        REQUIRE(tile.dram_address - tile.matrix_base_address ==
+                tile.tile_id.tj * full * config.element_size);
+        REQUIRE(tile.height == (tile.tile_id.tj == 3 ? tail : full));
+    }
+}
+
 TEST_CASE("ROW_STATS emits one compute per row",
           "[timing][schedule][reduction]") {
     auto config = base_config();


### PR DESCRIPTION
Fixes #107 — E3-T4 of the online-reduction epic (#72). Flips `online_reduction.functional`, an **M4 attention-gate cell**.

## What

- **`FunctionalReductionExecutor`** bridges the #106 generator to the #66 payload machinery for the stats forms (FULL_REDUCE, ROW_STATS): input tiles ride the real CSP path (DRAM→L3→L2→L1→compute), the per-row stat COMPUTE reduces every streamed feed to a finalized statistic, and the stat drains back to DRAM.
- **`reduce_payloads`** matches the VE_REDUCE ABI (#105): MAX/MIN/SUM/MEAN/VAR, population variance clamped ≥ 0, empty → NaN.
- **Host-oracle regression** (oracles are independent plain host loops, not `reduce_payloads`): all five ops, batched rows, partitioned credits, non-aligned spans. Exact compare for MAX/MIN, relative tolerance for SUM/MEAN/VAR.

## Scope decision: ROW_NORMALIZE deferred (rejected with a clear message)

ROW_NORMALIZE's apply phase needs the per-row stat *at* the apply computes. T3 delivers it via a DRAM round-trip (store → reload), which is timing-correct but **races in the value plane** — nothing in the schedule orders `load(stat)` after `store(stat)`. The correct fix is delivering the stat as a **compute-resident dependency** (no round-trip), which needs schedule-tier resident-dep support and lands naturally with the softmax/layernorm generators (E8/E9). The stats forms — no continuity issue, and exactly what the M4 gate requires — are delivered here.

## Fixed (found by the oracle)

The #106 generator sized every A/C tile as a full tile, so a non-tile-aligned `reduction_elems` read past the row end (out-of-bounds → wrong sum). `make_tile` now clamps the trailing footprint (full-tile stride preserved), matching the elementwise generator; a structure test pins it. This is exactly the kind of defect a value oracle exists to catch.

## Verification

- Full suite: **105/105 pass**. Coverage: `online_reduction` functional → done (**22/105**). Gates hold.
- Session log: `docs/sessions/2026-07-14_v0.9_e3_reduction_functional.md`

Next: E3-T5 (#108) — op × stream-length × envelope regression + characterization, which closes epic #72 and #18 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functional streaming reductions for full reductions and per-row statistics.
  - Supports MAX, MIN, SUM, MEAN, and VAR operations, including empty-input handling.
  - Returns computed statistics for validation and downstream use.

- **Bug Fixes**
  - Corrected processing of trailing partial tiles when reduction sizes are not tile-aligned, preventing out-of-range reads.

- **Documentation**
  - Added release documentation covering supported operations, validation results, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->