### PR TITLE
feat(examples): standalone softmax simulator with tile-state log (#165-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Standalone softmax simulator (#165, deliverable B).**
+  `examples/schedule/softmax_simulator` runs the E8 online-softmax schedule
+  one executor cycle at a time and drives the `TileTracker` to print the
+  horizontal L3/L2/L1/array state-transition log: the row streams in, the
+  stats compute produces the `(m, l)` state (visible in the log, e.g.
+  `B[0,0,0]=(-0.69,440)`), that state stays resident in the array and feeds
+  the apply computes, and the normalized `C` tiles drain back out - ending
+  on the per-row softmax-sums-to-1 check. Configurable
+  `--rows/--len/--tile/--l3/--l2`; CI smoke test; how-to-read writeup at
+  `docs/tools/softmax-simulator.md`. Completes issue #165.
+
 - **`TileTracker` horizontal tile-state debug log (#165, deliverable A).**
   Renders the tiles staged in the software-managed memory hierarchy as a
   horizontal per-snapshot band - L3 on the left, L2 to its right,

--- a/docs/tools/softmax-simulator.md
+++ b/docs/tools/softmax-simulator.md
@@ -1,0 +1,70 @@
+# Softmax simulator + tile-state tracker
+
+`examples/schedule/softmax_simulator.cpp` runs the online-softmax schedule
+(epic E8) one executor cycle at a time and prints a **horizontal tile-state
+log**: what tiles occupy each level of the software-managed memory hierarchy,
+snapshot by snapshot, so a human can watch the data-movement schedule execute.
+
+```
+softmax_simulator [--rows R] [--len N] [--tile T] [--l3 C] [--l2 C]
+```
+
+## How to read the log
+
+Each band is one snapshot. Columns run left-to-right in the direction data
+flows toward compute: **L3 | L2 | L1 / array**. A band is printed only when
+occupancy changes, so successive bands read as the state-transition
+progression. A tile cell shows its `TileID`; when the value plane is active it
+also shows a compact content summary, and an `*` marks a tile resident in the
+systolic array (compute storage).
+
+Sample (`softmax_simulator`, default 1 row x 512, two tiles):
+
+```
+Online softmax simulator  —  online_row_resident  (1 row(s) x 512, tile 256, envelope L3=32/L2=64)
+
+cyc    | L3 buffers                         | L2 banks                           | L1 / array                        
+-------+------------------------------------+------------------------------------+-----------------------------------
+0      | -                                  | -                                  | -
+36     | A[0,0,0]                           | -                                  | -
+37     | A[0,0,0] A[0,1,0]                  | -                                  | -
+60     | A[0,1,0]                           | A[0,0,0]                           | -
+72     | A[0,1,0]                           | A[0,0,0]                           | A[0,0,0]*
+84     | -                                  | A[0,1,0]                           | A[0,0,0]*
+96     | -                                  | A[0,1,0]                           | A[0,0,0]* A[0,1,0]*
+108    | -                                  | -                                  | A[0,0,0]* A[0,1,0]*
+129    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)*
+162    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+174    | -                                  | C[0,0,0]                           | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+186    | -                                  | C[0,0,0] C[0,1,0]                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+199    | C[0,0,0]                           | C[0,1,0]                           | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+223    | C[0,0,0] C[0,1,0]                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+250    | C[0,1,0]                           | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+274    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+
+Result: each row's softmax sums to 1
+  row 0: sum = 1  [OK]
+
+SOFTMAX OK
+```
+
+Reading it: the two input tiles `A[0,0]`/`A[0,1]` stream `DRAM -> L3 -> L2 ->
+L1/array`; the **stats compute** produces `B[0,0]=(m,l)` — here `(-0.69, 440)`,
+the running max and the exp-sum normalizer — which then stays **resident in the
+array** (the E8 compute-resident hand-off, no DRAM round-trip) and feeds the
+**apply computes** that emit the normalized `C[0,0]`/`C[0,1]`; those drain back
+`array -> L2 -> L3 -> DRAM`. The run ends on the softmax correctness check:
+each row sums to 1.
+
+These are **buffers, not caches** — the log reads as tile *arrived* / *resident*
+/ credit *returned*, never hit/miss/evict.
+
+## Under the hood
+
+- `OnlineSoftmaxScheduleGenerator` (#156) produces the movement schedule.
+- The softmax value ops (`softmax_stats`, `softmax_apply`) come from
+  `FunctionalSoftmaxExecutor` (#157); the simulator binds them to the COMPUTEs
+  and drives the executor cycle-by-cycle so it can observe between steps.
+- `TileTracker` (`include/sw/kpu/timing/tile_tracker.hpp`, #165) renders the
+  bands from `ConcurrentTimingExecutor::tiles_at(level)` — a pure observer,
+  never mutating executor state.

--- a/docs/tools/softmax-simulator.md
+++ b/docs/tools/softmax-simulator.md
@@ -5,7 +5,7 @@
 log**: what tiles occupy each level of the software-managed memory hierarchy,
 snapshot by snapshot, so a human can watch the data-movement schedule execute.
 
-```
+```text
 softmax_simulator [--rows R] [--len N] [--tile T] [--l3 C] [--l2 C]
 ```
 
@@ -20,7 +20,7 @@ systolic array (compute storage).
 
 Sample (`softmax_simulator`, default 1 row x 512, two tiles):
 
-```
+```text
 Online softmax simulator  —  online_row_resident  (1 row(s) x 512, tile 256, envelope L3=32/L2=64)
 
 cyc    | L3 buffers                         | L2 banks                           | L1 / array                        
@@ -48,11 +48,11 @@ Result: each row's softmax sums to 1
 SOFTMAX OK
 ```
 
-Reading it: the two input tiles `A[0,0]`/`A[0,1]` stream `DRAM -> L3 -> L2 ->
-L1/array`; the **stats compute** produces `B[0,0]=(m,l)` — here `(-0.69, 440)`,
+Reading it: the two input tiles `A[0,0,0]`/`A[0,1,0]` stream `DRAM -> L3 -> L2 ->
+L1/array`; the **stats compute** produces `B[0,0,0]=(m,l)` — here `(-0.69, 440)`,
 the running max and the exp-sum normalizer — which then stays **resident in the
 array** (the E8 compute-resident hand-off, no DRAM round-trip) and feeds the
-**apply computes** that emit the normalized `C[0,0]`/`C[0,1]`; those drain back
+**apply computes** that emit the normalized `C[0,0,0]`/`C[0,1,0]`; those drain back
 `array -> L2 -> L3 -> DRAM`. The run ends on the softmax correctness check:
 each row sums to 1.
 

--- a/examples/schedule/CMakeLists.txt
+++ b/examples/schedule/CMakeLists.txt
@@ -52,3 +52,15 @@ target_link_libraries(run_matmul_DEPRECATED PRIVATE
 set_target_properties(run_matmul_DEPRECATED PROPERTIES
     FOLDER "Examples/Schedule/Deprecated"
 )
+
+# Online softmax simulator with tile-state tracker (issue #165)
+add_executable(softmax_simulator softmax_simulator.cpp)
+target_link_libraries(softmax_simulator PRIVATE kpu_simulator)
+set_target_properties(softmax_simulator PROPERTIES FOLDER "Examples/Schedule")
+if(KPU_BUILD_TESTS)
+    # Smoke test: runs the simulator and expects exit 0 (each row sums to 1)
+    add_test(NAME softmax_simulator COMMAND softmax_simulator)
+    set_tests_properties(softmax_simulator PROPERTIES
+        LABELS "timing;softmax;tracker;example;v0.9"
+    )
+endif()

--- a/examples/schedule/softmax_simulator.cpp
+++ b/examples/schedule/softmax_simulator.cpp
@@ -76,12 +76,28 @@ long arg(int argc, char** argv, const char* flag, long def) {
 } // namespace
 
 int main(int argc, char** argv) {
+    // Read + validate each option: atol treats malformed input as 0, and a
+    // negative value would wrap to a huge Size, so require strictly positive.
+    struct Opt { const char* flag; long def; };
+    long vals[5];
+    const Opt opts[5] = {{"--rows", 1}, {"--len", 512}, {"--tile", 256},
+                         {"--l3", 32}, {"--l2", 64}};
+    for (int i = 0; i < 5; ++i) {
+        vals[i] = arg(argc, argv, opts[i].flag, opts[i].def);
+        if (vals[i] <= 0) {
+            std::cerr << "error: " << opts[i].flag << " must be a positive integer\n"
+                      << "usage: softmax_simulator [--rows R] [--len N] [--tile T]"
+                         " [--l3 C] [--l2 C]\n";
+            return 2;
+        }
+    }
+
     OnlineSoftmaxScheduleGenerator::Config cfg;
-    cfg.num_rows       = static_cast<Size>(arg(argc, argv, "--rows", 1));
-    cfg.reduction_elems = static_cast<Size>(arg(argc, argv, "--len", 512));
-    cfg.tile_elems     = static_cast<Size>(arg(argc, argv, "--tile", 256));
-    cfg.l3_buffer_count = static_cast<Size>(arg(argc, argv, "--l3", 32));
-    cfg.l2_bank_count  = static_cast<Size>(arg(argc, argv, "--l2", 64));
+    cfg.num_rows       = static_cast<Size>(vals[0]);
+    cfg.reduction_elems = static_cast<Size>(vals[1]);
+    cfg.tile_elems     = static_cast<Size>(vals[2]);
+    cfg.l3_buffer_count = static_cast<Size>(vals[3]);
+    cfg.l2_bank_count  = static_cast<Size>(vals[4]);
     cfg.in_base = 0x100000; cfg.stat_base = 0x200000; cfg.out_base = 0x300000;
 
     auto schedule = OnlineSoftmaxScheduleGenerator(cfg).generate();

--- a/examples/schedule/softmax_simulator.cpp
+++ b/examples/schedule/softmax_simulator.cpp
@@ -1,0 +1,160 @@
+// ============================================================================
+// examples/schedule/softmax_simulator.cpp
+// Standalone online-softmax simulator with a horizontal tile-state debug log
+// (issue #165, deliverable B).
+//
+// Runs the E8 online-softmax schedule (OnlineSoftmaxScheduleGenerator #156 +
+// the value ops from FunctionalSoftmaxExecutor #157) one executor cycle at a
+// time, and after each cycle asks the TileTracker (#165) to record any change
+// in what tiles occupy L3 / L2 / L1 / array. The result is a human-readable
+// progression: watch the row stream DRAM->L3->L2->L1, the stats compute
+// produce (m, l), that (m, l) stay resident and feed the apply computes, and
+// the normalized C tiles drain back out. Ends on the row-sums-to-1 check.
+//
+// Usage: softmax_simulator [--rows R] [--len N] [--tile T] [--l3 C] [--l2 C]
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/tile_tracker.hpp>
+#include <sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/functional_softmax_executor.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+// Enqueue one schedule operation on the executor, binding the softmax value
+// ops to the COMPUTEs: stats (matrix B) -> (m, l); apply (matrix C) ->
+// exp(x - m)/l reading the resident (m, l). This is the same binding
+// FunctionalSoftmaxExecutor uses, done inline so we can drive the executor
+// cycle-by-cycle and observe between steps.
+void enqueue(ConcurrentTimingExecutor& exec, const ScheduleOperation& op,
+             Size row_elems) {
+    switch (op.type) {
+        case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+        case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+        case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+        case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+        case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+        case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+        case ScheduleOpType::COMPUTE: {
+            ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+            spec.input_tiles = op.dependency_tiles;
+            for (const auto& r : op.resident_tiles) spec.input_tiles.push_back(r);
+            spec.resident_tiles = op.resident_tiles;
+            if (op.tile.tile_id.matrix == MatrixID::B) {
+                spec.operation = softmax_stats;
+            } else {
+                spec.operation = [row_elems](const std::vector<TilePayload>& in) {
+                    return softmax_apply(in, row_elems);
+                };
+            }
+            exec.schedule_functional_compute(op.tile, spec);
+            break;
+        }
+    }
+}
+
+long arg(int argc, char** argv, const char* flag, long def) {
+    for (int i = 1; i + 1 < argc; ++i)
+        if (std::strcmp(argv[i], flag) == 0) return std::atol(argv[i + 1]);
+    return def;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    OnlineSoftmaxScheduleGenerator::Config cfg;
+    cfg.num_rows       = static_cast<Size>(arg(argc, argv, "--rows", 1));
+    cfg.reduction_elems = static_cast<Size>(arg(argc, argv, "--len", 512));
+    cfg.tile_elems     = static_cast<Size>(arg(argc, argv, "--tile", 256));
+    cfg.l3_buffer_count = static_cast<Size>(arg(argc, argv, "--l3", 32));
+    cfg.l2_bank_count  = static_cast<Size>(arg(argc, argv, "--l2", 64));
+    cfg.in_base = 0x100000; cfg.stat_base = 0x200000; cfg.out_base = 0x300000;
+
+    auto schedule = OnlineSoftmaxScheduleGenerator(cfg).generate();
+    if (!schedule.valid) {
+        std::cerr << "schedule refused: " << schedule.error_message << "\n";
+        return 1;
+    }
+
+    // Deterministic input: a gentle per-row ramp
+    const Size n = cfg.num_rows * cfg.reduction_elems;
+    std::vector<float> data(n);
+    for (Size r = 0; r < cfg.num_rows; ++r)
+        for (Size i = 0; i < cfg.reduction_elems; ++i)
+            data[r * cfg.reduction_elems + i] =
+                static_cast<float>(r) - 1.0f + 0.01f * static_cast<float>(i % 32);
+
+    std::cout << "Online softmax simulator  —  " << schedule.metadata.strategy
+              << "  (" << cfg.num_rows << " row(s) x " << cfg.reduction_elems
+              << ", tile " << cfg.tile_elems << ", envelope L3=" << cfg.l3_buffer_count
+              << "/L2=" << cfg.l2_bank_count << ")\n\n";
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.l3_buffer_count = cfg.l3_buffer_count;
+    ecfg.l2_bank_count = cfg.l2_bank_count;
+    ecfg.max_cycles = 2'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+
+    // Seed A input tiles from the data (matrix A LOADs only)
+    const Size te = cfg.tile_elems;
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        if (op.tile.tile_id.matrix != MatrixID::A) continue;
+        const Size row = op.tile.tile_id.ti, t = op.tile.tile_id.tj;
+        const Size off = row * cfg.reduction_elems + t * te;
+        const Size elems = op.tile.height;
+        exec.set_tile_payload(op.tile.tile_id,
+                              TilePayload{elems, 1,
+                                          std::vector<float>(data.begin() + off,
+                                                             data.begin() + off + elems)});
+    }
+    for (const auto& op : schedule.operations) enqueue(exec, op, cfg.reduction_elems);
+
+    // Drive one cycle at a time, tracking every occupancy transition
+    TileTracker tracker;
+    tracker.observe(exec);
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
+        exec.step();
+        tracker.observe(exec);
+    }
+    std::cout << tracker.log() << "\n";
+
+    if (!exec.is_complete()) {
+        std::cerr << "did not complete within max_cycles\n";
+        return 1;
+    }
+
+    // Correctness: each output row sums to 1 (softmax is a distribution)
+    std::cout << "Result: each row's softmax sums to 1\n";
+    bool ok = true;
+    for (Size r = 0; r < cfg.num_rows; ++r) {
+        double sum = 0.0;
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::STORE) continue;
+            if (op.tile.tile_id.matrix != MatrixID::C) continue;
+            if (op.tile.tile_id.ti != r) continue;
+            const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, op.tile.tile_id);
+            for (float v : p.values) sum += v;
+        }
+        const bool row_ok = std::abs(sum - 1.0) < 1e-3;
+        ok = ok && row_ok;
+        std::cout << "  row " << r << ": sum = " << sum
+                  << (row_ok ? "  [OK]" : "  [FAIL]") << "\n";
+    }
+    std::cout << "\n" << (ok ? "SOFTMAX OK" : "SOFTMAX MISMATCH") << "\n";
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Deliverable B of #165 — **completes the issue**. A standalone program that runs the E8 online-softmax schedule one executor cycle at a time and prints the horizontal tile-state progression via the `TileTracker` (#167).

## Sample output

```
Online softmax simulator  —  online_row_resident  (1 row(s) x 512, tile 256, envelope L3=32/L2=64)

cyc    | L3 buffers                         | L2 banks                           | L1 / array                        
-------+------------------------------------+------------------------------------+-----------------------------------
0      | -                                  | -                                  | -
36     | A[0,0,0]                           | -                                  | -
37     | A[0,0,0] A[0,1,0]                  | -                                  | -
60     | A[0,1,0]                           | A[0,0,0]                           | -
72     | A[0,1,0]                           | A[0,0,0]                           | A[0,0,0]*
84     | -                                  | A[0,1,0]                           | A[0,0,0]*
96     | -                                  | A[0,1,0]                           | A[0,0,0]* A[0,1,0]*
108    | -                                  | -                                  | A[0,0,0]* A[0,1,0]*
129    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)*
162    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
174    | -                                  | C[0,0,0]                           | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
186    | -                                  | C[0,0,0] C[0,1,0]                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
199    | C[0,0,0]                           | C[0,1,0]                           | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
223    | C[0,0,0] C[0,1,0]                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
250    | C[0,1,0]                           | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
274    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*

Result: each row's softmax sums to 1
  row 0: sum = 1  [OK]

SOFTMAX OK
```

You can watch the schedule execute: the two input tiles stream `DRAM -> L3 -> L2 -> L1/array`; the **stats compute** produces `B[0,0,0]=(m,l)` — here `(-0.69, 440)`, the running max and the exp-sum normalizer, **visible in the log**; that `(m,l)` stays **resident in the array** (the E8 compute-resident hand-off, no DRAM round-trip) and feeds the **apply computes** that emit `C[0,0]`/`C[0,1]`; the outputs drain back `array -> L2 -> L3 -> DRAM`; and the run ends on the per-row softmax-sums-to-1 check.

## What

- `examples/schedule/softmax_simulator.cpp` binds the softmax value ops (`softmax_stats`/`softmax_apply`, #157) to the schedule's COMPUTEs and drives `ConcurrentTimingExecutor` **cycle-by-cycle**, calling `tracker.observe()` after each step so every occupancy transition is recorded.
- Configurable `--rows/--len/--tile/--l3/--l2`; both the row-resident and restreamed realizations are exercised (batched rows and a tight-envelope 16-tile run both verified, rows sum to 1).
- **CI smoke test** (exit 0 ⇔ each row sums to 1) and a **how-to-read writeup** at `docs/tools/softmax-simulator.md`.

## Verification

Full suite: **112/112 pass** (including the new simulator smoke test).

Closes #165 (with the `tiles_at` enumerator #166 and the `TileTracker` #167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standalone softmax simulator that runs the online softmax schedule cycle by cycle and prints a horizontal L3/L2/L1/array tile-state transition log.
  - Supports CLI configuration for rows, reduction length, tile size, and L3/L2 sizing, with input/config validation and final per-row correctness checking (row sums ~1).

- **Documentation**
  - Added a guide explaining how to run the simulator, read the snapshot/band log and occupancy changes, and interpret sample output and the DRAM → L3 → L2 → L1/array flow.

- **Tests**
  - Added an automated smoke test to confirm the simulator exits successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->