### PR TITLE
test(timing): reduction regression matrix + characterization (reduce-T5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Reduction regression matrix + characterization (#108, epic E3
+  COMPLETE).** `test_reduction_regression` executes the op x stream-length
+  x envelope matrix (MAX/SUM/VAR x 1/16/64-tile + non-aligned x
+  default/constrained-min/partitioned) with invariants stronger than
+  completion: exact per-stage tile accounting and full credit conservation
+  (both credit modes), plus a normalized stall bound. The envelope refusal
+  boundary is pinned exact (min 8 generates, 4 refuses), and values survive
+  the minimum envelope under partitioned credits on a non-aligned span.
+  Characterization on epic #72: the single K-scaled compute amortizes
+  per-tile cost 193 -> 42 cycles from 1 to 64 tiles. `online_reduction` is
+  now the fourth operator complete across all five stages after matmul,
+  elementwise, and broadcast (23/105). This closes epic #72 and, with the
+  ISA half from #105, closes #18 entirely.
+
 - **Value-producing streaming reduction + host oracles (#107, epic E3).**
   `FunctionalReductionExecutor` bridges the #106 generator to the #66
   payload machinery for the stats forms: input tiles ride the real CSP

--- a/docs/sessions/2026-07-14_v0.9_e3_reduction_regression.md
+++ b/docs/sessions/2026-07-14_v0.9_e3_reduction_regression.md
@@ -1,0 +1,79 @@
+# v0.9 E3-T5: Reduction Regression Matrix Decision Log
+
+**Date:** 2026-07-14
+**Version:** v0.9
+**Status:** Complete - closes epic E3 (#72) and #18
+**Tests:** 106/106 suites passing (new: test_reduction_regression, 4 cases /
+475 assertions / 36 matrix cells)
+**Issues:** #108 (done); epic #72 complete; #18 complete
+
+## 1. Summary
+
+Implemented E3-T5: execution regression for streaming reduction across the
+op x stream-length x envelope matrix with invariants stronger than
+completion, plus characterization recorded on the epic. This closes epic
+E3 - online_reduction is now the fourth operator (after matmul,
+elementwise, broadcast) with all five lifecycle stages done - and closes
+#18 (VE_ELEMENTWISE half in E2, VE_REDUCE half in E3).
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| Matrix: {MAX,SUM,VAR} x {1,16,64-tile,non-aligned} x {default,constrained-min,partitioned} = 36 cells | Done |
+| Per-stage tile accounting + credit conservation + normalized stall bound | Done |
+| Envelope refusal boundary exact (min(l3,l2)=8 generates, 4 refuses) | Done |
+| Functional-under-pressure (min envelope + partitioned + non-aligned, exact value) | Done |
+| Characterization table posted to epic #72 | Done |
+| Coverage: online_reduction regression -> done (23/105) | Done |
+
+Files:
+- `tests/timing/test_reduction_regression.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: same invariant battery as the elementwise matrix (E2-T5).**
+- Exact per-stage accounting (L3 arrivals = LOAD + WRITEBACK), full credit
+  return in both modes, and the normalized stall bound (stalls <
+  total_cycles x stall-capable components). Reusing the proven battery
+  keeps the P3 pattern held to the same standard as P5/P6.
+
+**Decision 2: three ops in the timing matrix, all five in functional.**
+- The timing tier does not distinguish reduction ops (identical cycles
+  across MAX/SUM/VAR, as the table shows), so the matrix samples three;
+  the functional oracle (T4) already covers all five for values.
+
+## 4. Issues Encountered
+
+None. The characterization confirms the design's matmul-shaped latency:
+single K-scaled compute, per-tile cost amortizing with stream length.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                           # 106/106
+./build/tests/timing/test_reduction_regression    # 475 assertions, 36 cells
+./build/tests/coverage/test_pattern_coverage      # 23/105, gates hold
+```
+
+## 7. Characterization Highlights (full table on epic #72)
+
+- Single K-scaled compute: per-tile cost amortizes 193 -> ~42 cycles from
+  1 to 64 tiles as the one compute spreads over the stream.
+- Timing is op-independent (MAX/SUM/VAR identical) - the reduction cost is
+  in movement + the K-scaled compute, not the combine kind.
+- Constrained-min envelope raises stalls (e.g. 64-tile 4240 -> 4851) but
+  does not change cycles - the pipeline absorbs the pressure, as in E2.
+
+## 8. Next Steps
+
+- Epic E3 (#72) closes with this PR; #18 closes entirely.
+- Remaining Wave 1 pattern epics: E1 (#70) gather, E4 (#73) layout.
+  E7/E8/E9 (pooling, softmax, norms) now have the reduction primitive they
+  need; E8/E9 own the ROW_NORMALIZE apply-phase numerics.

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -300,9 +300,9 @@
         "isa_closure": "done",
         "generator": "done",
         "functional": "done",
-        "regression": "missing"
+        "regression": "done"
       },
-      "notes": "VEReduceOperands + behavioral combine + CSP chained accumulator (#105); OnlineReductionScheduleGenerator FULL_REDUCE/ROW_STATS/ROW_NORMALIZE (#106); FunctionalReductionExecutor value-produces FULL_REDUCE/ROW_STATS for all 5 ops vs host oracles incl. partitioned credits + non-aligned spans (#107). ROW_NORMALIZE apply-phase numerics deferred to E8/E9 (stat needs compute-resident delivery, not a DRAM round-trip). Design #104. Regression is E3-T5."
+      "notes": "VEReduceOperands + behavioral combine + CSP chained accumulator (#105); OnlineReductionScheduleGenerator FULL_REDUCE/ROW_STATS/ROW_NORMALIZE (#106); FunctionalReductionExecutor value-produces FULL_REDUCE/ROW_STATS for all 5 ops vs host oracles incl. partitioned credits + non-aligned spans (#107). ROW_NORMALIZE apply-phase numerics deferred to E8/E9 (stat needs compute-resident delivery, not a DRAM round-trip). Design #104. Regression: op x stream-length x envelope matrix with credit/stall invariants + characterization (#108)."
     },
     {
       "name": "layout_transform",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -168,3 +168,13 @@ kpu_add_component_test(test_functional_reduction "timing"
 set_tests_properties(test_functional_reduction PROPERTIES
     LABELS "timing;functional;reduction;v0.9"
 )
+
+# Reduction regression matrix (issue #108, epic E3): op x stream-length x
+# envelope with credit/stall invariants and characterization
+kpu_add_component_test(test_reduction_regression "timing"
+    test_reduction_regression.cpp
+)
+
+set_tests_properties(test_reduction_regression PROPERTIES
+    LABELS "timing;regression;reduction;v0.9"
+)

--- a/tests/timing/test_reduction_regression.cpp
+++ b/tests/timing/test_reduction_regression.cpp
@@ -1,0 +1,215 @@
+// ============================================================================
+// tests/timing/test_reduction_regression.cpp
+// Streaming-reduction execution regression: op x stream-length x envelope
+// with credit/stall invariants and performance characterization
+// (issue #108, epic E3).
+//
+// Invariants stronger than completion: exact per-stage tile accounting and
+// full credit conservation - a leaked credit or an unconsumed tile fails
+// the cell, not just a livelock.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <sw/kpu/timing/schedule/functional_reduction_executor.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+using Form = OnlineReductionScheduleGenerator::Form;
+using ReduceOp = OnlineReductionScheduleGenerator::ReduceOp;
+
+struct EnvelopeCase { const char* name; Size l3; Size l2; bool partitioned; };
+
+// default, the minimum safe envelope (share = min(8,8)/4 = 2 = the stats
+// working set; one less refuses), and per-matrix partitioned credits.
+constexpr EnvelopeCase kEnvelopes[] = {
+    {"default",         32, 64, false},
+    {"constrained-min",  8,  8, false},
+    {"partitioned",     32, 64, true},
+};
+
+struct SizeCase { const char* name; Size reduction_elems; };
+constexpr SizeCase kSizes[] = {
+    {"single-tile", 256},
+    {"16-tile",     4096},
+    {"64-tile",     16384},
+    {"non-aligned", 4000},
+};
+
+constexpr ReduceOp kOps[] = {ReduceOp::MAX, ReduceOp::SUM, ReduceOp::VAR};
+
+const char* op_name(ReduceOp op) {
+    switch (op) {
+        case ReduceOp::MAX: return "MAX";
+        case ReduceOp::MIN: return "MIN";
+        case ReduceOp::SUM: return "SUM";
+        case ReduceOp::MEAN: return "MEAN";
+        case ReduceOp::VAR: return "VAR";
+    }
+    return "?";
+}
+
+OnlineReductionScheduleGenerator::Config make_config(ReduceOp op,
+                                                     const SizeCase& size,
+                                                     const EnvelopeCase& env) {
+    OnlineReductionScheduleGenerator::Config c;
+    c.num_rows = 1;
+    c.reduction_elems = size.reduction_elems;
+    c.tile_elems = 256;
+    c.form = Form::FULL_REDUCE;
+    c.op = op;
+    c.l3_buffer_count = env.l3;
+    c.l2_bank_count = env.l2;
+    c.in_base = 0x100000;
+    c.stat_base = 0x200000;
+    c.out_base = 0x300000;
+    return c;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config(const EnvelopeCase& env) {
+    ConcurrentTimingExecutor::Config config;
+    config.l3_buffer_count = env.l3;
+    config.l2_bank_count = env.l2;
+    config.partition_l3_credits = env.partitioned;
+    config.partition_l2_credits = env.partitioned;
+    config.max_cycles = 5'000'000;
+    return config;
+}
+
+struct CellResult {
+    std::string op, size, envelope;
+    Size tiles = 0;
+    Cycle cycles = 0;
+    double cycles_per_tile = 0.0;
+    Cycle stalls = 0;
+    double str_util = 0.0;
+};
+std::vector<CellResult>& characterization() {
+    static std::vector<CellResult> rows;
+    return rows;
+}
+
+void run_cell(ReduceOp op, const SizeCase& size, const EnvelopeCase& env) {
+    auto gen_config = make_config(op, size, env);
+    OnlineReductionScheduleGenerator gen(gen_config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor executor(make_executor_config(env));
+    ScheduleExecutor sched_exec(executor);
+    auto result = sched_exec.execute(schedule);
+
+    INFO("op=" << op_name(op) << " size=" << size.name << " env=" << env.name
+         << " cycles=" << result.total_cycles << " error=" << result.error_message);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+    REQUIRE(result.warnings.empty());
+
+    const auto stats = executor.get_statistics();
+
+    // Per-stage tile accounting (tiles reach L3 from LOAD and WRITEBACK)
+    REQUIRE(stats.tiles_loaded == schedule.count_ops(ScheduleOpType::LOAD) +
+                                  schedule.count_ops(ScheduleOpType::WRITEBACK));
+    REQUIRE(stats.tiles_moved == schedule.count_ops(ScheduleOpType::MOVE));
+    REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+    REQUIRE(stats.tiles_drained == schedule.count_ops(ScheduleOpType::DRAIN));
+    REQUIRE(stats.tiles_stored == schedule.count_ops(ScheduleOpType::STORE));
+
+    // Credit conservation (aggregates across partitions)
+    REQUIRE(executor.l3_credits().available() == env.l3);
+    REQUIRE(executor.l2_credits().available() == env.l2);
+
+    // Normalized stall bound: aggregated stalls cannot reach
+    // total_cycles x stall-capable components (that would be "stalled every
+    // cycle, no work ever done")
+    const Cycle stalls = stats.dma_credit_stalls + stats.bm_tag_stalls +
+                         stats.bm_credit_stalls + stats.str_tag_stalls +
+                         stats.str_credit_stalls;
+    const auto& ec = executor.config();
+    const Cycle stall_capable = static_cast<Cycle>(
+        ec.num_dma_engines + ec.num_block_movers +
+        ec.num_row_streamers + ec.num_col_streamers);
+    REQUIRE(result.total_cycles > 0);
+    REQUIRE(stalls < result.total_cycles * stall_capable);
+
+    const Size tiles = gen_config.reduction_tiles();
+    characterization().push_back(
+        {op_name(op), size.name, env.name, tiles, result.total_cycles,
+         static_cast<double>(result.total_cycles) / static_cast<double>(tiles),
+         stalls, stats.str_utilization()});
+}
+
+} // namespace
+
+TEST_CASE("Reduction execution matrix: op x stream-length x envelope",
+          "[timing][regression][reduction][matrix]") {
+    for (ReduceOp op : kOps) {
+        for (const auto& size : kSizes) {
+            for (const auto& env : kEnvelopes) {
+                DYNAMIC_SECTION(op_name(op) << "/" << size.name << "/" << env.name) {
+                    run_cell(op, size, env);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Reduction envelope refusal boundary is exact",
+          "[timing][regression][reduction][envelope]") {
+    // share = min(l3,l2)/4: 8 -> 2 (= working set, generates);
+    // 4 -> 1 (< working set, refused)
+    SizeCase big{"16-tile", 4096};
+    auto safe = make_config(ReduceOp::SUM, big, {"boundary-safe", 8, 8, false});
+    REQUIRE(OnlineReductionScheduleGenerator(safe).generate().valid);
+
+    auto unsafe = make_config(ReduceOp::SUM, big, {"boundary-unsafe", 4, 4, false});
+    auto sched = OnlineReductionScheduleGenerator(unsafe).generate();
+    REQUIRE_FALSE(sched.valid);
+    REQUIRE(sched.error_message.find("working set") != std::string::npos);
+}
+
+TEST_CASE("Reduction values survive the minimum envelope + partitioned credits",
+          "[timing][regression][reduction][functional]") {
+    const Size n = 4000;   // non-aligned, 16 tiles
+    std::vector<float> data(n);
+    for (Size i = 0; i < n; ++i) data[i] = -3.0f + 0.0021f * static_cast<float>(i);
+
+    EnvelopeCase env{"constrained-partitioned", 8, 8, true};
+    auto gen_config = make_config(ReduceOp::SUM, {"non-aligned", n}, env);
+    FunctionalReductionExecutor exec(gen_config, make_executor_config(env));
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+    REQUIRE_FALSE(result.execution.livelock_detected);
+
+    double sum = 0.0; for (float v : data) sum += v;
+    REQUIRE(result.stats[0] == Catch::Approx(sum).epsilon(1e-4).margin(1e-3));
+}
+
+TEST_CASE("Reduction characterization report",
+          "[timing][regression][reduction][report]") {
+    const auto& rows = characterization();
+    if (rows.empty()) { SUCCEED("matrix test did not run"); return; }
+    std::printf("\n%-6s %-12s %-16s %6s %9s %9s %8s %6s\n",
+                "op", "size", "envelope", "tiles", "cycles", "cyc/tile",
+                "stalls", "str%");
+    for (const auto& r : rows) {
+        std::printf("%-6s %-12s %-16s %6zu %9llu %9.1f %8llu %6.1f\n",
+                    r.op.c_str(), r.size.c_str(), r.envelope.c_str(),
+                    static_cast<size_t>(r.tiles),
+                    static_cast<unsigned long long>(r.cycles), r.cycles_per_tile,
+                    static_cast<unsigned long long>(r.stalls), 100.0 * r.str_util);
+    }
+    SUCCEED("characterization recorded");
+}


### PR DESCRIPTION
Fixes #108 — E3-T5, the final task of the online-reduction epic. **Completes epic #72** and **closes #18** (VE_ELEMENTWISE half in E2, VE_REDUCE half in E3). `online_reduction` becomes the fourth operator with all five lifecycle stages done, after matmul, elementwise, and broadcast.

## What

- **`test_reduction_regression`**: the op × stream-length × envelope matrix — {MAX, SUM, VAR} × {1-tile, 16-tile, 64-tile, non-aligned} × {default, constrained-min 8/8, partitioned} = **36 cells**, each enforcing invariants stronger than completion: exact per-stage tile accounting (L3 arrivals = LOAD + WRITEBACK), full credit conservation in both credit modes, and a normalized stall bound.
- **Envelope refusal boundary pinned exact**: min(l3,l2)=8 (share 2 = the stats working set) generates; 4 refuses a priori.
- **Functional-under-pressure**: exact value at the minimum envelope with partitioned credits on a non-aligned span.
- **Characterization** recorded on epic #72 (and reprinted every CI run): the single K-scaled compute amortizes per-tile cost 193 → 42 cycles from 1 to 64 tiles — the design's matmul-shaped latency claim, measured. Timing is op-independent (the ops differ in values, not cycles).

## Coverage

`online_reduction` regression → done: **23/105**. Gates hold. #18 closes entirely.

## Verification

Full suite: **106/106 pass** (new suite: 4 cases, 475 assertions).
Session log: `docs/sessions/2026-07-14_v0.9_e3_reduction_regression.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive regression coverage for online reduction across operations, stream sizes, and envelope configurations.
  * Added validation for tile accounting, credit conservation, execution stability, envelope boundaries, and reduction results.
  * Added timing and characterization reports covering cycles, stalls, and utilization.

* **Documentation**
  * Documented regression results, coverage, technical decisions, and follow-up work.
  * Marked online reduction regression coverage as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->