### PR TITLE
feat(timing): 2D submatrix tile labels + array payload retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tile tracker: 2D submatrix labels + array liveness (#165 follow-up).**
+  `TileTracker::Config::label` lets a driver name tiles by their 2D
+  submatrix index instead of the raw 3-tuple `TileID`: a tile coordinate
+  lives in the 3D M/N/K grid but each matrix uses only two axes (the third
+  is a placeholder 0), so the matmul simulator now prints `A[ti,tk]` /
+  `B[tk,tj]` / `C[ti,tj]` and softmax `[row,tile]` - e.g. `A[0,0,1]` reads
+  as `A[0,1]`, unambiguously a different submatrix from `A[0,0]`.
+
+### Fixed
+
+- **Value-plane payload retirement (#165 follow-up).** The executor freed
+  L3/L2 payloads on credit release but never freed the transient L1/COMPUTE
+  (array) copies, so `tiles_at`/`TileTracker` showed every tile that ever
+  reached the array and a long run grew memory unbounded. A compute now
+  retires each consumed input whose payload no pending compute still needs
+  (respecting the reuse of an A row-tile across several C tiles, and never
+  freeing the compute's own result - the accumulator case), and a result is
+  freed when it drains. The array column now shows only tiles still in play
+  and drains to empty.
+
 - **Matmul simulator + tile-log discussion.** `examples/schedule/matmul_simulator`
   drives a tiled `C = A x B` schedule (`MatMulScheduleGenerator`) cycle-by-cycle
   through the `TileTracker`, so the horizontal L3/L2/L1/array log shows the two

--- a/docs/tile-state-tracking.md
+++ b/docs/tile-state-tracking.md
@@ -29,10 +29,18 @@ cyc    | L3 buffers      | L2 banks        | L1 / array
 
 with L3 on the left, L2 to its right, and L1/array on the far right — the same
 left-to-right order data physically flows toward the compute fabric. Each cell
-names a resident tile (`A[0,0,0]`) and, when the value plane is active, shows a
-compact summary of its **content** (e.g. an online-softmax stats tile
-`B[0,0,0]=(-0.69,440)` carrying its running max and exp-sum). An `*` marks a
-tile resident in the array (compute storage).
+names a resident tile and, when the value plane is active, shows a compact
+summary of its **content** (e.g. an online-softmax stats tile
+`B[0,0]=(-0.69,440)` carrying its running max and exp-sum). An `*` marks a tile
+resident in the array (compute storage).
+
+Tiles carry a **2D submatrix index**. A `TileID` is a coordinate in the 3D
+M/N/K tile grid `(ti, tj, tk)`, but each matrix uses only two of those axes (the
+third is a placeholder pinned to 0), so a driver labels tiles with the two live
+axes — matmul as `A[ti,tk]` / `B[tk,tj]` / `C[ti,tj]`, softmax as `[row, tile]`.
+`A[0,1]` is thus row-block 0, K-block 1 — a genuinely different submatrix from
+`A[0,0]`. (`TileTracker::Config::label` sets the convention; the raw 3-tuple is
+the default.)
 
 A band is emitted only when occupancy *changes*, so reading the bands
 top-to-bottom is reading the schedule's **state-transition trace** — not a
@@ -137,39 +145,51 @@ C tile accumulates over its K-slices.
 ### Reading a band (worked example)
 
 From `softmax_simulator --rows 3 --len 512` (three softmax rows, two tiles each).
-Four bands, **excerpted** from the full trace (some cells elided with `...`):
+Tiles use their 2D `[row, tile]` index (the softmax driver drops the unused K
+axis). Five bands, **excerpted** from the full trace:
 
 ```text
 cyc    | L3 buffers                         | L2 banks                           | L1 / array
 -------+------------------------------------+------------------------------------+-----------------------------------
-36     | A[0,0,0]                           | -                                  | -
-120    | A[2,1,0]                           | A[1,0,0] A[1,1,0] A[2,0,0]         | A[0,0,0]* A[0,1,0]* A[1,0,0]*
-129    | A[2,1,0]                           | A[1,0,0] A[1,1,0] A[2,0,0]         | ... A[1,0,0]* B[0,0,0]=(-0.69,440)*
-204    | -                                  | -                                  | ... B[0,0,0]=(-0.69,440)* B[1,0,0]=(0.31,440)* C[0,0,0]* C[0,1,0]* C[1,0,0]* C[1,1,0]*
+36     | A[0,0]                             | -                                  | -
+120    | A[2,1]                             | A[1,0] A[1,1] A[2,0]               | A[0,0]* A[0,1]* A[1,0]*
+129    | A[2,1]                             | A[1,0] A[1,1] A[2,0]               | A[0,0]* A[0,1]* A[1,0]* B[0,0]=(-0.69,440)*
+162    | -                                  | A[2,0] A[2,1]                      | A[1,0]* A[1,1]* C[0,0]* C[0,1]*
+204    | -                                  | -                                  | A[2,0]* A[2,1]* C[0,0]* C[0,1]* C[1,0]* C[1,1]*
 ```
 
-- **cyc 36** — the first input tile `A[0,0,0]` has arrived at L3.
-- **cyc 120** — all three rows are in flight at once: `A[2,1,0]` still in L3,
+- **cyc 36** — the first input tile `A[0,0]` (row 0, reduction-tile 0) has
+  arrived at L3.
+- **cyc 120** — all three rows are in flight at once: `A[2,1]` still in L3,
   row 1's tiles in L2, row 0's tiles already in the array (`*`). That overlap is
   the schedule **pipelining** across the batch.
-- **cyc 129** — the stats compute for row 0 has produced `B[0,0,0]=(-0.69,440)`:
+- **cyc 129** — the stats compute for row 0 has produced `B[0,0]=(-0.69,440)`:
   running max `-0.69`, normalizer `440`. It stays resident (its `*` persists) to
   feed row 0's apply computes — no DRAM round-trip.
-- **cyc 204** — rows 0 and 1 have produced their normalized outputs
-  (`C[0,*]`, `C[1,*]`); their **per-row** stats `B[0,0,0]=(-0.69,440)` and
-  `B[1,0,0]=(0.31,440)` differ because each row has its own max. Row 2 is still
-  streaming through L2 in the full trace and finishes a few bands later — this
-  excerpt stops before its outputs form. The run ends when all three rows'
-  softmax sum to 1.
+- **cyc 162** — row 0 is done: its normalized outputs `C[0,0]`, `C[0,1]` have
+  formed, and its inputs `A[0,*]` **and** its stat `B[0,0]` have **retired** from
+  the array (no compute needs them any more). Only tiles still in play remain.
+- **cyc 204** — rows 0 and 1 have produced their outputs `C[0,*]`, `C[1,*]`;
+  row 2's inputs `A[2,*]` are still resident. The run ends when all three rows'
+  softmax sum to 1 and the array drains empty.
+
+### Tile liveness — the array holds only what is active
+
+The L1/array column shows only tiles **currently in play**: a fed input while a
+compute that needs it is still pending, a result until it drains, and a resident
+tile (like softmax's `(m, l)`) until no pending compute holds it. When a compute
+completes, its consumed inputs **retire** from the array unless another pending
+compute still needs them (an A row-tile feeds several C tiles, so it lingers
+until its last consumer fires); a result retires when it drains. So the array
+fills as the pipeline warms, then drains to empty — you can watch a matmul's
+`C` tiles leave the array and stream back out `L2 -> L3 -> DRAM` at the end.
+
+(This retirement also fixes a real value-plane leak: the executor already frees
+L3/L2 payloads on credit release, and now frees the transient L1/array copies
+too, so a long simulation no longer grows memory with every tile it moves.)
 
 ### Notes and limits when reading larger traces
 
-- **The L1/array column accumulates.** Compute-storage payloads persist (that
-  persistence is what enables the resident hand-off), so by the end of a run the
-  array column lists every tile that ever reached compute. This is faithful to
-  the model, but the rightmost column grows with the schedule; read it as
-  "everything that has reached the array so far," and watch the **left** columns
-  (L3/L2) for the live streaming front.
 - **Columns truncate** at `TileTracker::Config::col_width` (default 34). Widen
   it, or use a smaller `--tile` / `--len`, for wide rows.
 - The tracker only sees tiles once the **value plane** is active (payloads seeded);

--- a/docs/tools/matmul-simulator.md
+++ b/docs/tools/matmul-simulator.md
@@ -72,35 +72,59 @@ hierarchy differently, and the trace makes that visible.
 From `matmul_simulator` (default `C[32x32]=A*B`, tile 16, `interleaved_ab`).
 Excerpted from the full trace (`...` elides cells):
 
+Tiles are labelled with their **2D submatrix index** (see the naming note
+below): `A[ti,tk]`, `B[tk,tj]`, `C[ti,tj]`.
+
 ```text
 cyc    | L3 buffers                         | L2 banks                           | L1 / array
 -------+------------------------------------+------------------------------------+-----------------------------------
-38     | A[0,0,0] A[0,0,1] B[0,0,1]         | -                                  | -
-74     | A[0,0,1] B[0,1,1]                  | A[0,0,0] B[0,0,1]                  | A[0,0,0]* B[0,0,1]*
-159    | -                                  | -                                  | A[0,0,0]* A[0,0,1]* A[1,0,0]* A[1,0,1]* B[0,0,0]* B[0,0,1]* B[0,1,0]* B[0,1,1]*
-187    | -                                  | -                                  | ... B[0,1,1]* C[0,0,0]*
-248    | C[0,0,0] C[0,1,0]                  | C[1,0,0] C[1,1,0]                  | ... C[0,0,0]* C[0,1,0]* C[1,0,0]* C[1,1,0]*
+38     | A[0,0] A[0,1] B[0,1]               | -                                  | -
+88     | A[1,0] A[1,1] B[0,0] B[0,1]        | A[0,1] B[1,1]                      | A[0,0]* B[1,0]*
+159    | -                                  | -                                  | A[0,0]* A[0,1]* A[1,0]* A[1,1]* B[0,0]* B[0,1]* B[1,0]* B[1,1]*
+187    | -                                  | -                                  | ... B[1,1]* C[0,0]*
+211    | -                                  | C[0,0]                             | A[1,0]* A[1,1]* B[0,0]* B[0,1]* B[1,0]* B[1,1]* C[0,1]*
+311    | C[1,1]                             | -                                  | -
+335    | -                                  | -                                  | -
 ```
 
-- **cyc 38** — A and B tiles stream into L3 **interleaved**: two A K-slices and
-  a B K-slice already staged. Neither operand is allowed to monopolize the
+- **cyc 38** — A and B tiles stream into L3 **interleaved** (`A[0,0] A[0,1] B[0,1]`):
+  two A K-slices and a B tile already staged. Neither operand monopolizes the
   buffers.
-- **cyc 74** — the pipeline is filling: `A[0,0,0]`/`B[0,0,1]` in the array (`*`),
-  their successors one boundary behind in L2, more in L3.
-- **cyc 159** — all K-slices of A and B for the first outputs are resident in the
-  array: `A[0,0,*]`, `A[1,0,*]`, `B[*,*,*]`. The **join** is complete, so a
-  compute can fire.
-- **cyc 187** — the first result `C[0,0,0]` appears — `A[0,0,0]*B[0,0,0] +
-  A[0,0,1]*B[0,1,0]` accumulated over the two K-slices.
-- **cyc 248** — the four output tiles `C[0,0]`, `C[0,1]`, `C[1,0]`, `C[1,1]`
-  drain back out through L2/L3 toward DRAM. The run then checks `C = A x B`
-  against the host reference (max abs error 0 for integer operands).
+- **cyc 88** — the pipeline is filling: `A[0,0]`/`B[1,0]` in the array (`*`),
+  successors one boundary behind in L2, more in L3.
+- **cyc 159** — all K-slices for the first outputs are resident: `A[0,*]`,
+  `A[1,*]`, `B[*,*]`. The **join** is complete, so a compute can fire.
+- **cyc 187** — the first result `C[0,0]` appears — `A[0,0]*B[0,0] +
+  A[0,1]*B[1,0]` accumulated over the two K-slices.
+- **cyc 211** — `C[0,0]` has drained to L2 and its finished inputs have
+  **retired** from the array; `C[0,1]` is the next result. The array holds only
+  tiles still in play.
+- **cyc 311 → 335** — the output tiles drain back out through L2/L3 toward DRAM
+  and the array empties. The run then checks `C = A x B` against the host
+  reference (max abs error 0 for integer operands).
 
-The rightmost column accumulates all resident A/B/C tiles (compute payloads
-persist); read the **left** columns for the live streaming front, and note the
-strategy in the header (`interleaved_ab`). Other strategies
+Note the strategy in the header (`interleaved_ab`); other strategies
 (`output_stationary`, `blocked_ab`, `prefetch_next`) produce visibly different
 streaming orders in the same view.
+
+## A note on tile naming
+
+A `TileID` is a coordinate in the 3D **M/N/K tile grid** `(ti, tj, tk)`, but each
+matrix only uses **two** of those axes — the third is a placeholder pinned to 0:
+
+| matrix | shape | live axes | placeholder |
+|--------|-------|-----------|-------------|
+| A | M x K | `(ti, tk)` — row-block, K-block | `tj = 0` |
+| B | K x N | `(tk, tj)` — K-block, col-block | `ti = 0` |
+| C | M x N | `(ti, tj)` — row-block, col-block | `tk = 0` |
+
+So the raw `TileID` `A[0,0,1]` is **not** submatrix `A[0,0]` — its meaningful
+second coordinate is the *third* slot (`tk = 1`, a K-column block), and the
+middle `0` is dead weight. In 2D that tile is `A[0,1]`: row-block 0, K-block 1,
+i.e. `A[0:16, 16:32]`. The simulator drops the placeholder axis and prints the
+2D submatrix index, so `A[0,0]` and `A[0,1]` are genuinely different blocks of A.
+(`TileTracker::Config::label` lets any driver supply its operator's convention;
+the raw 3-tuple `TileID::to_string()` remains the default.)
 
 ## Under the hood
 

--- a/docs/tools/matmul-simulator.md
+++ b/docs/tools/matmul-simulator.md
@@ -38,15 +38,15 @@ hierarchy differently, and the trace makes that visible.
 
 - **Two interleaved input streams, not one.** Softmax streams a single row;
   matmul streams A row-blocks *and* B column-blocks together. In the log you see
-  pairs like `A[0,0,0] A[0,0,1] B[0,0,1] B[0,1,1]` filling L3 — the
-  `interleaved_ab` discipline keeping an A-burst and a B-burst simultaneously
-  resident so neither starves the other (the #67 per-matrix burst share).
+  pairs like `A[0,0] A[0,1] B[0,1] B[1,1]` filling L3 — the `interleaved_ab`
+  discipline keeping an A-burst and a B-burst simultaneously resident so neither
+  starves the other (the #67 per-matrix burst share).
 
 - **K-accumulation is a join, not a chain.** A `C[ti,tj]` compute depends on
-  every A[ti,*,tk] and B[*,tj,tk] K-slice (`2 * k_tiles` feeds); it cannot fire
+  every `A[ti,tk]` and `B[tk,tj]` K-slice (`2 * k_tiles` feeds); it cannot fire
   until all have arrived, and its latency scales with the K-slice count. You see
-  the A/B tiles for both K-slices reach the array (`*`) before `C[0,0,0]`
-  appears — the reduction depth made literal.
+  the A/B tiles for both K-slices reach the array (`*`) before `C[0,0]` appears —
+  the reduction depth made literal.
 
 - **Tiles are large data blocks, so the log shows movement, not content.** A
   softmax stats tile is two numbers `(m, l)` and prints its value; a matmul tile

--- a/docs/tools/softmax-simulator.md
+++ b/docs/tools/softmax-simulator.md
@@ -26,21 +26,21 @@ Online softmax simulator  —  online_row_resident  (1 row(s) x 512, tile 256, e
 cyc    | L3 buffers                         | L2 banks                           | L1 / array                        
 -------+------------------------------------+------------------------------------+-----------------------------------
 0      | -                                  | -                                  | -
-36     | A[0,0,0]                           | -                                  | -
-37     | A[0,0,0] A[0,1,0]                  | -                                  | -
-60     | A[0,1,0]                           | A[0,0,0]                           | -
-72     | A[0,1,0]                           | A[0,0,0]                           | A[0,0,0]*
-84     | -                                  | A[0,1,0]                           | A[0,0,0]*
-96     | -                                  | A[0,1,0]                           | A[0,0,0]* A[0,1,0]*
-108    | -                                  | -                                  | A[0,0,0]* A[0,1,0]*
-129    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)*
-162    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
-174    | -                                  | C[0,0,0]                           | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
-186    | -                                  | C[0,0,0] C[0,1,0]                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
-199    | C[0,0,0]                           | C[0,1,0]                           | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
-223    | C[0,0,0] C[0,1,0]                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
-250    | C[0,1,0]                           | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
-274    | -                                  | -                                  | A[0,0,0]* A[0,1,0]* B[0,0,0]=(-0.69,440)* C[0,0,0]* C[0,1,0]*
+36     | A[0,0]                             | -                                  | -
+37     | A[0,0] A[0,1]                      | -                                  | -
+60     | A[0,1]                             | A[0,0]                             | -
+72     | A[0,1]                             | A[0,0]                             | A[0,0]*
+84     | -                                  | A[0,1]                             | A[0,0]*
+96     | -                                  | A[0,1]                             | A[0,0]* A[0,1]*
+108    | -                                  | -                                  | A[0,0]* A[0,1]*
+129    | -                                  | -                                  | A[0,0]* A[0,1]* B[0,0]=(-0.69,440)*
+162    | -                                  | -                                  | C[0,0]* C[0,1]*
+174    | -                                  | C[0,0]                             | C[0,1]*
+186    | -                                  | C[0,0] C[0,1]                      | -
+199    | C[0,0]                             | C[0,1]                             | -
+223    | C[0,0] C[0,1]                      | -                                  | -
+250    | C[0,1]                             | -                                  | -
+274    | -                                  | -                                  | -
 
 Result: each row's softmax sums to 1
   row 0: sum = 1  [OK]
@@ -48,13 +48,15 @@ Result: each row's softmax sums to 1
 SOFTMAX OK
 ```
 
-Reading it: the two input tiles `A[0,0,0]`/`A[0,1,0]` stream `DRAM -> L3 -> L2 ->
-L1/array`; the **stats compute** produces `B[0,0,0]=(m,l)` — here `(-0.69, 440)`,
-the running max and the exp-sum normalizer — which then stays **resident in the
-array** (the E8 compute-resident hand-off, no DRAM round-trip) and feeds the
-**apply computes** that emit the normalized `C[0,0,0]`/`C[0,1,0]`; those drain back
-`array -> L2 -> L3 -> DRAM`. The run ends on the softmax correctness check:
-each row sums to 1.
+Reading it: tiles carry their 2D `[row, tile]` index. The two input tiles
+`A[0,0]`/`A[0,1]` stream `DRAM -> L3 -> L2 -> L1/array`; the **stats compute**
+produces `B[0,0]=(m,l)` — here `(-0.69, 440)`, the running max and the exp-sum
+normalizer — which then stays **resident in the array** (the E8 compute-resident
+hand-off, no DRAM round-trip) and feeds the **apply computes** that emit the
+normalized `C[0,0]`/`C[0,1]`. Once row 0's applies fire, its inputs and its stat
+**retire** from the array (cyc 162), leaving only the outputs, which drain back
+`array -> L2 -> L3 -> DRAM`. The run ends on the softmax correctness check: each
+row sums to 1.
 
 These are **buffers, not caches** — the log reads as tile *arrived* / *resident*
 / credit *returned*, never hit/miss/evict.

--- a/examples/schedule/matmul_simulator.cpp
+++ b/examples/schedule/matmul_simulator.cpp
@@ -131,8 +131,22 @@ int main(int argc, char** argv) {
     }
     for (const auto& op : schedule.operations) enqueue(exec, op);
 
-    // Drive one cycle at a time, tracking every occupancy transition
-    TileTracker tracker;
+    // Drive one cycle at a time, tracking every occupancy transition.
+    // Label tiles with their 2D submatrix index: A is rows x depth (ti,tk),
+    // B is depth x cols (tk,tj), C is rows x cols (ti,tj) - the unused third
+    // axis of the M/N/K grid is dropped, so A[0,0,1] reads as A[0,1].
+    TileTracker::Config tcfg;
+    tcfg.label = [](const TileID& id) {
+        auto ij = [](Size a, Size b) {
+            return "[" + std::to_string(a) + "," + std::to_string(b) + "]";
+        };
+        switch (id.matrix) {
+            case MatrixID::A: return "A" + ij(id.ti, id.tk);
+            case MatrixID::B: return "B" + ij(id.tk, id.tj);
+            default:          return "C" + ij(id.ti, id.tj);
+        }
+    };
+    TileTracker tracker(tcfg);
     tracker.observe(exec);
     while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
         exec.step();

--- a/examples/schedule/softmax_simulator.cpp
+++ b/examples/schedule/softmax_simulator.cpp
@@ -140,8 +140,17 @@ int main(int argc, char** argv) {
     }
     for (const auto& op : schedule.operations) enqueue(exec, op, cfg.reduction_elems);
 
-    // Drive one cycle at a time, tracking every occupancy transition
-    TileTracker tracker;
+    // Drive one cycle at a time, tracking every occupancy transition.
+    // Softmax tiles index (row, reduction-tile) in (ti, tj); the K axis is
+    // unused (tk=0), so label 2D as X[ti,tj] rather than the full X[ti,tj,tk].
+    TileTracker::Config tcfg;
+    tcfg.label = [](const TileID& id) {
+        const char* m = id.matrix == MatrixID::A ? "A"
+                      : id.matrix == MatrixID::B ? "B" : "C";
+        return std::string(m) + "[" + std::to_string(id.ti) + "," +
+               std::to_string(id.tj) + "]";
+    };
+    TileTracker tracker(tcfg);
     tracker.observe(exec);
     while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
         exec.step();

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -602,6 +602,29 @@ private:
     [[nodiscard]] size_t count_completed_tiles() const;
 
     [[nodiscard]] bool dependencies_satisfied(const PendingCompute& pc) const;
+
+    /**
+     * @brief Is this tile still an input of any pending (not-yet-fired) compute?
+     *
+     * Used to retire consumed payloads (issue #165 follow-up): a fed or
+     * resident input may be shared by several computes, so its L1/COMPUTE
+     * payload can only be freed once no pending compute still needs it.
+     */
+    [[nodiscard]] bool tile_needed_by_pending_compute(const TileID& id) const {
+        for (const auto& pc : pending_computes_) {
+            for (const auto& dep : pc.dependencies)
+                if (dep.first == id) return true;
+            for (const auto& dep : pc.resident_dependencies)
+                if (dep.first == id) return true;
+        }
+        return false;
+    }
+
+    /// Free a tile's transient array-side (L1 + COMPUTE) payloads.
+    void retire_array_payload(const TileID& id) {
+        l1_payloads_.erase(id);
+        compute_payloads_.erase(id);
+    }
     void execute_matmul(const PendingCompute& pc);
     void execute_functional(const PendingCompute& pc);
     void apply_payload_event(const TimingEvent& event);
@@ -1028,7 +1051,27 @@ inline bool ConcurrentTimingExecutor::step() {
             event.matrix_base_address = it->tile.matrix_base_address;
             events_.push_back(event);
 
+            // Collect this compute's input tiles before removing it, so we can
+            // retire any whose payload no consumer still needs (issue #165):
+            // the array holds a tile only while it is actively being consumed.
+            const TileID result_id = it->tile.tile_id;
+            std::vector<TileID> consumed_inputs;
+            consumed_inputs.reserve(it->dependencies.size() +
+                                    it->resident_dependencies.size());
+            for (const auto& d : it->dependencies) consumed_inputs.push_back(d.first);
+            for (const auto& d : it->resident_dependencies) consumed_inputs.push_back(d.first);
+
             it = pending_computes_.erase(it);
+
+            if (functional_payloads_enabled_) {
+                for (const auto& id : consumed_inputs) {
+                    // Never retire the compute's OWN result (the accumulator
+                    // pattern makes a tile both a resident input and the
+                    // result); it must survive for its DRAIN.
+                    if (id == result_id) continue;
+                    if (!tile_needed_by_pending_compute(id)) retire_array_payload(id);
+                }
+            }
         } else {
             ++it;
         }
@@ -1308,6 +1351,12 @@ inline void ConcurrentTimingExecutor::apply_payload_event(const TimingEvent& eve
         case EventType::TILE_DRAINED:
             copy_payload(MemoryLevel::COMPUTE, MemoryLevel::L1, event.tile_id, event.component_id);
             copy_payload(MemoryLevel::L1, MemoryLevel::L2, event.tile_id, event.slot_id);
+            // The result has moved to L2; free its array-side copies unless a
+            // pending compute still holds it resident (issue #165).
+            if (functional_payloads_enabled_ &&
+                !tile_needed_by_pending_compute(event.tile_id)) {
+                retire_array_payload(event.tile_id);
+            }
             break;
         case EventType::BM_WRITEBACK_COMPLETE:
             copy_payload(MemoryLevel::L2, MemoryLevel::L3, event.tile_id, event.slot_id);

--- a/include/sw/kpu/timing/tile_tracker.hpp
+++ b/include/sw/kpu/timing/tile_tracker.hpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -48,6 +49,14 @@ public:
         std::size_t col_width = 34;   ///< width of each level column
         std::size_t max_values = 3;   ///< values shown per tile cell (else elided)
         bool show_compute_in_l1 = true;  ///< fold COMPUTE (array) into the L1 column
+
+        /// How a tile is named in a cell. The default prints the full
+        /// (ti,tj,tk) TileID. A tile coordinate is really a 2D submatrix
+        /// index living in the 3D M/N/K grid (each matrix uses only two axes,
+        /// the third is 0), so a caller that knows its operator's convention
+        /// can supply a 2D label - e.g. matmul: A[ti,tk], B[tk,tj], C[ti,tj].
+        std::function<std::string(const TileID&)> label =
+            [](const TileID& id) { return id.to_string(); };
     };
 
     TileTracker() = default;
@@ -108,7 +117,7 @@ private:
     /// One cell: "A[0,2]" plus "=(v0,v1,...)" when a small payload is present.
     std::string cell(const ConcurrentTimingExecutor& exec, MemoryLevel level,
                      const TileID& id) const {
-        std::string c = id.to_string();
+        std::string c = config_.label(id);
         if (exec.has_tile_payload_at(level, id)) {
             const auto& p = exec.tile_payload_at(level, id);
             if (!p.values.empty() && p.values.size() <= config_.max_values) {


### PR DESCRIPTION
Follow-up to the tile-state tracking work (#165), addressing two things raised in review of the matmul simulator: the confusing 3-tuple tile names, and the ever-growing L1/array column.

## 1. 2D submatrix tile labels

A `TileID` is a coordinate in the 3D **M/N/K tile grid** `(ti, tj, tk)`, but each matrix uses only **two** of those axes — the third is a placeholder pinned to 0:

| matrix | live axes | placeholder |
|--------|-----------|-------------|
| A (M×K) | `(ti, tk)` | `tj = 0` |
| B (K×N) | `(tk, tj)` | `ti = 0` |
| C (M×N) | `(ti, tj)` | `tk = 0` |

So the raw `A[0,0,1]` is **not** the same as `A[0,0]` — its real second coordinate is the *third* slot (`tk = 1`, a K-column block). `TileTracker::Config::label` lets a driver print the 2D submatrix index instead: matmul → `A[ti,tk]` / `B[tk,tj]` / `C[ti,tj]`, softmax → `[row, tile]`. Now `A[0,1]` reads unambiguously as "row 0, K-block 1", a different block from `A[0,0]`. The raw 3-tuple stays the default.

## 2. Array payload retirement (a real value-plane leak)

The executor freed L3/L2 payloads on credit release but **never** freed the transient L1/COMPUTE (array) copies — so `tiles_at`/`TileTracker` showed every tile that ever reached the array, and a long run grew memory unbounded. Now a completed compute **retires** each consumed input whose payload no *pending* compute still needs (respecting that an A row-tile feeds several C tiles, and never freeing the compute's own result — the accumulator case the test suite caught), and a result is freed when it drains. The array column now shows **only tiles still in play** and drains to empty:

```text
cyc | L3           | L2                | L1 / array
187 | -            | -                 | ... B[1,1]* C[0,0]*
211 | -            | C[0,0]            | A[1,0]* A[1,1]* B[0,0]* ... C[0,1]*   (C[0,0] drained, its inputs retired)
335 | -            | -                 | -                                    (array empty)
```

## Verification

Full suite **113/113**; both simulator smoke tests green; `C = A×B` and softmax rows-sum-to-1 still exact. Docs (matmul/softmax tool pages + the tile-state-tracking concept page) updated with fresh output and the naming + liveness explanations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tile tracking now supports customizable labels, including concise 2D matrix coordinates for A, B, and C tiles.
  * Simulator logs now display clearer tile names and indexing conventions.

* **Bug Fixes**
  * Improved cleanup of temporary tile data after computation, preventing memory growth during long simulations.
  * Tile tracking now reflects only tiles that remain active in the pipeline.

* **Documentation**
  * Updated tile-state, matrix multiplication, and softmax simulator guides with revised labels, examples, and lifecycle explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->