### PR TITLE
feat(timing): value-producing online softmax + host oracle (softmax-T4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Value-producing online softmax + host oracle (#157, epic E8).**
+  `FunctionalSoftmaxExecutor` bridges the #156 generator to the #66 payload
+  machinery: input tiles ride the real CSP data path, the stats COMPUTE
+  produces the `(m, l)` state, the apply COMPUTEs consume it
+  **compute-resident** (the #155 mechanism, no DRAM round-trip) and emit
+  `exp(x - m)/l`. Verified elementwise against an independent host
+  safe-softmax oracle across single/batched rows, large logits (numerically
+  stable, no inf/NaN), non-aligned rows, partitioned credits, and the
+  RESTREAMED realization. The design-review edge cases are pinned: a fully
+  masked all-`-inf` row yields the uniform distribution, and an all-`-inf`
+  prefix followed by finite values produces no NaN (the `m == -inf` guard).
+  Flips `softmax.functional` (an M4 gate cell, 27/105).
+
 - **OnlineSoftmaxScheduleGenerator (#156, epic E8).** Single-pass online
   softmax schedules (pattern P3): a streaming stats pass (running max +
   rescaled running sum) produces the `(m, l)` state, and the apply pass

--- a/docs/sessions/2026-07-14_v0.9_e8_softmax_functional.md
+++ b/docs/sessions/2026-07-14_v0.9_e8_softmax_functional.md
@@ -1,0 +1,85 @@
+# v0.9 E8-T4: Functional Online Softmax + Oracle Decision Log
+
+**Date:** 2026-07-14
+**Version:** v0.9
+**Status:** Complete
+**Tests:** 109/109 suites passing (new: test_functional_softmax, 6 cases /
+17146 assertions)
+**Issues:** #157 (done)
+
+## 1. Summary
+
+Implemented E8-T4: value-producing online softmax on the CSP executor,
+verified against an independent host safe-softmax oracle. The stats
+COMPUTE produces the (m, l) state; the apply COMPUTEs consume it
+compute-resident (the #155 mechanism) and emit exp(x - m)/l. The
+design-review edge cases (all-(-inf) -> uniform, -inf prefix -> no NaN)
+are pinned.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| FunctionalSoftmaxExecutor (seed / bind stats+apply / gather) | Done |
+| softmax_stats (m + l, m==-inf guard) and softmax_apply (exp(x-m)/l, uniform on l==0) | Done |
+| Host safe-softmax oracle regression (6 cases, 17146 assertions) | Done |
+| Edge cases: fully masked -> uniform; masked prefix -> finite/no NaN | Done |
+| Coverage: softmax functional -> done (27/105) | Done |
+
+Files:
+- `include/sw/kpu/timing/schedule/functional_softmax_executor.hpp` (new)
+- `tests/timing/test_functional_softmax.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: two-accumulator safe form, not the streaming rescale.**
+- The stats COMPUTE receives every row tile at once (it depends on all
+  feeds), so it computes m = global max then l = sum exp(x - m) directly -
+  mathematically identical to the streaming running-max-with-rescale, and
+  simpler. The rescale is only needed for TRUE one-tile-at-a-time
+  streaming (flash attention, E12); the standalone materialized-row form
+  here does not need it. The design's rescale recurrence still documents
+  the semantics and E12's fusion.
+
+**Decision 2: the m == -inf guard (design-review fix) is in the kernel.**
+- softmax_stats leaves l = 0 when the row max is -inf rather than
+  evaluating exp(-inf - -inf) = NaN; softmax_apply emits uniform 1/N when
+  l == 0. Both the fully-masked row and the masked-prefix case are tested
+  and produce finite, correct output - validating the exact bug CodeRabbit
+  caught on the design PR (#159) is absent from the implementation.
+
+**Decision 3: independent oracle.**
+- The test oracle is a separate host loop, not the executor kernels, so a
+  semantic error cannot match itself. Relative tolerance (exp/division
+  amplify fp error).
+
+## 4. Issues Encountered
+
+None. The resident-dep mechanism (T2) and generator (T3) carried the
+implementation directly; the corrected edge-case semantics from the #159
+review resolution were implemented as specified.
+
+## 5. Wrong Decisions (CRITICAL)
+
+The relevant wrong decision this session was procedural and already
+corrected: earlier I merged the T1 design PR (#159) without resolving its
+reviews, which had flagged the -inf/NaN and empty-vs-all-inf issues. That
+was fixed (PR #162, all threads resolved) and a standing rule recorded
+(resolve reviews before every merge). This T4 implements the corrected
+semantics and its own reviews will be resolved before merge.
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                           # 109/109
+./build/tests/timing/test_functional_softmax     # 17146 assertions
+./build/tests/coverage/test_pattern_coverage     # 27/105, gates hold
+```
+
+## 7. Next Steps
+
+- E8-T5 (#158): shape x envelope regression + credit/stall invariants +
+  single-pass-vs-multi-pass DRAM-traffic comparison (the payoff);
+  characterization on the epic -> closes epic #77.

--- a/include/sw/kpu/timing/schedule/functional_softmax_executor.hpp
+++ b/include/sw/kpu/timing/schedule/functional_softmax_executor.hpp
@@ -1,0 +1,185 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/functional_softmax_executor.hpp
+// Value-producing online softmax on the CSP timing model (issue #157)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief Stats op: reduce the row's tiles to the (m, l) softmax state
+ *
+ * m = max over the row, l = sum_j exp(x_j - m). The stats COMPUTE receives
+ * every row tile at once, so the mathematically-equivalent two-accumulator
+ * safe form is used (no streaming rescale needed). The m == -inf guard (an
+ * all-(-inf) / fully-masked row) leaves l = 0 rather than evaluating
+ * exp(-inf - -inf) = NaN; the apply then emits a uniform distribution.
+ * Result rides lanes [m, l] of a 2-element payload.
+ */
+inline TilePayload softmax_stats(const std::vector<TilePayload>& inputs) {
+    double m = -std::numeric_limits<double>::infinity();
+    for (const auto& tile : inputs) {
+        for (float v : tile.values) if (v > m) m = v;
+    }
+    double l = 0.0;
+    if (m > -std::numeric_limits<double>::infinity()) {
+        for (const auto& tile : inputs) {
+            for (float v : tile.values) l += std::exp(static_cast<double>(v) - m);
+        }
+    }
+    return TilePayload{2, 1, {static_cast<float>(m), static_cast<float>(l)}};
+}
+
+/**
+ * @brief Apply op: normalize one row tile with the resident (m, l)
+ *
+ * inputs = [ x_tile (fed), (m, l) state (resident) ]. Emits
+ * exp(x - m)/l elementwise, or the uniform 1/row_elems when l == 0
+ * (nonempty all-(-inf) row).
+ */
+inline TilePayload softmax_apply(const std::vector<TilePayload>& inputs,
+                                 Size row_elems) {
+    if (inputs.size() < 2) {
+        throw std::invalid_argument("softmax apply needs the tile and the (m,l) state");
+    }
+    const auto& x = inputs[0];
+    const float m = inputs[1].values.at(0);
+    const float l = inputs[1].values.at(1);
+    TilePayload out{x.rows, x.cols, std::vector<float>(x.values.size())};
+    if (l > 0.0f) {
+        for (size_t i = 0; i < x.values.size(); ++i) {
+            out.values[i] = std::exp(x.values[i] - m) / l;
+        }
+    } else {
+        const float uniform = 1.0f / static_cast<float>(row_elems);
+        for (float& v : out.values) v = uniform;
+    }
+    return out;
+}
+
+/**
+ * @brief Value-producing online softmax over the real CSP data path
+ *
+ * Bridges the #156 OnlineSoftmaxScheduleGenerator to the #66 payload
+ * machinery: the stats COMPUTE produces the (m, l) state, which the apply
+ * COMPUTEs consume as a compute-RESIDENT dependency (the #155 mechanism) -
+ * no DRAM round-trip - and each apply emits its normalized output tile.
+ * Verified elementwise against a host safe-softmax oracle in the tests.
+ */
+class FunctionalSoftmaxExecutor {
+public:
+    struct Result {
+        ExecutionResult execution;      ///< Timing/completion status
+        std::vector<float> values;      ///< num_rows x reduction_elems softmax output
+    };
+
+    FunctionalSoftmaxExecutor(OnlineSoftmaxScheduleGenerator::Config generator_config,
+                              ConcurrentTimingExecutor::Config executor_config = {})
+        : generator_config_(std::move(generator_config)),
+          executor_config_(std::move(executor_config)) {}
+
+    Result run(const std::vector<float>& data) {
+        const auto& cfg = generator_config_;
+        if (data.size() != static_cast<size_t>(cfg.num_rows) * cfg.reduction_elems) {
+            throw std::invalid_argument(
+                "input size does not match num_rows x reduction_elems");
+        }
+
+        OnlineSoftmaxScheduleGenerator generator(cfg);
+        auto schedule = generator.generate();
+
+        Result result;
+        if (!schedule.valid) {
+            result.execution.error_message =
+                "Schedule generation refused: " + schedule.error_message;
+            return result;
+        }
+
+        ConcurrentTimingExecutor executor(executor_config_);
+        seed_input_payloads(executor, schedule, data);
+
+        ScheduleExecutor sched_exec(executor);
+        const Size row_elems = cfg.reduction_elems;
+        sched_exec.set_functional_compute_binder(
+            [row_elems](const ScheduleOperation& op)
+                -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+                ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+                // Fed inputs first, then the resident (m,l) state
+                spec.input_tiles = op.dependency_tiles;
+                for (const auto& r : op.resident_tiles) spec.input_tiles.push_back(r);
+                spec.resident_tiles = op.resident_tiles;
+                if (op.tile.tile_id.matrix == isa::MatrixID::B) {
+                    spec.operation = softmax_stats;                    // (m, l)
+                } else {
+                    spec.operation = [row_elems](const std::vector<TilePayload>& in) {
+                        return softmax_apply(in, row_elems);            // exp(x-m)/l
+                    };
+                }
+                return spec;
+            });
+
+        result.execution = sched_exec.execute(schedule);
+        if (result.execution.success) {
+            result.values = gather_output(executor, schedule);
+        }
+        return result;
+    }
+
+private:
+    OnlineSoftmaxScheduleGenerator::Config generator_config_;
+    ConcurrentTimingExecutor::Config executor_config_;
+
+    void seed_input_payloads(ConcurrentTimingExecutor& executor,
+                             const ScheduleResult& schedule,
+                             const std::vector<float>& data) const {
+        const Size te = generator_config_.tile_elems;
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::LOAD) continue;
+            const auto& tile = op.tile;
+            if (tile.tile_id.matrix != isa::MatrixID::A) continue;  // input only
+            const Size row = tile.tile_id.ti;
+            const Size t = tile.tile_id.tj;
+            const Size offset = row * generator_config_.reduction_elems + t * te;
+            const Size elems = tile.height;
+            TilePayload payload{elems, 1,
+                                std::vector<float>(data.begin() + offset,
+                                                   data.begin() + offset + elems)};
+            executor.set_tile_payload(tile.tile_id, std::move(payload));
+        }
+    }
+
+    std::vector<float> gather_output(const ConcurrentTimingExecutor& executor,
+                                     const ScheduleResult& schedule) const {
+        const Size te = generator_config_.tile_elems;
+        std::vector<float> out(
+            static_cast<size_t>(generator_config_.num_rows) *
+            generator_config_.reduction_elems, 0.0f);
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::STORE) continue;
+            const auto& tile = op.tile;
+            if (tile.tile_id.matrix != isa::MatrixID::C) continue;
+            const auto& payload =
+                executor.tile_payload_at(MemoryLevel::DRAM, tile.tile_id);
+            const Size offset = tile.tile_id.ti * generator_config_.reduction_elems +
+                                tile.tile_id.tj * te;
+            std::copy(payload.values.begin(), payload.values.end(),
+                      out.begin() + offset);
+        }
+        return out;
+    }
+};
+
+} // namespace sw::kpu::timing::schedule

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -118,10 +118,10 @@
         "design": "done",
         "isa_closure": "done",
         "generator": "done",
-        "functional": "missing",
+        "functional": "done",
         "regression": "missing"
       },
-      "notes": "Online single-pass softmax (#154 design, #155 resident-dep mechanism); OnlineSoftmaxScheduleGenerator: stats pass (running max+rescaled sum) + apply pass with (m,l) handed resident to the apply computes (no DRAM round-trip), row-resident/re-streamed realization, executable COMPUTEs, trailing-tile clamp (#156). Supersedes 4-pass generator; resolves #139 for softmax. Functional/regression are E8-T4/T5."
+      "notes": "Online single-pass softmax (#154 design, #155 resident-dep, #156 generator); FunctionalSoftmaxExecutor value-produces softmax vs host safe-softmax oracle - stats op (m,l) handed to apply computes compute-resident, numerically stable (max-subtracted), edge cases (all-(-inf)->uniform, -inf prefix, non-aligned, partitioned, restreamed) verified (#157). Supersedes 4-pass generator; resolves #139 for softmax. Regression is E8-T5."
     },
     {
       "name": "layernorm",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -198,3 +198,13 @@ kpu_add_component_test(test_softmax_generator "timing"
 set_tests_properties(test_softmax_generator PROPERTIES
     LABELS "timing;schedule;softmax;v0.9"
 )
+
+# Functional online softmax with host oracle (issue #157, epic E8):
+# value-producing single-pass softmax on the CSP data path
+kpu_add_component_test(test_functional_softmax "timing"
+    test_functional_softmax.cpp
+)
+
+set_tests_properties(test_functional_softmax PROPERTIES
+    LABELS "timing;functional;softmax;v0.9"
+)

--- a/tests/timing/test_functional_softmax.cpp
+++ b/tests/timing/test_functional_softmax.cpp
@@ -1,0 +1,188 @@
+// ============================================================================
+// tests/timing/test_functional_softmax.cpp
+// Value-producing online softmax on the CSP executor, verified against an
+// independent host safe-softmax oracle (issue #157, epic E8).
+//
+// The oracle is a plain host loop, separate from the executor kernels, so a
+// semantic error cannot match itself. Edge cases (all-(-inf) rows, an
+// all-(-inf) prefix) are pinned per the T1 design.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <sw/kpu/timing/schedule/functional_softmax_executor.hpp>
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+OnlineSoftmaxScheduleGenerator::Config make_config(Size num_rows, Size reduction_elems) {
+    OnlineSoftmaxScheduleGenerator::Config c;
+    c.num_rows = num_rows;
+    c.reduction_elems = reduction_elems;
+    c.tile_elems = 256;
+    c.in_base = 0x100000;
+    c.stat_base = 0x200000;
+    c.out_base = 0x300000;
+    return c;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.max_cycles = 2'000'000;
+    return config;
+}
+
+// Independent host safe-softmax over each row of a num_rows x re tensor
+std::vector<float> host_softmax(const std::vector<float>& data, Size rows, Size re) {
+    std::vector<float> out(data.size());
+    const float ninf = -std::numeric_limits<float>::infinity();
+    for (Size r = 0; r < rows; ++r) {
+        const Size base = r * re;
+        double m = -std::numeric_limits<double>::infinity();
+        for (Size i = 0; i < re; ++i) m = std::max(m, static_cast<double>(data[base + i]));
+        double l = 0.0;
+        if (m > -std::numeric_limits<double>::infinity())
+            for (Size i = 0; i < re; ++i) l += std::exp(static_cast<double>(data[base + i]) - m);
+        for (Size i = 0; i < re; ++i) {
+            out[base + i] = (l > 0.0)
+                ? static_cast<float>(std::exp(static_cast<double>(data[base + i]) - m) / l)
+                : 1.0f / static_cast<float>(re);
+        }
+    }
+    (void)ninf;
+    return out;
+}
+
+void require_softmax_match(const std::vector<float>& actual,
+                           const std::vector<float>& expected) {
+    REQUIRE(actual.size() == expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        INFO("element " << i);
+        REQUIRE(actual[i] == Catch::Approx(expected[i]).epsilon(1e-5).margin(1e-6));
+    }
+}
+
+std::vector<float> ramp(Size n, float base, float step) {
+    std::vector<float> v(n);
+    for (Size i = 0; i < n; ++i) v[i] = base + step * static_cast<float>(i);
+    return v;
+}
+
+} // namespace
+
+TEST_CASE("Online softmax matches the host oracle (single row)",
+          "[timing][functional][softmax]") {
+    const Size n = 1024;   // 4 tiles
+    auto data = ramp(n, -2.0f, 0.005f);
+
+    FunctionalSoftmaxExecutor exec(make_config(1, n), make_executor_config());
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+    REQUIRE_FALSE(result.execution.livelock_detected);
+
+    auto expected = host_softmax(data, 1, n);
+    require_softmax_match(result.values, expected);
+
+    // Softmax sums to 1 across the row
+    double sum = 0.0; for (float v : result.values) sum += v;
+    REQUIRE(sum == Catch::Approx(1.0).epsilon(1e-4));
+}
+
+TEST_CASE("Online softmax is numerically stable for large logits",
+          "[timing][functional][softmax]") {
+    const Size n = 512;
+    std::vector<float> data(n);
+    for (Size i = 0; i < n; ++i) data[i] = 50.0f + static_cast<float>(i % 13);  // large
+
+    FunctionalSoftmaxExecutor exec(make_config(1, n), make_executor_config());
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+    // No inf/NaN despite exp of large logits (max-subtraction)
+    for (float v : result.values) REQUIRE(std::isfinite(v));
+    require_softmax_match(result.values, host_softmax(data, 1, n));
+}
+
+TEST_CASE("Online softmax per-row over a batch",
+          "[timing][functional][softmax]") {
+    const Size rows = 4, re = 1024;
+    std::vector<float> data(rows * re);
+    for (Size r = 0; r < rows; ++r)
+        for (Size i = 0; i < re; ++i)
+            data[r * re + i] = static_cast<float>(r) - 1.0f + 0.003f * static_cast<float>(i);
+
+    FunctionalSoftmaxExecutor exec(make_config(rows, re), make_executor_config());
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+    require_softmax_match(result.values, host_softmax(data, rows, re));
+}
+
+TEST_CASE("Online softmax non-aligned row",
+          "[timing][functional][softmax]") {
+    const Size n = 1000;   // 4 tiles, 232 tail
+    auto data = ramp(n, -1.0f, 0.007f);
+    FunctionalSoftmaxExecutor exec(make_config(1, n), make_executor_config());
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+    require_softmax_match(result.values, host_softmax(data, 1, n));
+}
+
+TEST_CASE("Online softmax under partitioned credits and restreamed realization",
+          "[timing][functional][softmax][partition]") {
+    const Size n = 4096;   // 16 tiles
+    auto data = ramp(n, 0.0f, 0.001f);
+
+    SECTION("partitioned credits") {
+        auto ec = make_executor_config();
+        ec.partition_l3_credits = true; ec.partition_l2_credits = true;
+        FunctionalSoftmaxExecutor exec(make_config(1, n), ec);
+        auto result = exec.run(data);
+        REQUIRE(result.execution.success);
+        require_softmax_match(result.values, host_softmax(data, 1, n));
+    }
+    SECTION("restreamed realization (constrained envelope)") {
+        auto config = make_config(1, n);
+        config.l3_buffer_count = 16; config.l2_bank_count = 16;
+        REQUIRE(config.realization() ==
+                OnlineSoftmaxScheduleGenerator::Realization::RESTREAMED);
+        FunctionalSoftmaxExecutor exec(config, make_executor_config());
+        auto result = exec.run(data);
+        REQUIRE(result.execution.success);
+        require_softmax_match(result.values, host_softmax(data, 1, n));
+    }
+}
+
+TEST_CASE("Online softmax edge cases: all -inf and -inf prefix",
+          "[timing][functional][softmax][edge]") {
+    const Size n = 512;
+    const float ninf = -std::numeric_limits<float>::infinity();
+
+    SECTION("fully masked row -> uniform") {
+        std::vector<float> data(n, ninf);
+        FunctionalSoftmaxExecutor exec(make_config(1, n), make_executor_config());
+        auto result = exec.run(data);
+        REQUIRE(result.execution.success);
+        const float uniform = 1.0f / static_cast<float>(n);
+        for (float v : result.values) REQUIRE(v == Catch::Approx(uniform));
+    }
+    SECTION("masked prefix then finite values (no NaN poisoning)") {
+        std::vector<float> data(n, ninf);
+        for (Size i = n / 2; i < n; ++i) data[i] = 0.01f * static_cast<float>(i);
+        FunctionalSoftmaxExecutor exec(make_config(1, n), make_executor_config());
+        auto result = exec.run(data);
+        REQUIRE(result.execution.success);
+        for (float v : result.values) REQUIRE(std::isfinite(v));
+        require_softmax_match(result.values, host_softmax(data, 1, n));
+        // masked positions contribute ~0 probability
+        for (Size i = 0; i < n / 2; ++i) REQUIRE(result.values[i] == Catch::Approx(0.0f).margin(1e-6));
+    }
+}


### PR DESCRIPTION
Fixes #157 — E8-T4 of the online-softmax epic (#77). Flips `softmax.functional`, an **M4 attention-gate cell**. Implements the edge-case semantics corrected in the #159 review resolution.

## What

- **`FunctionalSoftmaxExecutor`** value-produces online softmax: input tiles ride the real CSP path, the stats COMPUTE produces the `(m, l)` state, and the apply COMPUTEs consume it **compute-resident** (the #155 mechanism — no DRAM round-trip) and emit `exp(x − m)/l`.
- **`softmax_stats`** uses the two-accumulator safe form (`m` = global max, then `l = Σexp(x − m)`) — the stats compute receives all row tiles at once, so this is mathematically identical to the streaming running-max-with-rescale and simpler (the rescale is only needed for true one-tile streaming, i.e. flash attention / E12). The `m == −∞` guard leaves `l = 0` rather than evaluating `exp(−∞ − −∞) = NaN`; `softmax_apply` emits uniform `1/N` when `l == 0`.

## Verification

- Independent host safe-softmax oracle (plain host loop, not the executor kernels): single/batched rows, **large logits** (finite, no inf/NaN — max-subtraction works), non-aligned rows, partitioned credits, RESTREAMED realization, and the two **design-review edge cases** — fully-masked all-`−∞` row → uniform, and a masked `−∞` prefix → finite output with no NaN poisoning (validating the exact bug CodeRabbit caught is absent). **17,146 assertions.**
- Full suite: **109/109 pass**. Coverage: `softmax` functional → done (**27/105**). Gates hold.
- Session log: `docs/sessions/2026-07-14_v0.9_e8_softmax_functional.md`

Next: E8-T5 (#158) — shape × envelope regression + single-pass-vs-multi-pass DRAM-traffic payoff, which closes epic #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a value-producing online softmax workflow with numerically stable outputs.
  * Supports multi-row inputs, non-aligned row sizes, large logits, and partitioned execution.
  * Defines safe behavior for fully masked rows and masked prefixes, avoiding NaN results.

* **Bug Fixes**
  * Added safeguards for edge cases involving all-`-inf` values and zero normalization factors.

* **Tests**
  * Added comprehensive validation against host-side softmax, including normalization, finiteness, and execution checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->