### PR TITLE
feat(timing): schedule-tier compute-resident dependency mechanism (softmax-T2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Schedule-tier compute-resident dependency mechanism (#155, epic E8).**
+  A COMPUTE can now declare `resident_tiles` - inputs it consumes from the
+  compute fabric, produced by a prior COMPUTE, rather than via a fresh
+  FEED. `ConcurrentTimingExecutor::schedule_compute(tile, feed, resident)`
+  records them as resident dependencies (the #66 completed-compute
+  accounting), `ScheduleExecutor` routes COMPUTEs carrying `resident_tiles`
+  there, and the `FunctionalComputeBinder` maps them onto
+  `FunctionalComputeSpec::resident_tiles`. This lets a running-stat tile
+  (online-softmax `(m, l)`, norm mean/var) reach the apply computes
+  ordered and race-free - no DRAM round-trip - which is exactly what
+  E3-T4 deferred. Built once here, reused by softmax (E8), norms (E9), and
+  the reduction ROW_NORMALIZE apply phase. Coverage: softmax design +
+  isa_closure -> done (25/105).
+
 - **Reduction regression matrix + characterization (#108, epic E3
   COMPLETE).** `test_reduction_regression` executes the op x stream-length
   x envelope matrix (MAX/SUM/VAR x 1/16/64-tile + non-aligned x

--- a/docs/sessions/2026-07-14_v0.9_e8_resident_dependency.md
+++ b/docs/sessions/2026-07-14_v0.9_e8_resident_dependency.md
@@ -1,0 +1,93 @@
+# v0.9 E8-T2: Schedule-Tier Resident-Dependency Mechanism Decision Log
+
+**Date:** 2026-07-14
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 107/107 suites passing (new: test_resident_dependency, 2 cases)
+**Issues:** #155 (done)
+
+## 1. Summary
+
+Implemented E8-T2: the schedule-tier compute-resident dependency
+mechanism - the load-bearing capability of the online-softmax epic, and
+the direct resolution of the delivery gap E3-T4 deferred. A COMPUTE can
+now consume a tile produced by a prior COMPUTE directly from the compute
+fabric (resident), ordered by the #66 completed-compute accounting, with
+no DRAM round-trip and no value-plane race.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| ScheduleOperation::resident_tiles + compute(tile, fed, resident) factory | Done |
+| ConcurrentTimingExecutor::schedule_compute(tile, feed, resident) | Done |
+| ScheduleExecutor routing (COMPUTE with resident_tiles) | Done |
+| FunctionalComputeBinder maps resident_tiles (reader-side, documented) | Done |
+| Resident-ordering validation test (functional value + timing-only) | Done |
+| Coverage: softmax design + isa_closure -> done (25/105) | Done |
+
+Files:
+- `include/sw/kpu/timing/concurrent_timing_executor.hpp`
+- `include/sw/kpu/timing/schedule/schedule_generator_interface.hpp`
+- `include/sw/kpu/timing/schedule/schedule_executor.hpp`
+- `tests/timing/test_resident_dependency.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: reuse the existing PendingCompute.resident_dependencies.**
+- The executor already tracks resident dependencies for matmul/functional
+  computes and increments completed_compute_counts on every compute
+  completion. The new overload just records resident deps the same way and
+  increments scheduled_compute_counts on the produced tile (so the compute
+  can itself be a resident source). No new accounting, no change to the
+  matmul/reduction paths.
+
+**Decision 2: no new behavioral ISA op for softmax (T1 refinement).**
+- The T1 design listed a "behavioral online-softmax VE_REDUCE op kind" in
+  T2. On implementation this is unnecessary: softmax on the behavioral
+  tier is a PROGRAM of existing VE_REDUCE (max/sum) + VE_ELEMENTWISE
+  (sub/exp/div) ops - the KernelCompiler already has a softmax compiler -
+  not a single new ISA op. The genuinely new capability is the
+  schedule-tier resident dependency (CSP movement), delivered here. The
+  online-softmax rescale-on-new-max value semantics live in the CSP
+  functional binder (T3/T4), where softmax values are actually computed.
+
+**Decision 3: validate via the functional path.**
+- The strong ordering check is functional: the apply compute reads the
+  resident stat's payload; if it ran before the stats compute completed,
+  the payload would be absent and the op would throw. A correct value
+  (C = 2*A + 1) therefore proves both ordering and value continuity
+  through the schedule tier. A timing-only case proves execution without
+  a binder.
+
+## 4. Issues Encountered
+
+1. ConcurrentTimingExecutor has no default constructor; the test passes an
+   explicit Config.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions. Decision 2 is a documented refinement of the approved
+T1 design, not a silent deviation - the design's intent (softmax value
+semantics on both tiers) is preserved; only the mechanism (existing VE
+program vs a new op) changed, and it reduces scope without loss.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                           # 107/107
+./build/tests/timing/test_resident_dependency    # ordering + value
+./build/tests/coverage/test_pattern_coverage     # 25/105, gates hold
+```
+
+## 7. Next Steps
+
+- E8-T3 (#156): OnlineSoftmaxScheduleGenerator (row-resident / re-streamed
+  realization, (m,l) resident hand-off via resident_tiles); supersedes the
+  4-pass generator; resolves #139 for softmax.
+- Then T4 (#157) functional + safe-softmax oracle, T5 (#158) regression +
+  single-pass-vs-multi-pass DRAM-traffic payoff -> closes epic #77.
+- Bonus: the reduction ROW_NORMALIZE apply phase E3-T4 deferred can now be
+  completed on this mechanism (follow-up in E3 or E9).

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -302,6 +302,24 @@ public:
     void schedule_compute(const TileDescriptor& tile, std::vector<TileID> dependencies);
 
     /**
+     * @brief Schedule a compute with both fed and compute-resident inputs
+     * @param tile Result tile descriptor
+     * @param feed_dependencies input tiles that must be FED before compute
+     * @param resident_dependencies input tiles produced by a PRIOR compute
+     *        that stay in the compute fabric (no fresh feed) - each requires
+     *        that many completed computes of the producing tile
+     *
+     * The timing-tier counterpart of MatMulComputeSpec/FunctionalComputeSpec
+     * resident_tiles, for schedules (e.g. online softmax, issue #155) whose
+     * apply computes consume a running-stat tile resident rather than via a
+     * DRAM round-trip. A resident dependency cannot be satisfied until the
+     * producing compute completes, so it orders the chain without a race.
+     */
+    void schedule_compute(const TileDescriptor& tile,
+                          std::vector<TileID> feed_dependencies,
+                          std::vector<TileID> resident_dependencies);
+
+    /**
      * @brief Schedule a compute completion (no explicit dependency)
      * @param tile Result tile descriptor (C matrix tile)
      *
@@ -779,6 +797,29 @@ inline void ConcurrentTimingExecutor::schedule_compute(
     pc.schedule_cycle = current_cycle_;
     pc.complete_cycle = 0;  // Set when started
     pc.started = false;
+    pending_computes_.push_back(std::move(pc));
+}
+
+inline void ConcurrentTimingExecutor::schedule_compute(
+    const TileDescriptor& tile, std::vector<TileID> feed_dependencies,
+    std::vector<TileID> resident_dependencies) {
+    PendingCompute pc;
+    pc.tile = tile;
+    for (const auto& dep : feed_dependencies) {
+        const size_t required = std::max<size_t>(1, scheduled_feed_counts_[dep]);
+        pc.dependencies.push_back({dep, required});
+    }
+    // Resident inputs are gated on the producing compute having completed,
+    // not on a fresh feed (the #66 completed-compute accounting)
+    for (const auto& dep : resident_dependencies) {
+        const size_t required = std::max<size_t>(1, scheduled_compute_counts_[dep]);
+        pc.resident_dependencies.push_back({dep, required});
+    }
+    pc.schedule_cycle = current_cycle_;
+    pc.complete_cycle = 0;
+    pc.started = false;
+    // This compute may itself be a resident source for a later compute
+    ++scheduled_compute_counts_[tile.tile_id];
     pending_computes_.push_back(std::move(pc));
 }
 

--- a/include/sw/kpu/timing/schedule/schedule_executor.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_executor.hpp
@@ -329,7 +329,11 @@ private:
                         break;
                     }
                 }
-                if (!op.dependency_tiles.empty()) {
+                if (!op.resident_tiles.empty()) {
+                    // Timing-tier compute with compute-resident inputs (#155)
+                    executor_.schedule_compute(op.tile, op.dependency_tiles,
+                                               op.resident_tiles);
+                } else if (!op.dependency_tiles.empty()) {
                     executor_.schedule_compute(op.tile, op.dependency_tiles);
                 } else {
                     executor_.schedule_compute(op.tile, op.dependency_tile);

--- a/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
+++ b/include/sw/kpu/timing/schedule/schedule_generator_interface.hpp
@@ -101,8 +101,14 @@ struct ScheduleOperation {
     // starts (every A and B K-slice contributing to the result tile).
     // dependency_tile is retained for backward compatibility and holds the
     // last entry of dependency_tiles.
-    std::vector<TileID> dependency_tiles;   ///< COMPUTE waits for all of these
+    std::vector<TileID> dependency_tiles;   ///< COMPUTE waits for all of these (fed)
     TileID dependency_tile{};               ///< Last dependency (legacy field)
+
+    // Compute-resident inputs (issue #155): tiles a COMPUTE consumes from
+    // compute storage, produced by a PRIOR compute, rather than via a fresh
+    // FEED - e.g. the running (m, l) state of online softmax handed to the
+    // apply computes. Empty for ordinary computes.
+    std::vector<TileID> resident_tiles;
 
     /**
      * @brief Create a LOAD operation
@@ -198,6 +204,28 @@ struct ScheduleOperation {
             op.dependency_tile = dependencies.back();
         }
         op.dependency_tiles = std::move(dependencies);
+        return op;
+    }
+
+    /**
+     * @brief Create a COMPUTE with both fed and compute-resident inputs
+     *
+     * @param tile Result tile
+     * @param fed_dependencies input tiles that must be FED before compute
+     * @param resident_dependencies input tiles produced by a prior COMPUTE
+     *        that stay resident in the compute fabric (issue #155)
+     */
+    static ScheduleOperation compute(const TileDescriptor& tile,
+                                     std::vector<TileID> fed_dependencies,
+                                     std::vector<TileID> resident_dependencies) {
+        ScheduleOperation op;
+        op.type = ScheduleOpType::COMPUTE;
+        op.tile = tile;
+        if (!fed_dependencies.empty()) {
+            op.dependency_tile = fed_dependencies.back();
+        }
+        op.dependency_tiles = std::move(fed_dependencies);
+        op.resident_tiles = std::move(resident_dependencies);
         return op;
     }
 

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -115,13 +115,13 @@
         "jepa"
       ],
       "stages": {
-        "design": "partial",
-        "isa_closure": "partial",
+        "design": "done",
+        "isa_closure": "done",
         "generator": "partial",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "Multi-pass form only (envelope-checked, #90); online single-pass is the epic's core; schedule generator affected by #139; kernel program op-faithful (#142)."
+      "notes": "Online single-pass softmax design: running max + rescaled sum, row-resident apply, schedule-tier resident-dependency mechanism (#154). isa_closure: ScheduleOperation::resident_tiles + ConcurrentTimingExecutor::schedule_compute(tile,feed,resident) + ScheduleExecutor routing + binder mapping - apply computes consume the running (m,l) state compute-resident, no DRAM round-trip race (#155). Generator/functional/regression are E8-T3/T4/T5; supersedes the 4-pass SoftmaxScheduleGenerator."
     },
     {
       "name": "layernorm",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -178,3 +178,13 @@ kpu_add_component_test(test_reduction_regression "timing"
 set_tests_properties(test_reduction_regression PROPERTIES
     LABELS "timing;regression;reduction;v0.9"
 )
+
+# Schedule-tier resident-dependency mechanism (issue #155, epic E8):
+# compute-resident inputs (online softmax / norm apply hand-off)
+kpu_add_component_test(test_resident_dependency "timing"
+    test_resident_dependency.cpp
+)
+
+set_tests_properties(test_resident_dependency PROPERTIES
+    LABELS "timing;executor;resident;v0.9"
+)

--- a/tests/timing/test_resident_dependency.cpp
+++ b/tests/timing/test_resident_dependency.cpp
@@ -1,0 +1,118 @@
+// ============================================================================
+// tests/timing/test_resident_dependency.cpp
+// Schedule-tier compute-resident dependency mechanism (issue #155, epic E8).
+//
+// A COMPUTE carrying resident_tiles consumes a tile produced by a PRIOR
+// compute directly from the compute fabric - no drain/reload, no DRAM
+// round-trip race. This is the capability online softmax / norm apply
+// phases need. Verified two ways: the functional path proves the resident
+// value reaches the consumer (and therefore that ordering held), the
+// timing-only path proves the schedule executes.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+TileDescriptor scalar_tile(MatrixID matrix, Size ti, Address base) {
+    TileDescriptor t;
+    t.tile_id = {matrix, ti, 0, 0};
+    t.height = 1; t.width = 1; t.element_size = 4; t.size_bytes = 4;
+    t.dram_address = base + ti * 0x1000;
+    t.matrix_base_address = base;
+    return t;
+}
+
+// A two-compute schedule: a stats compute produces B = 2*A from a fed A,
+// then an apply compute consumes B RESIDENT and produces C = B + 1.
+ScheduleResult build_schedule() {
+    auto a = scalar_tile(MatrixID::A, 0, 0x100000);
+    auto b = scalar_tile(MatrixID::B, 0, 0x200000);
+    auto c = scalar_tile(MatrixID::C, 0, 0x300000);
+
+    ScheduleResult s;
+    s.operations.push_back(ScheduleOperation::load(a));
+    s.operations.push_back(ScheduleOperation::move(a));
+    s.operations.push_back(ScheduleOperation::feed(a));
+    s.operations.push_back(ScheduleOperation::compute(b, {a.tile_id}));  // stats
+    // apply: no fresh feed, B consumed resident
+    s.operations.push_back(ScheduleOperation::compute(
+        c, /*fed*/ std::vector<TileID>{}, /*resident*/ std::vector<TileID>{b.tile_id}));
+    s.operations.push_back(ScheduleOperation::drain(c));
+    s.operations.push_back(ScheduleOperation::writeback(c));
+    s.operations.push_back(ScheduleOperation::store(c));
+    s.metadata.l3_buffer_count = 0;  // exempt from envelope check
+    s.metadata.l2_bank_count = 0;
+    s.valid = true;
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("Resident dependency delivers a prior compute's value to the consumer",
+          "[timing][executor][resident]") {
+    auto schedule = build_schedule();
+
+    ConcurrentTimingExecutor::Config cfg; cfg.max_cycles = 1000000;
+    ConcurrentTimingExecutor executor(cfg);
+    executor.set_tile_payload({MatrixID::A, 0, 0, 0}, TilePayload{1, 1, {5.0f}});
+
+    ScheduleExecutor sched_exec(executor);
+    sched_exec.set_functional_compute_binder(
+        [](const ScheduleOperation& op)
+            -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+            ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+            // Fed inputs first, then resident inputs (both must be listed in
+            // input_tiles; resident_tiles marks which are compute-resident)
+            spec.input_tiles = op.dependency_tiles;
+            for (const auto& r : op.resident_tiles) spec.input_tiles.push_back(r);
+            spec.resident_tiles = op.resident_tiles;
+            if (op.tile.tile_id.matrix == MatrixID::B) {
+                spec.operation = [](const std::vector<TilePayload>& in) {
+                    TilePayload out = in.at(0);            // stats: B = 2*A
+                    for (float& v : out.values) v *= 2.0f;
+                    return out;
+                };
+            } else {
+                spec.operation = [](const std::vector<TilePayload>& in) {
+                    TilePayload out = in.at(0);            // apply: C = B + 1
+                    for (float& v : out.values) v += 1.0f;
+                    return out;
+                };
+            }
+            return spec;
+        });
+
+    auto result = sched_exec.execute(schedule);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+
+    // C = 2*A + 1 = 11. If the apply compute had run before the stats
+    // compute completed, B's resident payload would have been absent and
+    // the functional op would have thrown - so a correct value here proves
+    // the resident dependency ordered the chain.
+    REQUIRE(executor.tile_payload_at(MemoryLevel::DRAM, {MatrixID::C, 0, 0, 0})
+                .values[0] == Catch::Approx(11.0f));
+}
+
+TEST_CASE("Resident-dependency schedule executes on the timing-only path",
+          "[timing][executor][resident]") {
+    auto schedule = build_schedule();
+    ConcurrentTimingExecutor::Config cfg; cfg.max_cycles = 1000000;
+    ConcurrentTimingExecutor executor(cfg);
+    ScheduleExecutor sched_exec(executor);   // no functional binder
+    auto result = sched_exec.execute(schedule);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+}


### PR DESCRIPTION
Fixes #155 — E8-T2 of the online-softmax epic (#77). The **load-bearing capability** of the epic, and the direct resolution of the delivery gap E3-T4 deferred.

## What

A COMPUTE can now declare **`resident_tiles`** — inputs it consumes from the compute fabric, produced by a *prior* COMPUTE, rather than via a fresh FEED.

- `ScheduleOperation::resident_tiles` + a `compute(tile, fed, resident)` factory.
- `ConcurrentTimingExecutor::schedule_compute(tile, feed, resident)` records them as resident dependencies (the #66 `completed_compute_counts` accounting) and marks the produced tile a possible resident source. The matmul and reduction paths are untouched.
- `ScheduleExecutor` routes COMPUTEs carrying `resident_tiles` to that overload; the `FunctionalComputeBinder` maps them onto `FunctionalComputeSpec::resident_tiles`.

**Why it matters:** a running-stat tile (online-softmax `(m, l)`, norm mean/var) now reaches the apply computes **ordered and race-free — no DRAM round-trip**. This is exactly what E3-T4 could not express (its DRAM round-trip raced in the value plane, so ROW_NORMALIZE's apply phase was deferred). Built once here, reused by softmax (E8), norms (E9), and the deferred reduction apply phase.

## Verification

- `test_resident_dependency`: the **functional path** proves the resident value reaches the consumer — `C = 2·A + 1 = 11` is only correct if the stats compute (`B = 2·A`) completed before the apply compute (`C = B + 1`) read `B` resident; had it raced, `B`'s payload would be absent and the op would throw. A **timing-only** case proves execution without a binder.
- Full suite: **107/107 pass**. Coverage: `softmax` design + isa_closure → done (**25/105**). Gates hold.
- Session log: `docs/sessions/2026-07-14_v0.9_e8_resident_dependency.md`

## T1 design refinement (documented)

No new behavioral ISA op: softmax on the behavioral tier is a *program* of existing VE_REDUCE + VE_ELEMENTWISE ops (the KernelCompiler already has a softmax compiler), not a single new op. The genuinely new capability is this schedule-tier resident dependency; the online-softmax rescale semantics live in the CSP binder (T3/T4). Scope reduced without loss.

Next: E8-T3 (#156) OnlineSoftmaxScheduleGenerator on this mechanism → T4 (#157) functional + safe-softmax oracle → T5 (#158) regression + single-pass-vs-multi-pass DRAM-traffic payoff, which closes epic #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compute operations can now consume tiles that remain resident in the compute fabric, reducing unnecessary DRAM transfers.
  * Scheduling preserves dependency order for resident inputs, supporting reliable multi-stage computations such as online softmax and normalization.
  * Added support for declaring resident inputs alongside standard fed dependencies.

* **Bug Fixes**
  * Improved execution safety by preventing ordering conflicts and data races when compute stages share resident results.

* **Tests**
  * Added timing coverage validating resident dependency execution with and without functional compute binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->