### PR TITLE
test(timing): online softmax regression matrix + DRAM payoff (softmax-T5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Online softmax regression matrix + DRAM-traffic payoff (#158, epic E8
+  COMPLETE).** `test_softmax_regression` executes the shape x envelope
+  matrix with invariants stronger than completion (exact per-stage tile
+  accounting, full credit conservation in both credit modes, normalized
+  stall bound), a functional-under-pressure check (exact softmax values at
+  the minimum envelope under partitioned credits), and the
+  single-pass-vs-multi-pass **DRAM-read comparison**: for a 4-tile row the
+  online generator reads the row once (LOAD=4) versus the 4-pass
+  safe-softmax's LOAD=16 - **4x fewer reads**, the online-softmax payoff.
+  `softmax` is now the fifth operator complete across all five lifecycle
+  stages after matmul, elementwise, broadcast, and online_reduction
+  (28/105). Closes epic #77.
+
 - **Value-producing online softmax + host oracle (#157, epic E8).**
   `FunctionalSoftmaxExecutor` bridges the #156 generator to the #66 payload
   machinery: input tiles ride the real CSP data path, the stats COMPUTE

--- a/docs/sessions/2026-07-14_v0.9_e8_softmax_regression.md
+++ b/docs/sessions/2026-07-14_v0.9_e8_softmax_regression.md
@@ -1,0 +1,84 @@
+# v0.9 E8-T5: Online Softmax Regression Matrix Decision Log
+
+**Date:** 2026-07-14
+**Version:** v0.9
+**Status:** Complete - closes epic E8 (#77)
+**Tests:** 110/110 suites passing (new: test_softmax_regression, 4 cases /
+4259 assertions)
+**Issues:** #158 (done); epic #77 complete
+
+## 1. Summary
+
+Implemented E8-T5: execution regression for online softmax across the
+shape x envelope matrix with the standard invariant battery, a
+functional-under-pressure check, and the single-pass-vs-multi-pass
+DRAM-read comparison that quantifies the online-softmax payoff. Closes
+epic E8 - softmax is the fifth operator complete across all five
+lifecycle stages.
+
+## 2. Scope
+
+| Item | Status |
+|------|--------|
+| Matrix: {1,4,16-tile,non-aligned} x {default,large,partitioned} = 12 cells | Done |
+| Per-stage tile accounting + credit conservation + normalized stall bound | Done |
+| Functional-under-pressure (min envelope + partitioned, exact values) | Done |
+| DRAM-read payoff: online vs 4-pass LOAD count (4x fewer for a 4-tile row) | Done |
+| Characterization posted to epic #77 | Done |
+| Coverage: softmax regression -> done (28/105) | Done |
+
+Files:
+- `tests/timing/test_softmax_regression.cpp` (new) + `tests/timing/CMakeLists.txt`
+- `tests/coverage/pattern_coverage.json`, `CHANGELOG.md`, this log
+
+## 3. Technical Decisions
+
+**Decision 1: quantify the payoff via LOAD-count comparison.**
+- The design's headline claim is that online softmax reads the row once
+  (row-resident) vs the multi-pass generator's per-pass re-reads. The test
+  generates both for a shape both support (4-tile row, both valid at the
+  default envelope) and asserts online LOAD < multi-pass LOAD - measured
+  4 vs 16, a 4x reduction. This is the concrete evidence for the epic's
+  DoD, not a hand-wave.
+
+**Decision 2: same invariant battery as E2/E3.**
+- Exact accounting (L3 arrivals = LOAD + WRITEBACK), full credit return in
+  both modes, normalized stall bound. Holds P3-softmax to the same
+  standard as the elementwise and reduction rows.
+
+## 4. Issues Encountered
+
+None. The matrix shows the realization selection working as designed
+(16-tile -> RESTREAMED at default/partitioned, ROW_RESIDENT at the large
+envelope).
+
+## 5. Wrong Decisions (CRITICAL)
+
+No wrong decisions this session. (The earlier process failure - merging
+#159 without resolving reviews - was corrected before this task and its
+rule applied: T4 and this T5 resolve reviews before merge.)
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --test-dir build                           # 110/110
+./build/tests/timing/test_softmax_regression      # 4259 assertions
+./build/tests/coverage/test_pattern_coverage      # 28/105, gates hold
+```
+
+## 7. Characterization Highlights (full table on epic #77)
+
+- DRAM-read payoff: 4-tile row reads 4 tiles (online, row-resident) vs 16
+  (4-pass) - 4x fewer reads; the payoff grows with pass count.
+- Realization selection: 16-tile is RESTREAMED at the default/partitioned
+  envelope (share too small for a resident row) and ROW_RESIDENT at the
+  large envelope - chosen a priori, no empirical fallback.
+
+## 8. Next Steps
+
+- Epic E8 (#77) closes with this PR. The schedule-tier resident-dependency
+  mechanism (T2) now unblocks E9 (LayerNorm/RMSNorm apply phase) and the
+  E3 ROW_NORMALIZE apply phase.
+- M4 attention path: `softmax.functional` is now done; attention (E12)
+  and its chained/flash forms are the remaining M4 gate cells.

--- a/docs/sessions/2026-07-14_v0.9_e8_softmax_regression.md
+++ b/docs/sessions/2026-07-14_v0.9_e8_softmax_regression.md
@@ -34,17 +34,27 @@ Files:
 ## 3. Technical Decisions
 
 **Decision 1: quantify the payoff via LOAD-count comparison.**
-- The design's headline claim is that online softmax reads the row once
-  (row-resident) vs the multi-pass generator's per-pass re-reads. The test
-  generates both for a shape both support (4-tile row, both valid at the
-  default envelope) and asserts online LOAD < multi-pass LOAD - measured
-  4 vs 16, a 4x reduction. This is the concrete evidence for the epic's
-  DoD, not a hand-wave.
+- **Choice:** generate both the online and 4-pass generators for a shape
+  both support (4-tile row, both valid at the default envelope) and assert
+  the exact ratio `multi-pass LOAD == 4 * online LOAD` (16 vs 4). Concrete
+  evidence for the epic's DoD, and a regression guard for the documented
+  number.
+- **Alternatives considered:** (a) comparing DRAM *bytes* instead of LOAD
+  count - equivalent here (uniform tile size) but noisier to read;
+  (b) comparing execution *cycles* - conflates movement with the timing
+  model's compute latency, so it would not isolate the DRAM-read saving;
+  (c) a bare `online < multi-pass` inequality - too weak, a 16->12
+  regression would still pass while the docs claim 4x. The exact-ratio
+  assertion on LOAD count is the tightest direct measure of the claim.
 
 **Decision 2: same invariant battery as E2/E3.**
-- Exact accounting (L3 arrivals = LOAD + WRITEBACK), full credit return in
-  both modes, normalized stall bound. Holds P3-softmax to the same
-  standard as the elementwise and reduction rows.
+- **Choice:** exact accounting (L3 arrivals = LOAD + WRITEBACK), full
+  credit return in both modes, normalized stall bound. Holds P3-softmax to
+  the same standard as the elementwise and reduction rows.
+- **Alternatives considered:** a softmax-specific battery (e.g. asserting
+  the (m,l) tile is never drained) - rejected as redundant with the
+  functional oracle (T4) and less reusable; the shared battery keeps every
+  pattern row held to one consistent, proven standard.
 
 ## 4. Issues Encountered
 
@@ -55,7 +65,7 @@ envelope).
 ## 5. Wrong Decisions (CRITICAL)
 
 No wrong decisions this session. (The earlier process failure - merging
-#159 without resolving reviews - was corrected before this task and its
+`#159` without resolving reviews - was corrected before this task and its
 rule applied: T4 and this T5 resolve reviews before merge.)
 
 ## 6. Verification

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -119,9 +119,9 @@
         "isa_closure": "done",
         "generator": "done",
         "functional": "done",
-        "regression": "missing"
+        "regression": "done"
       },
-      "notes": "Online single-pass softmax (#154 design, #155 resident-dep, #156 generator); FunctionalSoftmaxExecutor value-produces softmax vs host safe-softmax oracle - stats op (m,l) handed to apply computes compute-resident, numerically stable (max-subtracted), edge cases (all-(-inf)->uniform, -inf prefix, non-aligned, partitioned, restreamed) verified (#157). Supersedes 4-pass generator; resolves #139 for softmax. Regression is E8-T5."
+      "notes": "Online single-pass softmax (#154 design, #155 resident-dep, #156 generator); FunctionalSoftmaxExecutor value-produces softmax vs host safe-softmax oracle - stats op (m,l) handed to apply computes compute-resident, numerically stable (max-subtracted), edge cases (all-(-inf)->uniform, -inf prefix, non-aligned, partitioned, restreamed) verified (#157). Supersedes 4-pass generator; resolves #139 for softmax. Regression: shape x envelope matrix with credit/stall invariants + single-pass-vs-multi-pass DRAM payoff (4x fewer reads) + characterization (#158)."
     },
     {
       "name": "layernorm",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -208,3 +208,13 @@ kpu_add_component_test(test_functional_softmax "timing"
 set_tests_properties(test_functional_softmax PROPERTIES
     LABELS "timing;functional;softmax;v0.9"
 )
+
+# Online softmax regression matrix (issue #158, epic E8): shape x envelope
+# with credit/stall invariants and single-pass-vs-multi-pass DRAM payoff
+kpu_add_component_test(test_softmax_regression "timing"
+    test_softmax_regression.cpp
+)
+
+set_tests_properties(test_softmax_regression PROPERTIES
+    LABELS "timing;regression;softmax;v0.9"
+)

--- a/tests/timing/test_softmax_regression.cpp
+++ b/tests/timing/test_softmax_regression.cpp
@@ -14,6 +14,7 @@
 #include <sw/kpu/timing/schedule/functional_softmax_executor.hpp>
 #include <sw/kpu/timing/schedule/softmax_schedule_generator.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <limits>
@@ -180,6 +181,10 @@ TEST_CASE("Online softmax reads the row fewer times than the multi-pass generato
     REQUIRE(online_loads < mp_loads);
     // The online row is read exactly once (row-resident realization)
     REQUIRE(online_loads == on.reduction_elems / on.tile_elems);
+    // Pin the documented 4x: the 4-pass safe-softmax re-reads the row once
+    // per pass (4 passes), the online form reads it once. A regression in
+    // either would break the claim in CHANGELOG/session/coverage notes.
+    REQUIRE(mp_loads == 4 * online_loads);
 }
 
 TEST_CASE("Online softmax characterization report",

--- a/tests/timing/test_softmax_regression.cpp
+++ b/tests/timing/test_softmax_regression.cpp
@@ -1,0 +1,199 @@
+// ============================================================================
+// tests/timing/test_softmax_regression.cpp
+// Online softmax execution regression: shape x envelope with credit/stall
+// invariants, functional-under-pressure, and a single-pass-vs-multi-pass
+// DRAM-traffic comparison - the online-softmax payoff (issue #158, epic E8).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <sw/kpu/timing/schedule/functional_softmax_executor.hpp>
+#include <sw/kpu/timing/schedule/softmax_schedule_generator.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+using Realization = OnlineSoftmaxScheduleGenerator::Realization;
+
+struct EnvelopeCase { const char* name; Size l3; Size l2; bool partitioned; };
+constexpr EnvelopeCase kEnvelopes[] = {
+    {"default",     32,  64, false},
+    {"large",      128, 128, false},
+    {"partitioned", 32,  64, true},
+};
+
+struct SizeCase { const char* name; Size reduction_elems; };
+constexpr SizeCase kSizes[] = {
+    {"single-tile", 256},
+    {"4-tile",      1024},
+    {"16-tile",     4096},
+    {"non-aligned", 1000},
+};
+
+OnlineSoftmaxScheduleGenerator::Config make_config(const SizeCase& s,
+                                                   const EnvelopeCase& e) {
+    OnlineSoftmaxScheduleGenerator::Config c;
+    c.num_rows = 1;
+    c.reduction_elems = s.reduction_elems;
+    c.tile_elems = 256;
+    c.l3_buffer_count = e.l3;
+    c.l2_bank_count = e.l2;
+    c.in_base = 0x100000; c.stat_base = 0x200000; c.out_base = 0x300000;
+    return c;
+}
+
+ConcurrentTimingExecutor::Config make_executor_config(const EnvelopeCase& e) {
+    ConcurrentTimingExecutor::Config config;
+    config.l3_buffer_count = e.l3;
+    config.l2_bank_count = e.l2;
+    config.partition_l3_credits = e.partitioned;
+    config.partition_l2_credits = e.partitioned;
+    config.max_cycles = 5'000'000;
+    return config;
+}
+
+struct CellResult {
+    std::string size, envelope, realization;
+    Size tiles = 0; Cycle cycles = 0; Cycle stalls = 0;
+};
+std::vector<CellResult>& characterization() { static std::vector<CellResult> r; return r; }
+
+void run_cell(const SizeCase& size, const EnvelopeCase& env) {
+    auto gen_config = make_config(size, env);
+    OnlineSoftmaxScheduleGenerator gen(gen_config);
+    auto schedule = gen.generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor executor(make_executor_config(env));
+    ScheduleExecutor sched_exec(executor);
+    auto result = sched_exec.execute(schedule);
+
+    INFO("size=" << size.name << " env=" << env.name
+         << " strategy=" << schedule.metadata.strategy
+         << " cycles=" << result.total_cycles << " error=" << result.error_message);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+    REQUIRE(result.warnings.empty());
+
+    const auto stats = executor.get_statistics();
+    // Per-stage tile accounting (L3 arrivals = LOAD + WRITEBACK)
+    REQUIRE(stats.tiles_loaded == schedule.count_ops(ScheduleOpType::LOAD) +
+                                  schedule.count_ops(ScheduleOpType::WRITEBACK));
+    REQUIRE(stats.tiles_moved == schedule.count_ops(ScheduleOpType::MOVE));
+    REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+    REQUIRE(stats.tiles_drained == schedule.count_ops(ScheduleOpType::DRAIN));
+    REQUIRE(stats.tiles_stored == schedule.count_ops(ScheduleOpType::STORE));
+
+    // Credit conservation (both credit modes)
+    REQUIRE(executor.l3_credits().available() == env.l3);
+    REQUIRE(executor.l2_credits().available() == env.l2);
+
+    // Normalized stall bound
+    const Cycle stalls = stats.dma_credit_stalls + stats.bm_tag_stalls +
+                         stats.bm_credit_stalls + stats.str_tag_stalls +
+                         stats.str_credit_stalls;
+    const auto& ec = executor.config();
+    const Cycle stall_capable = static_cast<Cycle>(
+        ec.num_dma_engines + ec.num_block_movers +
+        ec.num_row_streamers + ec.num_col_streamers);
+    REQUIRE(result.total_cycles > 0);
+    REQUIRE(stalls < result.total_cycles * stall_capable);
+
+    characterization().push_back(
+        {size.name, env.name, schedule.metadata.strategy,
+         gen_config.reduction_tiles(), result.total_cycles, stalls});
+}
+
+} // namespace
+
+TEST_CASE("Online softmax execution matrix: shape x envelope",
+          "[timing][regression][softmax][matrix]") {
+    for (const auto& size : kSizes) {
+        for (const auto& env : kEnvelopes) {
+            DYNAMIC_SECTION(size.name << "/" << env.name) {
+                run_cell(size, env);
+            }
+        }
+    }
+}
+
+TEST_CASE("Online softmax values survive the minimum envelope + partitioned",
+          "[timing][regression][softmax][functional]") {
+    const Size n = 4096;   // 16 tiles -> RESTREAMED at a tight envelope
+    std::vector<float> data(n);
+    for (Size i = 0; i < n; ++i) data[i] = -2.0f + 0.001f * static_cast<float>(i);
+
+    EnvelopeCase env{"constrained-partitioned", 16, 16, true};
+    auto config = make_config({"16-tile", n}, env);
+    REQUIRE(config.realization() == Realization::RESTREAMED);
+
+    FunctionalSoftmaxExecutor exec(config, make_executor_config(env));
+    auto result = exec.run(data);
+    REQUIRE(result.execution.success);
+
+    // Independent host softmax
+    double m = -std::numeric_limits<double>::infinity();
+    for (float v : data) m = std::max(m, static_cast<double>(v));
+    double l = 0.0; for (float v : data) l += std::exp(static_cast<double>(v) - m);
+    for (Size i = 0; i < n; ++i) {
+        INFO("i=" << i);
+        REQUIRE(result.values[i] ==
+                Catch::Approx(std::exp(static_cast<double>(data[i]) - m) / l)
+                    .epsilon(1e-5).margin(1e-6));
+    }
+}
+
+TEST_CASE("Online softmax reads the row fewer times than the multi-pass generator",
+          "[timing][regression][softmax][payoff]") {
+    // The online-softmax payoff: single-pass stats + resident (m,l) means
+    // the row is read once (row-resident); the 4-pass safe-softmax re-reads
+    // it every pass. Compare LOAD counts at a shape both support.
+    const Size n = 1024;   // 4 tiles
+
+    OnlineSoftmaxScheduleGenerator::Config on;
+    on.num_rows = 1; on.reduction_elems = n; on.tile_elems = 256;
+    auto online = OnlineSoftmaxScheduleGenerator(on).generate();
+    REQUIRE(online.valid);
+
+    SoftmaxScheduleGenerator::Config mp;
+    mp.batch_size = 1; mp.reduction_dim = n; mp.Ti = 1; mp.Tj = 256;
+    auto multipass = SoftmaxScheduleGenerator(mp).generate();
+    REQUIRE(multipass.valid);
+
+    const auto online_loads = online.count_ops(ScheduleOpType::LOAD);
+    const auto mp_loads = multipass.count_ops(ScheduleOpType::LOAD);
+    std::printf("\nDRAM-read payoff (4-tile row): online LOAD=%zu, multi-pass LOAD=%zu (%.1fx fewer)\n",
+                static_cast<size_t>(online_loads), static_cast<size_t>(mp_loads),
+                static_cast<double>(mp_loads) / static_cast<double>(online_loads));
+    REQUIRE(online_loads < mp_loads);
+    // The online row is read exactly once (row-resident realization)
+    REQUIRE(online_loads == on.reduction_elems / on.tile_elems);
+}
+
+TEST_CASE("Online softmax characterization report",
+          "[timing][regression][softmax][report]") {
+    const auto& rows = characterization();
+    if (rows.empty()) { SUCCEED("matrix test did not run"); return; }
+    std::printf("\n%-12s %-14s %-22s %6s %9s %8s\n",
+                "size", "envelope", "realization", "tiles", "cycles", "stalls");
+    for (const auto& r : rows) {
+        std::printf("%-12s %-14s %-22s %6zu %9llu %8llu\n",
+                    r.size.c_str(), r.envelope.c_str(), r.realization.c_str(),
+                    static_cast<size_t>(r.tiles),
+                    static_cast<unsigned long long>(r.cycles),
+                    static_cast<unsigned long long>(r.stalls));
+    }
+    SUCCEED("characterization recorded");
+}


### PR DESCRIPTION
Fixes #158 — E8-T5, the final task of the online-softmax epic. **Completes epic #77.** `softmax` becomes the fifth operator with all five lifecycle stages done, after matmul, elementwise, broadcast, and online_reduction.

## What

- **Shape × envelope matrix** — {1, 4, 16-tile, non-aligned} × {default, large, partitioned} = **12 cells**, each enforcing invariants stronger than completion: exact per-stage tile accounting (L3 arrivals = LOAD + WRITEBACK), full credit conservation in both credit modes, and a normalized stall bound.
- **Functional-under-pressure**: exact softmax values at the minimum envelope under partitioned credits (the RESTREAMED realization).
- **The DRAM-read payoff, measured**: for a 4-tile row the online generator reads the row **once** (LOAD=4, row-resident) versus the 4-pass safe-softmax's **LOAD=16** — **4× fewer reads**. This is the concrete evidence for the epic's DoD, asserted and logged, not a hand-wave.
- **Characterization** on epic #77: realization selection works a priori (16-tile → RESTREAMED at default/partitioned, ROW_RESIDENT at the large envelope).

## Coverage

`softmax` regression → done: **28/105**. Gates hold.

## Verification

Full suite: **110/110 pass** (new suite: 4 cases, 4,259 assertions).
Session log: `docs/sessions/2026-07-14_v0.9_e8_softmax_regression.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added expanded online softmax regression validation across multiple shapes and execution envelopes, including stronger correctness and progress checks.
  - Added a single-pass vs multi-pass DRAM-read comparison demonstrating up to ~4× fewer reads.

- **Tests**
  - Introduced new timing/regression test coverage for online softmax, including per-stage accounting and partitioned-credit scenarios.

- **Documentation**
  - Updated the changelog, added a new session decision log, and marked softmax regression coverage as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->