### PR TITLE
feat(schedule): OnlineSoftmaxScheduleGenerator (softmax-T3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OnlineSoftmaxScheduleGenerator (#156, epic E8).** Single-pass online
+  softmax schedules (pattern P3): a streaming stats pass (running max +
+  rescaled running sum) produces the `(m, l)` state, and the apply pass
+  emits `exp(x - m)/l` consuming that state as a **compute-resident
+  dependency** (the #155 mechanism) - no drain/reload, no DRAM round-trip
+  race, which is what distinguishes it from the reduction ROW_NORMALIZE.
+  Realization is chosen a priori from the envelope (ROW_RESIDENT delivers
+  the row once with `consumer_count=2`; RESTREAMED re-reads it), trailing
+  tiles are clamped, and every COMPUTE is executable. Supersedes the
+  4-pass `SoftmaxScheduleGenerator` and resolves #139 for softmax.
+  Coverage: softmax generator -> done (26/105).
+
 - **Schedule-tier compute-resident dependency mechanism (#155, epic E8).**
   A COMPUTE can now declare `resident_tiles` - inputs it consumes from the
   compute fabric, produced by a prior COMPUTE, rather than via a fresh

--- a/docs/sessions/2026-07-14_v0.9_e8_softmax_generator.md
+++ b/docs/sessions/2026-07-14_v0.9_e8_softmax_generator.md
@@ -1,0 +1,74 @@
+# v0.9 E8-T3: OnlineSoftmaxScheduleGenerator Decision Log
+
+**Date:** 2026-07-14
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 108/108 suites passing (new: test_softmax_generator, 4 cases /
+35 assertions)
+**Issues:** #156 (done)
+
+## 1. Summary
+
+Implemented E8-T3: the OnlineSoftmaxScheduleGenerator - single-pass online
+softmax where the running `(m, l)` state produced by the stats compute is
+handed to the apply computes as a compute-resident dependency (the #155
+mechanism), so the normalize reads it ordered and race-free with no DRAM
+round-trip. This is what E3's ROW_NORMALIZE could not do and is the
+online-softmax payoff.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| OnlineSoftmaxScheduleGenerator (stats pass + resident (m,l) apply) | Done |
+| Envelope-derived realization (ROW_RESIDENT / RESTREAMED) | Done |
+| Executable COMPUTEs; trailing-tile clamp | Done |
+| Structure tests (row-once vs re-read, resident apply count, refusal) | Done |
+| Execution tests (both realizations, batched, non-aligned) | Done |
+| Coverage: softmax generator -> done (26/105) | Done |
+
+Files:
+- `include/sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp` (new)
+- `tests/timing/test_softmax_generator.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: (m, l) rides the resident path, never DRAM.**
+- The stats COMPUTE produces the stat tile; the apply COMPUTEs list it in
+  `resident_tiles` (the #155 factory overload). No drain/writeback/store
+  of the stat, no reload, no store-before-load race. This is the concrete
+  first use of the T2 mechanism and the reason online softmax is correct
+  where the reduction ROW_NORMALIZE (DRAM round-trip) was deferred.
+
+**Decision 2: same realization + clamp discipline as E3.**
+- ROW_RESIDENT vs RESTREAMED chosen a priori from the envelope; trailing
+  tiles clamped (full-tile stride). Reuses the proven reduction-generator
+  structure; the only softmax-specific change is the resident stat
+  hand-off and the two-phase row consumption (consumer_count=2).
+
+## 4. Issues Encountered
+
+None. The resident mechanism from T2 carried the design directly.
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions identified this session.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                          # 108/108
+./build/tests/timing/test_softmax_generator     # 35 assertions
+./build/tests/coverage/test_pattern_coverage    # 26/105, gates hold
+```
+
+## 7. Next Steps
+
+- E8-T4 (#157): value-producing online softmax via the FunctionalCompute
+  binder (stats op = running max + rescaled sum producing [m, l]; apply op
+  = exp(x - m)/l reading the resident state), vs a host safe-softmax
+  oracle. Flips softmax.functional (M4 gate).
+- E8-T5 (#158): shape x envelope regression + single-pass-vs-multi-pass
+  DRAM-traffic comparison -> closes epic #77.

--- a/include/sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp
@@ -1,0 +1,280 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp
+// Online single-pass softmax schedule generator (issue #156, epic E8)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/schedule/elementwise_schedule_generator.hpp>  // emit_broadcast_tile
+#include <sw/kpu/timing/schedule/schedule_generator_interface.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief Online (single-pass) softmax schedule generator (pattern P3)
+ *
+ * softmax(x)_i = exp(x_i - m) / sum_j exp(x_j - m), m = max_j x_j. The
+ * online form computes m and the normalizer l = sum_j exp(x_j - m) in ONE
+ * streaming stats pass (running max with sum rescaling), then an apply
+ * pass emits exp(x - m)/l. The running (m, l) state produced by the stats
+ * COMPUTE is handed to the apply COMPUTEs as a compute-RESIDENT dependency
+ * (issue #155) - no drain/reload, no DRAM round-trip race - which is what
+ * distinguishes this from the reduction ROW_NORMALIZE (E3) and supersedes
+ * the 4-pass SoftmaxScheduleGenerator (resolving #139 for softmax).
+ *
+ * Realization is chosen a priori from the envelope (the #67 discipline):
+ *  - ROW_RESIDENT (reduction_tiles + 2 <= per-matrix burst share): the row
+ *    is delivered once with consumer_count=2 (fed for stats, fed again for
+ *    apply). DRAM traffic 1 read + 1 write per element - the payoff.
+ *  - RESTREAMED (otherwise): the row is re-read for the apply pass, so only
+ *    3 tiles are ever in flight. The (m, l) state rides the resident path
+ *    either way.
+ *
+ * Every emitted schedule is executable: COMPUTEs carry their full
+ * dependency sets (the #101 discipline).
+ */
+class OnlineSoftmaxScheduleGenerator : public IScheduleGenerator {
+public:
+    enum class Realization { ROW_RESIDENT, RESTREAMED };
+
+    struct Config {
+        Size num_rows = 1;            ///< Independent softmax rows (batch)
+        Size reduction_elems = 4096;  ///< Softmax dimension length per row
+        Size tile_elems = 256;        ///< Elements per tile
+
+        Size element_size = 4;
+
+        // Resource envelope (issue #90 discipline)
+        Size l3_buffer_count = 32;
+        Size l2_bank_count = 64;
+
+        Address in_base = 0;
+        Address stat_base = 0;
+        Address out_base = 0;
+
+        [[nodiscard]] Size reduction_tiles() const {
+            return (reduction_elems + tile_elems - 1) / tile_elems;
+        }
+        [[nodiscard]] Size max_burst_tiles() const {
+            return per_matrix_burst_share(l3_buffer_count, l2_bank_count);
+        }
+        [[nodiscard]] Realization realization() const {
+            return reduction_tiles() + 2 <= max_burst_tiles()
+                ? Realization::ROW_RESIDENT
+                : Realization::RESTREAMED;
+        }
+        /**
+         * @brief Peak tile residency
+         *
+         * ROW_RESIDENT holds the whole row resident across its two phases
+         * (reduction_tiles) plus an in-flight output; the (m, l) stat is
+         * compute-resident, not an L2 tile. RESTREAMED re-reads the row so
+         * only 3 tiles are ever in flight.
+         */
+        [[nodiscard]] Size required_working_set() const {
+            return realization() == Realization::ROW_RESIDENT
+                ? reduction_tiles() + 2
+                : 3;
+        }
+    };
+
+    explicit OnlineSoftmaxScheduleGenerator(const Config& config)
+        : config_(config) {}
+
+    ScheduleResult generate() override {
+        ScheduleResult result;
+        if (config_.num_rows == 0 || config_.reduction_elems == 0 ||
+            config_.tile_elems == 0) {
+            result.valid = false;
+            result.error_message = "Softmax dimensions must be non-zero";
+            return result;
+        }
+        if (config_.required_working_set() > config_.max_burst_tiles()) {
+            result.valid = false;
+            result.error_message =
+                "online softmax requires a working set of " +
+                std::to_string(config_.required_working_set()) +
+                " tiles but the resource envelope share is " +
+                std::to_string(config_.max_burst_tiles()) +
+                "; enlarge l3_buffer_count/l2_bank_count";
+            return result;
+        }
+
+        for (Size r = 0; r < config_.num_rows; ++r) {
+            if (config_.realization() == Realization::ROW_RESIDENT) {
+                emit_row_resident(result, r);
+            } else {
+                emit_restreamed(result, r);
+            }
+        }
+
+        stamp_metadata(result);
+        result.valid = true;
+        return result;
+    }
+
+    [[nodiscard]] std::string name() const override {
+        return "OnlineSoftmaxScheduleGenerator";
+    }
+    [[nodiscard]] std::string description() const override {
+        std::ostringstream ss;
+        ss << "OnlineSoftmax [" << config_.num_rows << "x"
+           << config_.reduction_elems << "] (" << strategy_name() << ")";
+        return ss.str();
+    }
+    [[nodiscard]] const Config& config() const { return config_; }
+
+private:
+    Config config_;
+
+    // ROW_RESIDENT: deliver each row tile once (consumer_count=2), stats
+    // COMPUTE produces (m, l), apply COMPUTEs consume the row tile's second
+    // feed plus the resident (m, l).
+    void emit_row_resident(ScheduleResult& result, Size row) {
+        const Size rt = config_.reduction_tiles();
+
+        std::vector<TileDescriptor> row_tiles;
+        row_tiles.reserve(rt);
+        for (Size t = 0; t < rt; ++t) {
+            auto in = make_input_tile(row, t);
+            in.consumer_count = 2;
+            result.operations.push_back(ScheduleOperation::load(in));
+            result.operations.push_back(ScheduleOperation::move(in));
+            row_tiles.push_back(in);
+        }
+
+        // Stats pass: one COMPUTE over the first consumption of every tile
+        std::vector<TileID> stat_deps;
+        stat_deps.reserve(rt);
+        for (const auto& in : row_tiles) {
+            result.operations.push_back(ScheduleOperation::feed(in));
+            stat_deps.push_back(in.tile_id);
+        }
+        auto stat = make_stat_tile(row);
+        result.operations.push_back(ScheduleOperation::compute(stat, std::move(stat_deps)));
+
+        // Apply pass: (m, l) stays RESIDENT - no drain/store/reload
+        for (Size t = 0; t < rt; ++t) {
+            result.operations.push_back(ScheduleOperation::feed(row_tiles[t]));
+            emit_apply(result, row, t, row_tiles[t].tile_id, stat.tile_id);
+        }
+    }
+
+    // RESTREAMED: stats pass on a fresh delivery, then re-read the row for
+    // the apply pass; (m, l) rides the resident path across both.
+    void emit_restreamed(ScheduleResult& result, Size row) {
+        const Size rt = config_.reduction_tiles();
+
+        std::vector<TileID> stat_deps;
+        stat_deps.reserve(rt);
+        for (Size t = 0; t < rt; ++t) {
+            auto in = make_input_tile(row, t);
+            result.operations.push_back(ScheduleOperation::load(in));
+            result.operations.push_back(ScheduleOperation::move(in));
+            result.operations.push_back(ScheduleOperation::feed(in));
+            stat_deps.push_back(in.tile_id);
+        }
+        auto stat = make_stat_tile(row);
+        result.operations.push_back(ScheduleOperation::compute(stat, std::move(stat_deps)));
+
+        for (Size t = 0; t < rt; ++t) {
+            auto in = make_input_tile(row, t);
+            result.operations.push_back(ScheduleOperation::load(in));
+            result.operations.push_back(ScheduleOperation::move(in));
+            result.operations.push_back(ScheduleOperation::feed(in));
+            emit_apply(result, row, t, in.tile_id, stat.tile_id);
+        }
+    }
+
+    // One normalized output tile: apply COMPUTE consuming the fed input and
+    // the resident (m, l), then drain/writeback/store.
+    void emit_apply(ScheduleResult& result, Size row, Size t,
+                    const TileID& in_id, const TileID& stat_id) {
+        auto out = make_output_tile(row, t);
+        result.operations.push_back(ScheduleOperation::compute(
+            out, /*fed*/ std::vector<TileID>{in_id},
+            /*resident*/ std::vector<TileID>{stat_id}));
+        result.operations.push_back(ScheduleOperation::drain(out));
+        result.operations.push_back(ScheduleOperation::writeback(out));
+        result.operations.push_back(ScheduleOperation::store(out));
+    }
+
+    TileDescriptor make_input_tile(Size row, Size t) const {
+        return make_tile(isa::MatrixID::A, row, t, config_.in_base);
+    }
+    TileDescriptor make_stat_tile(Size row) const {
+        return make_tile(isa::MatrixID::B, row, 0, config_.stat_base);
+    }
+    TileDescriptor make_output_tile(Size row, Size t) const {
+        return make_tile(isa::MatrixID::C, row, t, config_.out_base);
+    }
+
+    TileDescriptor make_tile(isa::MatrixID matrix, Size row, Size t,
+                             Address base) const {
+        TileDescriptor tile;
+        tile.tile_id.matrix = matrix;
+        tile.tile_id.ti = row;
+        tile.tile_id.tj = t;
+        tile.tile_id.tk = 0;
+
+        // A/C tiles span the reduction dim: clamp the trailing partial tile
+        // (full-tile stride preserved). Stat tiles (B) are one per row.
+        Size elems = config_.tile_elems;
+        if (matrix != isa::MatrixID::B) {
+            const Size within_row = t * config_.tile_elems;
+            if (within_row + elems > config_.reduction_elems) {
+                elems = config_.reduction_elems - within_row;
+            }
+        }
+        tile.height = elems;
+        tile.width = 1;
+        tile.element_size = config_.element_size;
+        tile.size_bytes = elems * config_.element_size;
+
+        const Size full_bytes = config_.tile_elems * config_.element_size;
+        const Size linear = matrix == isa::MatrixID::B
+            ? row
+            : row * config_.reduction_tiles() + t;
+        tile.dram_address = base + linear * full_bytes;
+        tile.matrix_base_address = base;
+        return tile;
+    }
+
+    void stamp_metadata(ScheduleResult& result) const {
+        const Size rt = config_.reduction_tiles();
+        result.metadata.name = generate_name();
+        result.metadata.generator = name();
+        result.metadata.M = config_.num_rows;
+        result.metadata.N = config_.reduction_elems;
+        result.metadata.K = 1;
+        result.metadata.Ti = config_.tile_elems;
+        result.metadata.Tj = 1;
+        result.metadata.Tk = 1;
+        result.metadata.a_tiles = config_.num_rows * rt;
+        result.metadata.b_tiles = config_.num_rows;   // one (m,l) per row
+        result.metadata.c_tiles = config_.num_rows * rt;
+        result.metadata.strategy = strategy_name();
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
+    }
+
+    std::string strategy_name() const {
+        return config_.realization() == Realization::ROW_RESIDENT
+            ? "online_row_resident" : "online_restreamed";
+    }
+    std::string generate_name() const {
+        std::ostringstream ss;
+        ss << "online_softmax_" << config_.num_rows << "x"
+           << config_.reduction_elems << "_" << strategy_name();
+        return ss.str();
+    }
+};
+
+} // namespace sw::kpu::timing::schedule

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -117,11 +117,11 @@
       "stages": {
         "design": "done",
         "isa_closure": "done",
-        "generator": "partial",
+        "generator": "done",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "Online single-pass softmax design: running max + rescaled sum, row-resident apply, schedule-tier resident-dependency mechanism (#154). isa_closure: ScheduleOperation::resident_tiles + ConcurrentTimingExecutor::schedule_compute(tile,feed,resident) + ScheduleExecutor routing + binder mapping - apply computes consume the running (m,l) state compute-resident, no DRAM round-trip race (#155). Generator/functional/regression are E8-T3/T4/T5; supersedes the 4-pass SoftmaxScheduleGenerator."
+      "notes": "Online single-pass softmax (#154 design, #155 resident-dep mechanism); OnlineSoftmaxScheduleGenerator: stats pass (running max+rescaled sum) + apply pass with (m,l) handed resident to the apply computes (no DRAM round-trip), row-resident/re-streamed realization, executable COMPUTEs, trailing-tile clamp (#156). Supersedes 4-pass generator; resolves #139 for softmax. Functional/regression are E8-T4/T5."
     },
     {
       "name": "layernorm",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -188,3 +188,13 @@ kpu_add_component_test(test_resident_dependency "timing"
 set_tests_properties(test_resident_dependency PROPERTIES
     LABELS "timing;executor;resident;v0.9"
 )
+
+# Online softmax schedule generator (issue #156, epic E8): single-pass
+# stats + resident (m,l) apply, row-resident / re-streamed realization
+kpu_add_component_test(test_softmax_generator "timing"
+    test_softmax_generator.cpp
+)
+
+set_tests_properties(test_softmax_generator PROPERTIES
+    LABELS "timing;schedule;softmax;v0.9"
+)

--- a/tests/timing/test_softmax_generator.cpp
+++ b/tests/timing/test_softmax_generator.cpp
@@ -1,0 +1,141 @@
+// ============================================================================
+// tests/timing/test_softmax_generator.cpp
+// OnlineSoftmaxScheduleGenerator structure + execution (issue #156, epic E8)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+using Realization = OnlineSoftmaxScheduleGenerator::Realization;
+
+OnlineSoftmaxScheduleGenerator::Config base_config() {
+    OnlineSoftmaxScheduleGenerator::Config c;
+    c.num_rows = 1;
+    c.reduction_elems = 1024;   // 4 tiles
+    c.tile_elems = 256;
+    c.in_base = 0x100000;
+    c.stat_base = 0x200000;
+    c.out_base = 0x300000;
+    return c;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.max_cycles = 2'000'000;
+    return config;
+}
+
+size_t count_resident_computes(const ScheduleResult& s) {
+    size_t n = 0;
+    for (const auto& op : s.operations) {
+        if (op.type == ScheduleOpType::COMPUTE && !op.resident_tiles.empty()) ++n;
+    }
+    return n;
+}
+
+} // namespace
+
+TEST_CASE("Online softmax ROW_RESIDENT delivers the row once, apply resident",
+          "[timing][schedule][softmax]") {
+    auto config = base_config();
+    REQUIRE(config.realization() == Realization::ROW_RESIDENT);
+    OnlineSoftmaxScheduleGenerator gen(config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    const Size rt = config.reduction_tiles();  // 4
+    // Row delivered once (rt loads); NO stat load (it stays resident)
+    REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == rt);
+    // Stats feeds (rt) + apply feeds (rt)
+    REQUIRE(schedule.count_ops(ScheduleOpType::FEED) == 2 * rt);
+    // 1 stats compute + rt apply computes
+    REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) == 1 + rt);
+    // Every apply compute carries a resident (m,l) dependency
+    REQUIRE(count_resident_computes(schedule) == rt);
+    REQUIRE(schedule.count_ops(ScheduleOpType::STORE) == rt);   // outputs only
+}
+
+TEST_CASE("Online softmax RESTREAMED re-reads the row, apply still resident",
+          "[timing][schedule][softmax][envelope]") {
+    auto config = base_config();
+    config.reduction_elems = 4096;   // rt=16
+    config.l3_buffer_count = 16;     // share = 4 < rt+2 -> RESTREAMED
+    config.l2_bank_count = 16;
+    REQUIRE(config.realization() == Realization::RESTREAMED);
+    OnlineSoftmaxScheduleGenerator gen(config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    const Size rt = config.reduction_tiles();
+    REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) == 2 * rt);   // row read twice
+    REQUIRE(count_resident_computes(schedule) == rt);             // apply resident
+}
+
+TEST_CASE("Online softmax refuses a degenerate envelope",
+          "[timing][schedule][softmax][envelope]") {
+    auto config = base_config();
+    config.reduction_elems = 4096;   // rt=16, restreamed needs share>=3
+    config.l3_buffer_count = 8;      // share = 2 < 3
+    config.l2_bank_count = 8;
+    auto schedule = OnlineSoftmaxScheduleGenerator(config).generate();
+    REQUIRE_FALSE(schedule.valid);
+    REQUIRE(schedule.error_message.find("working set") != std::string::npos);
+}
+
+TEST_CASE("Online softmax schedules execute to completion",
+          "[timing][executor][regression][softmax]") {
+    auto run = [](const OnlineSoftmaxScheduleGenerator::Config& config) {
+        OnlineSoftmaxScheduleGenerator gen(config);
+        auto schedule = gen.generate();
+        REQUIRE(schedule.valid);
+
+        ConcurrentTimingExecutor executor(make_executor_config());
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(schedule);
+
+        INFO("strategy=" << schedule.metadata.strategy
+             << " cycles=" << result.total_cycles
+             << " error=" << result.error_message);
+        REQUIRE(result.success);
+        REQUIRE_FALSE(result.livelock_detected);
+
+        auto stats = executor.get_statistics();
+        REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+        REQUIRE(stats.tiles_drained == schedule.count_ops(ScheduleOpType::DRAIN));
+    };
+
+    SECTION("row-resident, single row") {
+        auto c = base_config();
+        REQUIRE(c.realization() == Realization::ROW_RESIDENT);
+        run(c);
+    }
+    SECTION("row-resident, batched rows") {
+        auto c = base_config();
+        c.num_rows = 3;
+        run(c);
+    }
+    SECTION("restreamed, large row") {
+        auto c = base_config();
+        c.reduction_elems = 4096;
+        c.l3_buffer_count = 16;
+        c.l2_bank_count = 16;
+        REQUIRE(c.realization() == Realization::RESTREAMED);
+        run(c);
+    }
+    SECTION("non-aligned row") {
+        auto c = base_config();
+        c.reduction_elems = 1000;   // 4 tiles, 232 tail
+        run(c);
+    }
+}


### PR DESCRIPTION
Fixes #156 — E8-T3 of the online-softmax epic (#77). The first real use of the #155 resident-dependency mechanism.

## What

Single-pass online softmax schedules (pattern P3):

- **Stats pass** streams the row and one COMPUTE produces the running `(m, l)` state (running max + rescaled running sum).
- **Apply pass** emits `exp(x − m)/l`, consuming `(m, l)` as a **compute-resident dependency** (the #155 `resident_tiles`) — no drain/writeback/store of the stat, no reload, **no store-before-load race**. This is exactly what E3's ROW_NORMALIZE (DRAM round-trip) could not do, and the reason online softmax is correct where that was deferred.
- **Realization chosen a priori** from the envelope: `ROW_RESIDENT` delivers the row once with `consumer_count=2` (fed for stats, fed again for apply — the online-softmax DRAM payoff, 1 read + 1 write per element); `RESTREAMED` re-reads the row for the apply pass. Trailing tiles clamped, every COMPUTE executable.
- Supersedes the 4-pass `SoftmaxScheduleGenerator` and **resolves #139 for softmax**.

## Verification

- Structure tests: row-delivered-once vs read-twice, resident-apply count (every apply COMPUTE carries an `(m,l)` resident dep), a-priori refusal.
- Execution tests: both realizations, batched rows, non-aligned row — all run to completion with matching feed/drain accounting.
- Full suite: **108/108 pass**. Coverage: `softmax` generator → done (**26/105**). Gates hold.
- Session log: `docs/sessions/2026-07-14_v0.9_e8_softmax_generator.md`

Next: E8-T4 (#157) — value-producing online softmax (stats op = running max + rescaled sum; apply op = `exp(x−m)/l` reading the resident state) vs a host safe-softmax oracle, flipping `softmax.functional` (M4 gate) → T5 (#158) regression + single-pass-vs-multi-pass DRAM-traffic payoff, which closes epic #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an online, single-pass softmax schedule that keeps intermediate statistics resident for efficient normalization.
  * Supports both row-resident and restreamed execution based on available resources.
  * Handles tiled inputs, partial trailing tiles, batched rows, and resource validation.

* **Bug Fixes**
  * Improved softmax scheduling coverage and validated execution across multiple configuration scenarios.

* **Documentation**
  * Added release notes and a decision log describing the new softmax approach, verification results, and follow-up milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->