### PR TITLE
feat(timing): TileTracker horizontal L3/L2/L1 occupancy log (#165-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`TileTracker` horizontal tile-state debug log (#165, deliverable A).**
+  Renders the tiles staged in the software-managed memory hierarchy as a
+  horizontal per-snapshot band - L3 on the left, L2 to its right,
+  L1/array on the far right (the direction data flows toward compute) -
+  appended to a log so successive bands read top-to-bottom as the
+  state-transition progression. Each tile cell shows its `TileID` and, when
+  the value plane is active, a compact content summary (e.g. an online
+  softmax stats tile's `(m, l)` pair); in-array tiles are marked `*`.
+  `observe()` dedupes on occupancy change (via `tiles_at`, #165) so the log
+  tracks transitions, not idle cycles; output is deterministic and
+  diffable. A pure observer - no change to executor state. Buffer/credit
+  terminology throughout, never hit/miss/evict.
+
 - **`ConcurrentTimingExecutor::tiles_at(MemoryLevel)` per-level occupancy
   enumerator (#165).** A read-only observer over the value plane that
   returns the full set of tiles resident at a level (sorted, so a rendered

--- a/include/sw/kpu/timing/tile_tracker.hpp
+++ b/include/sw/kpu/timing/tile_tracker.hpp
@@ -12,6 +12,7 @@
 #include <sw/kpu/timing/concurrent_timing_executor.hpp>
 #include <sw/kpu/timing/tile_descriptor.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <sstream>
 #include <string>
@@ -57,7 +58,7 @@ public:
         std::ostringstream ss;
         ss << pad("cyc", 6) << " | " << pad("L3 buffers", config_.col_width)
            << " | " << pad("L2 banks", config_.col_width)
-           << " | " << "L1 / array\n";
+           << " | " << pad("L1 / array", config_.col_width) << "\n";
         ss << rule();
         return ss.str();
     }
@@ -101,7 +102,7 @@ private:
     std::string rule() const {
         auto dashes = [](std::size_t n) { return std::string(n, '-'); };
         return dashes(6) + "-+-" + dashes(config_.col_width) + "-+-" +
-               dashes(config_.col_width) + "-+-" + dashes(12) + "\n";
+               dashes(config_.col_width) + "-+-" + dashes(config_.col_width) + "\n";
     }
 
     /// One cell: "A[0,2]" plus "=(v0,v1,...)" when a small payload is present.
@@ -136,26 +137,30 @@ private:
         return out;
     }
 
-    /// The rightmost column: L1 tiles plus COMPUTE (array) tiles marked '*'.
-    /// A tile resident at both L1 and COMPUTE is shown once, as in-array,
-    /// since the array is its furthest state.
+    /// The rightmost column: L1 tiles plus COMPUTE (array) tiles marked '*',
+    /// rendered in a single TileID-sorted sequence. A tile resident at both
+    /// L1 and COMPUTE is shown once, as in-array (its furthest state).
     std::string render_l1_array(const ConcurrentTimingExecutor& exec) const {
         const auto l1 = exec.tiles_at(MemoryLevel::L1);
         const auto compute = config_.show_compute_in_l1
             ? exec.tiles_at(MemoryLevel::COMPUTE) : std::vector<TileID>{};
-        std::string out;
         auto in_compute = [&](const TileID& id) {
             for (const auto& c : compute) if (c == id) return true;
             return false;
         };
-        for (const auto& id : l1) {              // L1-only tiles (plain)
-            if (in_compute(id)) continue;
+        // Merge into one sorted list: L1-only tiles + all compute tiles.
+        struct Entry { TileID id; bool in_array; };
+        std::vector<Entry> merged;
+        for (const auto& id : l1) if (!in_compute(id)) merged.push_back({id, false});
+        for (const auto& id : compute) merged.push_back({id, true});
+        std::sort(merged.begin(), merged.end(),
+                  [](const Entry& a, const Entry& b) { return a.id < b.id; });
+
+        std::string out;
+        for (const auto& e : merged) {
             if (!out.empty()) out += " ";
-            out += cell(exec, MemoryLevel::L1, id);
-        }
-        for (const auto& id : compute) {         // in-array tiles ('*')
-            if (!out.empty()) out += " ";
-            out += cell(exec, MemoryLevel::COMPUTE, id) + "*";
+            out += cell(exec, e.in_array ? MemoryLevel::COMPUTE : MemoryLevel::L1, e.id);
+            if (e.in_array) out += "*";
         }
         return out.empty() ? "-" : out;
     }

--- a/include/sw/kpu/timing/tile_tracker.hpp
+++ b/include/sw/kpu/timing/tile_tracker.hpp
@@ -1,0 +1,183 @@
+// ============================================================================
+// include/sw/kpu/timing/tile_tracker.hpp
+// Human-readable tile-state tracker: horizontal L3 | L2 | L1/array occupancy
+// bands appended as a progression log (issue #165)
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/tile_descriptor.hpp>
+
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace sw::kpu::timing {
+
+/**
+ * @brief Renders the tiles staged in the software-managed memory hierarchy
+ *        as a horizontal, per-snapshot text band, appended to a log
+ *
+ * We conceptualize the data-movement schedule as transfers of tiles of state
+ * staging in the memory hierarchy. This tracker makes that legible: at each
+ * snapshot it prints one band with L3 on the left, L2 to its right, and
+ * L1/array on the far right - the direction data flows toward compute - and
+ * successive bands read top-to-bottom as the state-transition progression.
+ * Each tile cell shows its TileID and, where the value plane is active, a
+ * compact content summary (e.g. the (m, l) pair of an online-softmax stats
+ * tile), so the reader sees content, not just location.
+ *
+ * A pure observer over ConcurrentTimingExecutor::tiles_at (#165) - it never
+ * mutates executor state. `observe()` dedupes: it appends a band only when
+ * occupancy changed since the last observation, so the log tracks
+ * transitions rather than idle cycles. Output is deterministic (tiles_at is
+ * sorted), hence diffable in tests.
+ *
+ * These are BUFFERS, not caches: the log reads as "tile arrived / resident /
+ * credit returned", never hit/miss/evict.
+ */
+class TileTracker {
+public:
+    struct Config {
+        std::size_t col_width = 34;   ///< width of each level column
+        std::size_t max_values = 3;   ///< values shown per tile cell (else elided)
+        bool show_compute_in_l1 = true;  ///< fold COMPUTE (array) into the L1 column
+    };
+
+    TileTracker() = default;
+    explicit TileTracker(Config config) : config_(config) {}
+
+    /// Column header + rule. Emitted automatically before the first band.
+    [[nodiscard]] std::string header() const {
+        std::ostringstream ss;
+        ss << pad("cyc", 6) << " | " << pad("L3 buffers", config_.col_width)
+           << " | " << pad("L2 banks", config_.col_width)
+           << " | " << "L1 / array\n";
+        ss << rule();
+        return ss.str();
+    }
+
+    /**
+     * @brief Append a band iff occupancy changed since the last observe
+     * @return true if a band was appended
+     */
+    bool observe(const ConcurrentTimingExecutor& exec) {
+        std::string sig = signature(exec);
+        if (sig == last_signature_) return false;
+        last_signature_ = sig;
+        snapshot(exec);
+        return true;
+    }
+
+    /// Append a band for the current state unconditionally.
+    void snapshot(const ConcurrentTimingExecutor& exec) {
+        if (!header_emitted_) { log_ += header(); header_emitted_ = true; }
+        std::ostringstream ss;
+        ss << pad(std::to_string(exec.current_cycle()), 6) << " | "
+           << pad(render_level(exec, MemoryLevel::L3), config_.col_width) << " | "
+           << pad(render_level(exec, MemoryLevel::L2), config_.col_width) << " | "
+           << render_l1_array(exec) << "\n";
+        log_ += ss.str();
+    }
+
+    [[nodiscard]] const std::string& log() const { return log_; }
+    void clear() { log_.clear(); last_signature_.clear(); header_emitted_ = false; }
+
+private:
+    Config config_;
+    std::string log_;
+    std::string last_signature_;
+    bool header_emitted_ = false;
+
+    static std::string pad(const std::string& s, std::size_t w) {
+        if (s.size() >= w) return s.substr(0, w);
+        return s + std::string(w - s.size(), ' ');
+    }
+    std::string rule() const {
+        auto dashes = [](std::size_t n) { return std::string(n, '-'); };
+        return dashes(6) + "-+-" + dashes(config_.col_width) + "-+-" +
+               dashes(config_.col_width) + "-+-" + dashes(12) + "\n";
+    }
+
+    /// One cell: "A[0,2]" plus "=(v0,v1,...)" when a small payload is present.
+    std::string cell(const ConcurrentTimingExecutor& exec, MemoryLevel level,
+                     const TileID& id) const {
+        std::string c = id.to_string();
+        if (exec.has_tile_payload_at(level, id)) {
+            const auto& p = exec.tile_payload_at(level, id);
+            if (!p.values.empty() && p.values.size() <= config_.max_values) {
+                std::ostringstream v;
+                v << "=(";
+                for (std::size_t i = 0; i < p.values.size(); ++i) {
+                    if (i) v << ",";
+                    v << format_value(p.values[i]);
+                }
+                v << ")";
+                c += v.str();
+            }
+        }
+        return c;
+    }
+
+    std::string render_level(const ConcurrentTimingExecutor& exec,
+                             MemoryLevel level) const {
+        const auto ids = exec.tiles_at(level);
+        if (ids.empty()) return "-";
+        std::string out;
+        for (std::size_t i = 0; i < ids.size(); ++i) {
+            if (i) out += " ";
+            out += cell(exec, level, ids[i]);
+        }
+        return out;
+    }
+
+    /// The rightmost column: L1 tiles plus COMPUTE (array) tiles marked '*'.
+    /// A tile resident at both L1 and COMPUTE is shown once, as in-array,
+    /// since the array is its furthest state.
+    std::string render_l1_array(const ConcurrentTimingExecutor& exec) const {
+        const auto l1 = exec.tiles_at(MemoryLevel::L1);
+        const auto compute = config_.show_compute_in_l1
+            ? exec.tiles_at(MemoryLevel::COMPUTE) : std::vector<TileID>{};
+        std::string out;
+        auto in_compute = [&](const TileID& id) {
+            for (const auto& c : compute) if (c == id) return true;
+            return false;
+        };
+        for (const auto& id : l1) {              // L1-only tiles (plain)
+            if (in_compute(id)) continue;
+            if (!out.empty()) out += " ";
+            out += cell(exec, MemoryLevel::L1, id);
+        }
+        for (const auto& id : compute) {         // in-array tiles ('*')
+            if (!out.empty()) out += " ";
+            out += cell(exec, MemoryLevel::COMPUTE, id) + "*";
+        }
+        return out.empty() ? "-" : out;
+    }
+
+    static std::string format_value(float v) {
+        std::ostringstream ss;
+        ss.precision(3);
+        ss << v;
+        return ss.str();
+    }
+
+    /// Occupancy fingerprint for dedupe (levels x tile ids x arrival cycle).
+    std::string signature(const ConcurrentTimingExecutor& exec) const {
+        std::ostringstream ss;
+        for (MemoryLevel level : {MemoryLevel::L3, MemoryLevel::L2,
+                                  MemoryLevel::L1, MemoryLevel::COMPUTE}) {
+            ss << static_cast<int>(level) << ":";
+            for (const auto& id : exec.tiles_at(level)) ss << id.to_string() << ",";
+            ss << ";";
+        }
+        return ss.str();
+    }
+};
+
+} // namespace sw::kpu::timing

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -218,3 +218,12 @@ kpu_add_component_test(test_softmax_regression "timing"
 set_tests_properties(test_softmax_regression PROPERTIES
     LABELS "timing;regression;softmax;v0.9"
 )
+
+# TileTracker horizontal L3/L2/L1 occupancy log (issue #165)
+kpu_add_component_test(test_tile_tracker "timing"
+    test_tile_tracker.cpp
+)
+
+set_tests_properties(test_tile_tracker PROPERTIES
+    LABELS "timing;tracker;v0.9"
+)

--- a/tests/timing/test_tile_tracker.cpp
+++ b/tests/timing/test_tile_tracker.cpp
@@ -48,6 +48,7 @@ std::string run_and_track(TileTracker& tracker) {
         exec.step();
         tracker.observe(exec);
     }
+    REQUIRE(exec.is_complete());   // fail on cap/deadlock, not silently
     return tracker.log();
 }
 
@@ -79,10 +80,10 @@ TEST_CASE("TileTracker renders a horizontal L3|L2|L1 progression",
     REQUIRE(hpos_l3 < hpos_l2);      // L3 left of L2
     REQUIRE(hpos_l2 < hpos_l1);      // L2 left of L1/array
 
-    // The tile appears in each column at some snapshot, in flow order.
-    // Parse bands (skip header + rule) and record when A[0,0,0] shows in
-    // the L3, L2, and L1/array segments.
-    bool in_l3 = false, in_l2 = false, in_l1 = false;
+    // Record the FIRST cycle the tile shows in each column, and assert it
+    // actually flowed L3 -> L2 -> L1/array (not merely appeared in each).
+    constexpr long kNever = -1;
+    long first_l3 = kNever, first_l2 = kNever, first_l1 = kNever;
     std::istringstream ls(log);
     std::string line;
     while (std::getline(ls, line)) {
@@ -90,13 +91,16 @@ TEST_CASE("TileTracker renders a horizontal L3|L2|L1 progression",
         if (line.find("L3 buffers") != std::string::npos) continue;  // header
         auto cols = columns(line);
         if (cols.size() < 4) continue;  // cyc, L3, L2, L1
-        if (cols[1].find("A[0,0,0]") != std::string::npos) in_l3 = true;
-        if (cols[2].find("A[0,0,0]") != std::string::npos) in_l2 = true;
-        if (cols[3].find("A[0,0,0]") != std::string::npos) in_l1 = true;
+        const long cyc = std::stol(cols[0]);
+        if (first_l3 == kNever && cols[1].find("A[0,0,0]") != std::string::npos) first_l3 = cyc;
+        if (first_l2 == kNever && cols[2].find("A[0,0,0]") != std::string::npos) first_l2 = cyc;
+        if (first_l1 == kNever && cols[3].find("A[0,0,0]") != std::string::npos) first_l1 = cyc;
     }
-    REQUIRE(in_l3);
-    REQUIRE(in_l2);
-    REQUIRE(in_l1);
+    REQUIRE(first_l3 != kNever);
+    REQUIRE(first_l2 != kNever);
+    REQUIRE(first_l1 != kNever);
+    REQUIRE(first_l3 <= first_l2);   // reaches L3 no later than L2
+    REQUIRE(first_l2 <= first_l1);   // reaches L2 no later than L1/array
 }
 
 TEST_CASE("TileTracker shows tile content and marks the array",

--- a/tests/timing/test_tile_tracker.cpp
+++ b/tests/timing/test_tile_tracker.cpp
@@ -1,0 +1,127 @@
+// ============================================================================
+// tests/timing/test_tile_tracker.cpp
+// TileTracker horizontal L3 | L2 | L1/array occupancy log (issue #165).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/tile_tracker.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+ConcurrentTimingExecutor::Config exec_config() {
+    ConcurrentTimingExecutor::Config c;
+    c.max_cycles = 200000;
+    return c;
+}
+
+TileDescriptor scalar_tile(MatrixID m, Size ti) {
+    TileDescriptor t;
+    t.tile_id = {m, ti, 0, 0};
+    t.height = 1; t.width = 1; t.element_size = 4; t.size_bytes = 4;
+    t.dram_address = 0x100000 + ti * 0x1000;
+    return t;
+}
+
+// Run one A tile through load/move/feed, tracking every occupancy change.
+std::string run_and_track(TileTracker& tracker) {
+    ConcurrentTimingExecutor exec(exec_config());
+    auto a = scalar_tile(MatrixID::A, 0);
+    exec.set_tile_payload(a.tile_id, TilePayload{1, 1, {7.0f}});
+    exec.schedule_load(a);
+    exec.schedule_move(a);
+    exec.schedule_feed(a);
+
+    tracker.observe(exec);
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
+        exec.step();
+        tracker.observe(exec);
+    }
+    return tracker.log();
+}
+
+// Split a band line "cyc | L3 | L2 | L1" into its column segments.
+std::vector<std::string> columns(const std::string& line) {
+    std::vector<std::string> cols;
+    std::stringstream ss(line);
+    std::string seg;
+    while (std::getline(ss, seg, '|')) {
+        size_t a = seg.find_first_not_of(" ");
+        size_t b = seg.find_last_not_of(" ");
+        cols.push_back(a == std::string::npos ? "" : seg.substr(a, b - a + 1));
+    }
+    return cols;
+}
+
+} // namespace
+
+TEST_CASE("TileTracker renders a horizontal L3|L2|L1 progression",
+          "[timing][tracker]") {
+    TileTracker tracker;
+    const std::string log = run_and_track(tracker);
+
+    // Header names the columns left-to-right: L3, then L2, then L1/array
+    const auto hpos_l3 = log.find("L3 buffers");
+    const auto hpos_l2 = log.find("L2 banks");
+    const auto hpos_l1 = log.find("L1 / array");
+    REQUIRE(hpos_l3 != std::string::npos);
+    REQUIRE(hpos_l3 < hpos_l2);      // L3 left of L2
+    REQUIRE(hpos_l2 < hpos_l1);      // L2 left of L1/array
+
+    // The tile appears in each column at some snapshot, in flow order.
+    // Parse bands (skip header + rule) and record when A[0,0,0] shows in
+    // the L3, L2, and L1/array segments.
+    bool in_l3 = false, in_l2 = false, in_l1 = false;
+    std::istringstream ls(log);
+    std::string line;
+    while (std::getline(ls, line)) {
+        if (line.find('|') == std::string::npos) continue;
+        if (line.find("L3 buffers") != std::string::npos) continue;  // header
+        auto cols = columns(line);
+        if (cols.size() < 4) continue;  // cyc, L3, L2, L1
+        if (cols[1].find("A[0,0,0]") != std::string::npos) in_l3 = true;
+        if (cols[2].find("A[0,0,0]") != std::string::npos) in_l2 = true;
+        if (cols[3].find("A[0,0,0]") != std::string::npos) in_l1 = true;
+    }
+    REQUIRE(in_l3);
+    REQUIRE(in_l2);
+    REQUIRE(in_l1);
+}
+
+TEST_CASE("TileTracker shows tile content and marks the array",
+          "[timing][tracker]") {
+    TileTracker tracker;
+    const std::string log = run_and_track(tracker);
+
+    // Value summary for the scalar payload (7) appears in a cell
+    REQUIRE(log.find("A[0,0,0]=(7)") != std::string::npos);
+    // COMPUTE (array) residency is marked with '*'
+    REQUIRE(log.find("A[0,0,0]=(7)*") != std::string::npos);
+}
+
+TEST_CASE("TileTracker dedupes on occupancy change and is deterministic",
+          "[timing][tracker]") {
+    // observe() appends only when occupancy changed
+    TileTracker t;
+    ConcurrentTimingExecutor exec(exec_config());
+    auto a = scalar_tile(MatrixID::A, 0);
+    exec.set_tile_payload(a.tile_id, TilePayload{1, 1, {1.0f}});
+    exec.schedule_load(a); exec.schedule_move(a); exec.schedule_feed(a);
+    REQUIRE(t.observe(exec));            // first observation appends
+    REQUIRE_FALSE(t.observe(exec));      // unchanged -> no band
+
+    // Deterministic: two independent runs produce identical logs
+    TileTracker t1, t2;
+    REQUIRE(run_and_track(t1) == run_and_track(t2));
+}


### PR DESCRIPTION
Deliverable A of #165 (softmax simulator + tile-state tracker): the reusable renderer, built on the #166 `tiles_at` enumerator.

## What

`TileTracker` renders the tiles staged in the software-managed memory hierarchy as a **horizontal per-snapshot band** — L3 on the left, L2 to its right, L1/array on the far right (the direction data flows toward compute) — appended to a log so successive bands read top-to-bottom as the state-transition progression. Sample:

```
cyc    | L3 buffers                         | L2 banks                           | L1 / array
-------+------------------------------------+------------------------------------+-------------
0      | -                                  | -                                  | -
36     | A[0,0,0]=(1)                       | -                                  | -
37     | A[0,0,0]=(1) A[1,0,0]=(2)          | -                                  | -
38     | A[0,0,0]=(1) A[1,0,0]=(2) A[2,0,0] | -                                  | -
41     | A[1,0,0]=(2) A[2,0,0]=(3)          | A[0,0,0]=(1)                       | -
42     | A[2,0,0]=(3)                       | A[0,0,0]=(1) A[1,0,0]=(2)          | -
44     | A[2,0,0]=(3)                       | A[1,0,0]=(2)                       | A[0,0,0]=(1)*
46     | -                                  | A[1,0,0]=(2) A[2,0,0]=(3)          | A[0,0,0]=(1)*
47     | -                                  | A[2,0,0]=(3)                       | A[0,0,0]=(1)* A[1,0,0]=(2)*
50     | -                                  | -                                  | A[0,0,0]=(1)* A[1,0,0]=(2)* A[2,0,0]=(3)*
```

- Tile cells show the `TileID` and, when the value plane is active, a compact **content summary** (e.g. an online-softmax stats tile's `(m, l)` pair). In-array (COMPUTE) tiles are marked `*`, deduped against L1 so each tile shows once.
- `observe()` appends a band **only on occupancy change** (via `tiles_at`), so the log tracks transitions rather than idle cycles.
- Output is **deterministic** (`tiles_at` is sorted) and therefore diffable in tests.
- A **pure observer** — no change to executor state. Buffer/credit terminology throughout, never hit/miss/evict.

## Verification

- Tests: header column order is L3 → L2 → L1/array; a streamed tile appears in each column in flow order; content + array marking; `observe()` dedupe; two independent runs produce identical logs.
- Full suite: **111/111 pass**.

Next: **deliverable B** — the standalone softmax simulator that drives this tracker over the online-softmax schedule (E8), so a human can watch the row stream into L3→L2→L1, the stats compute produce `(m,l)`, the resident `(m,l)` feed the apply computes, and the normalized `C` tiles drain out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic tile-state tracker that renders horizontal occupancy “bands” across L3, L2, L1/array, and optionally compute residency.
  * Each band includes tile identifiers, current cycle context, and compact per-tile value summaries when present.
  * Automatically suppresses duplicate entries when tile occupancy hasn’t changed.
  * Supports clearing/resetting the log and viewing it via a dedicated accessor.

* **Tests**
  * Added tile tracker tests covering progression ordering, value rendering, compute/array marking, deduplication behavior, and deterministic output across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->