### PR TITLE
feat(examples): matmul simulator + tile-log discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Matmul simulator + tile-log discussion.** `examples/schedule/matmul_simulator`
+  drives a tiled `C = A x B` schedule (`MatMulScheduleGenerator`) cycle-by-cycle
+  through the `TileTracker`, so the horizontal L3/L2/L1/array log shows the two
+  operand streams (A rows, B columns) interleaving, each `C[ti,tj]` compute
+  joining over its K-slices in the array, and the results draining out - ending
+  on a `C = A x B` host-oracle check (max error 0). Configurable
+  `--m/--n/--k/--tile`; CI smoke test. Companion doc
+  `docs/tools/matmul-simulator.md` discusses the what/why/how of the matmul tile
+  log and contrasts it with softmax (large data tiles show movement, not content;
+  K-accumulation is a join not a chain; operand reuse is visible).
+
 - **Standalone softmax simulator (#165, deliverable B).**
   `examples/schedule/softmax_simulator` runs the E8 online-softmax schedule
   one executor cycle at a time and drives the `TileTracker` to print the

--- a/docs/README.md
+++ b/docs/README.md
@@ -161,7 +161,8 @@ The KPU is NOT a stored-program processor. It uses credit-based dataflow:
 See [KPU Execution Model](01-architecture/kpu-execution-model.md) for details.
 To *watch* a schedule execute as tiles migrate through the hierarchy, see
 [Tracking Schedules as Tile-State Movement](tile-state-tracking.md) and the
-[softmax simulator](tools/softmax-simulator.md).
+[softmax](tools/softmax-simulator.md) / [matmul](tools/matmul-simulator.md)
+simulators.
 
 ---
 

--- a/docs/tile-state-tracking.md
+++ b/docs/tile-state-tracking.md
@@ -129,7 +129,10 @@ if (!exec.is_complete()) {
 This is exactly what `softmax_simulator` does around the E8 online-softmax
 schedule. The approach is **operator-agnostic**: any schedule (matmul,
 reductions, norms, attention) can be driven the same way to get the same trace —
-bind the value ops to the COMPUTEs, seed the inputs, step, observe.
+bind the value ops to the COMPUTEs, seed the inputs, step, observe. See
+[`matmul_simulator`](tools/matmul-simulator.md) for the same view over a
+tiled matmul, where two operand streams (A rows, B columns) interleave and a
+C tile accumulates over its K-slices.
 
 ### Reading a band (worked example)
 

--- a/docs/tools/matmul-simulator.md
+++ b/docs/tools/matmul-simulator.md
@@ -1,0 +1,114 @@
+# Matmul simulator + tile-state tracker
+
+`examples/schedule/matmul_simulator.cpp` runs a tiled matmul schedule
+(`MatMulScheduleGenerator`) one executor cycle at a time and prints the
+**horizontal tile-state log** — what tiles occupy each level of the
+software-managed memory hierarchy, snapshot by snapshot. It is the matmul
+companion to the [softmax simulator](softmax-simulator.md); for the general
+approach, see [Tracking Schedules as Tile-State Movement](../tile-state-tracking.md).
+
+```text
+matmul_simulator [--m M] [--n N] [--k K] [--tile T]
+```
+
+`--tile` must divide `M`, `N`, and `K` evenly. Default: `C[32x32] = A[32x32] *
+B[32x32]`, tile 16 (a 2x2x2 tile grid).
+
+---
+
+## What the matmul tile log shows
+
+A tiled matmul `C = A x B` moves **two** operand streams and reduces over K:
+
+- `A[ti,0,tk]` — a row-block of A (rows `ti`, K-slice `tk`).
+- `B[0,tj,tk]` — a column-block of B (columns `tj`, K-slice `tk`).
+- `C[ti,tj,0]` — an output block, the sum over `tk` of `A[ti,tk] * B[tk,tj]`.
+
+The log shows the A and B tiles streaming `DRAM -> L3 -> L2 -> L1/array`
+interleaved (the default `interleaved_ab` strategy alternates an A tile and a B
+tile so neither operand monopolizes the buffers), each `C[ti,tj]` compute firing
+once **all** its K-slices have been fed and accumulating them in the array, and
+the finished `C` tiles draining back out `array -> L2 -> L3 -> DRAM`. The run
+ends on the `C = A x B` host-oracle check.
+
+## Why matmul's log looks the way it does
+
+Reading it next to the softmax log is instructive — the two operators stress the
+hierarchy differently, and the trace makes that visible.
+
+- **Two interleaved input streams, not one.** Softmax streams a single row;
+  matmul streams A row-blocks *and* B column-blocks together. In the log you see
+  pairs like `A[0,0,0] A[0,0,1] B[0,0,1] B[0,1,1]` filling L3 — the
+  `interleaved_ab` discipline keeping an A-burst and a B-burst simultaneously
+  resident so neither starves the other (the #67 per-matrix burst share).
+
+- **K-accumulation is a join, not a chain.** A `C[ti,tj]` compute depends on
+  every A[ti,*,tk] and B[*,tj,tk] K-slice (`2 * k_tiles` feeds); it cannot fire
+  until all have arrived, and its latency scales with the K-slice count. You see
+  the A/B tiles for both K-slices reach the array (`*`) before `C[0,0,0]`
+  appears — the reduction depth made literal.
+
+- **Tiles are large data blocks, so the log shows movement, not content.** A
+  softmax stats tile is two numbers `(m, l)` and prints its value; a matmul tile
+  is a `T x T` block (256 values at tile 16), too large to summarize inline, so
+  the cells show tile *identity and location*. The matmul log is a **data-motion**
+  view; the softmax log is a data-motion **and content** view. Same tracker,
+  different information density because the operators carry different state.
+
+- **Reuse is visible.** An A row-tile contributes to every C tile in its row
+  (all `tj`); a B column-tile to every C tile in its column (all `ti`). Watching
+  A/B tiles remain resident in the array while multiple C tiles form is the
+  classic matmul operand-reuse the tiling exists to exploit.
+
+- **Blocking to the hierarchy.** L3 occupancy stays bounded by the envelope
+  share as tiles stream — the blocked-linear-algebra discipline of sizing bursts
+  to the credit pools (#67). A schedule that let A or B flood L3 would show it
+  here as one operand crowding the left column; a wedge would show as occupancy
+  that never drains. (The #61 multi-tile livelock was exactly a drain that never
+  happened — invisible in cycle counts, obvious in this view.)
+
+## How to read a band (worked example)
+
+From `matmul_simulator` (default `C[32x32]=A*B`, tile 16, `interleaved_ab`).
+Excerpted from the full trace (`...` elides cells):
+
+```text
+cyc    | L3 buffers                         | L2 banks                           | L1 / array
+-------+------------------------------------+------------------------------------+-----------------------------------
+38     | A[0,0,0] A[0,0,1] B[0,0,1]         | -                                  | -
+74     | A[0,0,1] B[0,1,1]                  | A[0,0,0] B[0,0,1]                  | A[0,0,0]* B[0,0,1]*
+159    | -                                  | -                                  | A[0,0,0]* A[0,0,1]* A[1,0,0]* A[1,0,1]* B[0,0,0]* B[0,0,1]* B[0,1,0]* B[0,1,1]*
+187    | -                                  | -                                  | ... B[0,1,1]* C[0,0,0]*
+248    | C[0,0,0] C[0,1,0]                  | C[1,0,0] C[1,1,0]                  | ... C[0,0,0]* C[0,1,0]* C[1,0,0]* C[1,1,0]*
+```
+
+- **cyc 38** — A and B tiles stream into L3 **interleaved**: two A K-slices and
+  a B K-slice already staged. Neither operand is allowed to monopolize the
+  buffers.
+- **cyc 74** — the pipeline is filling: `A[0,0,0]`/`B[0,0,1]` in the array (`*`),
+  their successors one boundary behind in L2, more in L3.
+- **cyc 159** — all K-slices of A and B for the first outputs are resident in the
+  array: `A[0,0,*]`, `A[1,0,*]`, `B[*,*,*]`. The **join** is complete, so a
+  compute can fire.
+- **cyc 187** — the first result `C[0,0,0]` appears — `A[0,0,0]*B[0,0,0] +
+  A[0,0,1]*B[0,1,0]` accumulated over the two K-slices.
+- **cyc 248** — the four output tiles `C[0,0]`, `C[0,1]`, `C[1,0]`, `C[1,1]`
+  drain back out through L2/L3 toward DRAM. The run then checks `C = A x B`
+  against the host reference (max abs error 0 for integer operands).
+
+The rightmost column accumulates all resident A/B/C tiles (compute payloads
+persist); read the **left** columns for the live streaming front, and note the
+strategy in the header (`interleaved_ab`). Other strategies
+(`output_stationary`, `blocked_ab`, `prefetch_next`) produce visibly different
+streaming orders in the same view.
+
+## Under the hood
+
+- `MatMulScheduleGenerator` (`include/sw/kpu/timing/schedule/matmul_schedule_generator.hpp`)
+  produces the movement schedule; each `C[ti,tj]` COMPUTE carries its full A/B
+  K-slice dependency set.
+- The simulator seeds A/B tiles from host operands, splits each COMPUTE's
+  interleaved dependencies into the paired `a_tiles`/`b_tiles` of a
+  `MatMulComputeSpec`, and drives the executor cycle-by-cycle so `TileTracker`
+  (#165) can observe between steps — a pure observer over
+  `ConcurrentTimingExecutor::tiles_at(level)`, never mutating executor state.

--- a/examples/schedule/CMakeLists.txt
+++ b/examples/schedule/CMakeLists.txt
@@ -64,3 +64,14 @@ if(KPU_BUILD_TESTS)
         LABELS "timing;softmax;tracker;example;v0.9"
     )
 endif()
+
+# Matmul simulator with tile-state tracker (companion to softmax_simulator)
+add_executable(matmul_simulator matmul_simulator.cpp)
+target_link_libraries(matmul_simulator PRIVATE kpu_simulator)
+set_target_properties(matmul_simulator PROPERTIES FOLDER "Examples/Schedule")
+if(KPU_BUILD_TESTS)
+    add_test(NAME matmul_simulator COMMAND matmul_simulator)
+    set_tests_properties(matmul_simulator PROPERTIES
+        LABELS "timing;matmul;tracker;example;v0.9"
+    )
+endif()

--- a/examples/schedule/matmul_simulator.cpp
+++ b/examples/schedule/matmul_simulator.cpp
@@ -1,0 +1,165 @@
+// ============================================================================
+// examples/schedule/matmul_simulator.cpp
+// Standalone matmul simulator with a horizontal tile-state debug log
+// (companion to softmax_simulator; see docs/tile-state-tracking.md).
+//
+// Runs a tiled matmul schedule (MatMulScheduleGenerator) one executor cycle at
+// a time and, after each cycle, records any change in what tiles occupy
+// L3 / L2 / L1 / array via the TileTracker. Watch A tiles (rows) and B tiles
+// (columns) stream DRAM->L3->L2->L1/array, a C[ti,tj] compute accumulate over
+// the K-slices in the array, and the C result drain back out. Ends on the
+// C = A x B host-oracle check.
+//
+// Usage: matmul_simulator [--m M] [--n N] [--k K] [--tile T]
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/tile_tracker.hpp>
+#include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+// Enqueue one schedule operation; a COMPUTE for C[ti,tj] becomes a
+// value-producing MatMulComputeSpec by splitting its interleaved A/B K-slice
+// dependencies into the paired a_tiles / b_tiles the executor accumulates.
+void enqueue(ConcurrentTimingExecutor& exec, const ScheduleOperation& op) {
+    switch (op.type) {
+        case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+        case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+        case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+        case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+        case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+        case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+        case ScheduleOpType::COMPUTE: {
+            ConcurrentTimingExecutor::MatMulComputeSpec spec;
+            for (const auto& dep : op.dependency_tiles) {
+                if (dep.matrix == MatrixID::A) spec.a_tiles.push_back(dep);
+                else                            spec.b_tiles.push_back(dep);
+            }
+            exec.schedule_matmul_compute(op.tile, spec);
+            break;
+        }
+    }
+}
+
+long arg(int argc, char** argv, const char* flag, long def) {
+    for (int i = 1; i + 1 < argc; ++i)
+        if (std::strcmp(argv[i], flag) == 0) return std::atol(argv[i + 1]);
+    return def;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    struct Opt { const char* flag; long def; };
+    long vals[4];
+    const Opt opts[4] = {{"--m", 32}, {"--n", 32}, {"--k", 32}, {"--tile", 16}};
+    for (int i = 0; i < 4; ++i) {
+        vals[i] = arg(argc, argv, opts[i].flag, opts[i].def);
+        if (vals[i] <= 0) {
+            std::cerr << "error: " << opts[i].flag << " must be a positive integer\n"
+                      << "usage: matmul_simulator [--m M] [--n N] [--k K] [--tile T]\n";
+            return 2;
+        }
+    }
+    const Size M = vals[0], N = vals[1], K = vals[2], T = vals[3];
+    if (M % T || N % T || K % T) {
+        std::cerr << "error: --tile must divide --m, --n and --k evenly\n";
+        return 2;
+    }
+
+    MatMulScheduleGenerator::Config cfg;
+    cfg.M = M; cfg.N = N; cfg.K = K;
+    cfg.Ti = cfg.Tj = cfg.Tk = T;
+    cfg.a_base = 0x100000; cfg.b_base = 0x400000; cfg.c_base = 0x700000;
+    auto schedule = MatMulScheduleGenerator(cfg).generate();
+    if (!schedule.valid) {
+        std::cerr << "schedule refused: " << schedule.error_message << "\n";
+        return 1;
+    }
+
+    // Host operands (deterministic, non-trivial) and the reference C = A x B
+    std::vector<double> A(M * K), B(K * N), C(M * N, 0.0);
+    for (Size i = 0; i < M; ++i)
+        for (Size k = 0; k < K; ++k) A[i * K + k] = ((i + k) % 4) + 1;
+    for (Size k = 0; k < K; ++k)
+        for (Size j = 0; j < N; ++j) B[k * N + j] = ((k * 2 + j) % 3) + 1;
+    for (Size i = 0; i < M; ++i)
+        for (Size k = 0; k < K; ++k)
+            for (Size j = 0; j < N; ++j) C[i * N + j] += A[i * K + k] * B[k * N + j];
+
+    std::cout << "Matmul simulator  —  " << schedule.metadata.strategy
+              << "  (C[" << M << "x" << N << "] = A[" << M << "x" << K
+              << "] * B[" << K << "x" << N << "], tile " << T << ")\n\n";
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.max_cycles = 2'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+
+    // Seed the A and B input tiles from the host operands. A[ti,0,tk] is the
+    // [T x T] block A(ti,tk); B[0,tj,tk] is the block B(tk,tj).
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        std::vector<float> block(T * T);
+        if (id.matrix == MatrixID::A) {
+            for (Size r = 0; r < T; ++r)
+                for (Size c = 0; c < T; ++c)
+                    block[r * T + c] = static_cast<float>(A[(id.ti * T + r) * K + id.tk * T + c]);
+        } else {  // B[0, tj, tk] -> B block (tk, tj)
+            for (Size r = 0; r < T; ++r)
+                for (Size c = 0; c < T; ++c)
+                    block[r * T + c] = static_cast<float>(B[(id.tk * T + r) * N + id.tj * T + c]);
+        }
+        exec.set_tile_payload(id, TilePayload{T, T, std::move(block)});
+    }
+    for (const auto& op : schedule.operations) enqueue(exec, op);
+
+    // Drive one cycle at a time, tracking every occupancy transition
+    TileTracker tracker;
+    tracker.observe(exec);
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
+        exec.step();
+        tracker.observe(exec);
+    }
+    std::cout << tracker.log() << "\n";
+
+    if (!exec.is_complete()) {
+        std::cerr << "schedule did not complete (deadlock or max_cycles)\n";
+        return 1;
+    }
+
+    // Correctness: each C tile matches the host reference C = A x B
+    std::cout << "Result: C = A x B\n";
+    double max_err = 0.0;
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        for (Size r = 0; r < T; ++r)
+            for (Size c = 0; c < T; ++c) {
+                const double got = p.values[r * T + c];
+                const double want = C[(id.ti * T + r) * N + id.tj * T + c];
+                max_err = std::max(max_err, std::abs(got - want));
+            }
+    }
+    const bool ok = max_err < 1e-3;
+    std::cout << "  max abs error vs host oracle: " << max_err
+              << (ok ? "  [OK]" : "  [FAIL]") << "\n";
+    std::cout << "\n" << (ok ? "MATMUL OK" : "MATMUL MISMATCH") << "\n";
+    return ok ? 0 : 1;
+}

--- a/examples/schedule/matmul_simulator.cpp
+++ b/examples/schedule/matmul_simulator.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -82,6 +83,7 @@ int main(int argc, char** argv) {
         return 2;
     }
 
+    try {
     MatMulScheduleGenerator::Config cfg;
     cfg.M = M; cfg.N = N; cfg.K = K;
     cfg.Ti = cfg.Tj = cfg.Tk = T;
@@ -162,4 +164,8 @@ int main(int argc, char** argv) {
               << (ok ? "  [OK]" : "  [FAIL]") << "\n";
     std::cout << "\n" << (ok ? "MATMUL OK" : "MATMUL MISMATCH") << "\n";
     return ok ? 0 : 1;
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n";
+        return 1;
+    }
 }


### PR DESCRIPTION
The matmul counterpart to the softmax simulator (#165): a standalone tiled matmul that drives the `TileTracker` to show the same horizontal L3/L2/L1/array state-transition log, plus a matmul-specific discussion of the tile log.

## Sample output (`matmul_simulator`, default C[32x32]=A*B, tile 16)

```text
cyc    | L3 buffers                         | L2 banks                           | L1 / array                        
-------+------------------------------------+------------------------------------+-----------------------------------
0      | -                                  | -                                  | -
36     | A[0,0,0]                           | -                                  | -
37     | A[0,0,0] A[0,0,1]                  | -                                  | -
38     | A[0,0,0] A[0,0,1] B[0,0,1]         | -                                  | -
39     | A[0,0,0] A[0,0,1] B[0,0,1] B[0,1,1 | -                                  | -
60     | A[0,0,1] B[0,0,1] B[0,1,1]         | A[0,0,0]                           | -
62     | A[0,0,1] B[0,1,1]                  | A[0,0,0] B[0,0,1]                  | -
72     | A[0,0,1] B[0,1,1]                  | A[0,0,0] B[0,0,1]                  | A[0,0,0]*
74     | A[0,0,1] B[0,1,1]                  | A[0,0,0] B[0,0,1]                  | A[0,0,0]* B[0,0,1]*
84     | B[0,1,1]                           | A[0,0,1] B[0,0,1]                  | A[0,0,0]* B[0,0,1]*
85     | B[0,0,0] B[0,1,1]                  | A[0,0,1] B[0,0,1]                  | A[0,0,0]* B[0,0,1]*
86     | B[0,0,0] B[0,1,0]                  | A[0,0,1] B[0,1,1]                  | A[0,0,0]* B[0,0,1]*
87     | A[1,0,0] B[0,0,0] B[0,1,0]         | A[0,0,1] B[0,1,1]                  | A[0,0,0]* B[0,0,1]*
88     | A[1,0,0] A[1,0,1] B[0,0,0] B[0,1,0 | A[0,0,1] B[0,1,1]                  | A[0,0,0]* B[0,0,1]*
96     | A[1,0,0] A[1,0,1] B[0,0,0] B[0,1,0 | A[0,0,1] B[0,1,1]                  | A[0,0,0]* A[0,0,1]* B[0,0,1]*
98     | A[1,0,0] A[1,0,1] B[0,0,0] B[0,1,0 | A[0,0,1] B[0,1,1]                  | A[0,0,0]* A[0,0,1]* B[0,0,1]* B[0,1,1]*
...
Result: C = A x B
  max abs error vs host oracle: 0  [OK]

MATMUL OK
```

## What

- `examples/schedule/matmul_simulator.cpp` drives a `MatMulScheduleGenerator` schedule **cycle-by-cycle**; each `C[ti,tj]` COMPUTE becomes a value-producing `MatMulComputeSpec` by splitting its interleaved A/B K-slice dependencies into the paired `a_tiles`/`b_tiles` the executor accumulates. It seeds A/B from host operands and verifies `C = A x B` against a host oracle (**max error 0**). Configurable `--m/--n/--k/--tile`; CI smoke test.
- `docs/tools/matmul-simulator.md` discusses the **what / why / how** of the matmul tile log and contrasts it with softmax:
  - **two interleaved operand streams** (A rows, B columns), not softmax's one;
  - **K-accumulation is a join, not a chain** — a C tile fires only when all its K-slices are fed;
  - **large data tiles show movement, not content** — a matmul tile is a T×T block (256 values), so the cells show identity/location, whereas softmax's tiny `(m,l)` stat prints its value. Same tracker, different information density because the operators carry different state;
  - **operand reuse and blocking** are visible in the trace.

## Verification

Full suite: **113/113 pass** (including the new `matmul_simulator` smoke test). Cross-linked from the concept doc and `docs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tiled matrix multiplication simulator with cycle-by-cycle tile-state logs (L3/L2/L1/array).
  * Supports configurable matrix and tile dimensions and runs a tiled `C = A × B` schedule.
  * Validates results against a reference multiplication with clear `[OK]`/`[FAIL]` reporting.
* **Documentation**
  * Added a dedicated matmul simulator guide and expanded tile-state tracking explanations.
  * Updated simulator references to include both softmax and matmul simulators.
* **Tests**
  * Added a CI smoke test for the new matmul simulator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->