### PR TITLE
feat(examples): LayerNorm simulator + tile-log discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **LayerNorm simulator + tile-log discussion.** `examples/schedule/layernorm_simulator`
+  drives a LayerNorm schedule cycle-by-cycle through the `TileTracker`, showing
+  the row streaming in, the stats compute producing the `(mean, var)` tile
+  (visible in the log, e.g. `B[0,0]=(-0.115,0.0525)`) staying resident and
+  feeding the affine-normalize apply computes, and the outputs draining out -
+  ending on a host `y = gamma*(x-mean)/sqrt(var+eps)+beta` oracle check (max
+  error ~1e-7). Configurable `--rows/--len/--tile`; CI smoke test. Companion doc
+  `docs/tools/layernorm-simulator.md` shows layernorm is the *same* P3 movement
+  pattern as softmax (so it reuses the online row-reduction schedule), told
+  apart only by the statistic content `(mean, var)` vs `(max, exp-sum)` and the
+  apply.
+
 - **Tile tracker: 2D submatrix labels + array liveness (#165 follow-up).**
   `TileTracker::Config::label` lets a driver name tiles by their 2D
   submatrix index instead of the raw 3-tuple `TileID`: a tile coordinate

--- a/docs/README.md
+++ b/docs/README.md
@@ -161,8 +161,8 @@ The KPU is NOT a stored-program processor. It uses credit-based dataflow:
 See [KPU Execution Model](01-architecture/kpu-execution-model.md) for details.
 To *watch* a schedule execute as tiles migrate through the hierarchy, see
 [Tracking Schedules as Tile-State Movement](tile-state-tracking.md) and the
-[softmax](tools/softmax-simulator.md) / [matmul](tools/matmul-simulator.md)
-simulators.
+[softmax](tools/softmax-simulator.md) / [matmul](tools/matmul-simulator.md) /
+[layernorm](tools/layernorm-simulator.md) simulators.
 
 ---
 

--- a/docs/tools/layernorm-simulator.md
+++ b/docs/tools/layernorm-simulator.md
@@ -1,0 +1,104 @@
+# LayerNorm simulator + tile-state tracker
+
+`examples/schedule/layernorm_simulator.cpp` runs a LayerNorm schedule one
+executor cycle at a time and prints the **horizontal tile-state log** — what
+tiles occupy each level of the software-managed memory hierarchy, snapshot by
+snapshot. It is a third companion to the [softmax](softmax-simulator.md) and
+[matmul](matmul-simulator.md) simulators; for the general approach see
+[Tracking Schedules as Tile-State Movement](../tile-state-tracking.md).
+
+```text
+layernorm_simulator [--rows R] [--len N] [--tile T]
+```
+
+Default: `1 row x 512 features`, tile 256.
+
+---
+
+## What the LayerNorm tile log shows
+
+LayerNorm normalizes each row over its feature dimension:
+
+```text
+y = gamma * (x - mean) / sqrt(var + eps) + beta
+```
+
+That is a **row-streaming reduction** (compute `mean` and `var` over the row)
+followed by an **apply** pass (normalize each feature, then scale/shift by the
+per-feature `gamma`/`beta`). The log shows the row streaming
+`DRAM -> L3 -> L2 -> L1/array`, the stats compute producing the `(mean, var)`
+tile, that tile staying **resident in the array** and feeding the apply
+computes, and the normalized outputs draining back out. It ends on a host-oracle
+check.
+
+Sample (`layernorm_simulator`, default 1 row x 512, two tiles):
+
+```text
+LayerNorm simulator  —  online_row_resident  (1 row(s) x 512 features, tile 256, eps 1e-05)
+
+cyc    | L3 buffers                         | L2 banks                           | L1 / array                        
+-------+------------------------------------+------------------------------------+-----------------------------------
+0      | -                                  | -                                  | -
+36     | A[0,0]                             | -                                  | -
+37     | A[0,0] A[0,1]                      | -                                  | -
+60     | A[0,1]                             | A[0,0]                             | -
+72     | A[0,1]                             | A[0,0]                             | A[0,0]*
+84     | -                                  | A[0,1]                             | A[0,0]*
+96     | -                                  | A[0,1]                             | A[0,0]* A[0,1]*
+108    | -                                  | -                                  | A[0,0]* A[0,1]*
+129    | -                                  | -                                  | A[0,0]* A[0,1]* B[0,0]=(-0.115,0.0525)*
+162    | -                                  | -                                  | C[0,0]* C[0,1]*
+174    | -                                  | C[0,0]                             | C[0,1]*
+186    | -                                  | C[0,0] C[0,1]                      | -
+199    | C[0,0]                             | C[0,1]                             | -
+223    | C[0,0] C[0,1]                      | -                                  | -
+250    | C[0,1]                             | -                                  | -
+274    | -                                  | -                                  | -
+
+Result: y = gamma * (x - mean)/sqrt(var + eps) + beta
+  max abs error vs host oracle: 1.55641e-07  [OK]
+
+LAYERNORM OK
+```
+
+Reading it: tiles carry their 2D `[row, feature-tile]` index. `A[0,0]`/`A[0,1]`
+stream in; the **stats compute** produces `B[0,0]=(mean, var)` — here
+`(-0.115, 0.0525)` — which stays **resident** and feeds the apply computes that
+emit the normalized `C[0,0]`/`C[0,1]`; once the applies fire, the inputs and the
+stat **retire** from the array and the outputs drain back
+`array -> L2 -> L3 -> DRAM`.
+
+## Why it looks like softmax — and where it differs
+
+LayerNorm and softmax are the **same P3 movement pattern**: stream the row,
+reduce it to a small resident statistic, keep that statistic on chip, stream the
+row past it again to apply, drain the result. So the layernorm simulator reuses
+the *same online row-reduction schedule* as the softmax simulator — the tile
+movement is identical. What differs is the **content of the statistic** and the
+**apply**:
+
+| | statistic tile `B` | apply |
+|---|---|---|
+| softmax | `(max, exp-sum)` | `exp(x - max) / sum` |
+| layernorm | `(mean, var)` | `gamma * (x - mean)/sqrt(var + eps) + beta` |
+
+The tracker makes that visible: the `B` cell shows `(mean, var)` where softmax
+showed `(max, sum)`, and in a batched run each row carries its own stats
+(`B[0,0]=(-0.115,0.0525)`, `B[1,0]=(0.885,0.0525)` — the means differ per row).
+This is the value of a content-carrying log: the same movement, told apart by
+what the tiles hold. The per-feature `gamma`/`beta` are applied inside the apply
+op (one slice per feature-tile); their delivery is the elementwise/broadcast
+pattern and is not shown as separate tile movement here.
+
+## Under the hood
+
+- The movement schedule is the online row-reduction + resident-apply structure
+  (`OnlineSoftmaxScheduleGenerator` — the class is softmax-named but the
+  schedule is the generic P3 pattern; a dedicated LayerNorm generator is epic
+  E9 / issue #78).
+- `layernorm_stats` (mean + clamped population variance, the E3 VAR-moment
+  semantics) and `layernorm_apply` are bound to the COMPUTEs; `(mean, var)`
+  reaches the apply computes as a compute-**resident** dependency (the #155
+  mechanism, no DRAM round-trip).
+- `TileTracker` (#165) renders the bands from
+  `ConcurrentTimingExecutor::tiles_at(level)` - a pure observer.

--- a/docs/tools/layernorm-simulator.md
+++ b/docs/tools/layernorm-simulator.md
@@ -8,7 +8,7 @@ snapshot. It is a third companion to the [softmax](softmax-simulator.md) and
 [Tracking Schedules as Tile-State Movement](../tile-state-tracking.md).
 
 ```text
-layernorm_simulator [--rows R] [--len N] [--tile T]
+layernorm_simulator [--rows R] [--len N] [--tile T] [--max-cycles C]
 ```
 
 Default: `1 row x 512 features`, tile 256.

--- a/examples/schedule/CMakeLists.txt
+++ b/examples/schedule/CMakeLists.txt
@@ -75,3 +75,14 @@ if(KPU_BUILD_TESTS)
         LABELS "timing;matmul;tracker;example;v0.9"
     )
 endif()
+
+# LayerNorm simulator with tile-state tracker (companion to softmax_simulator)
+add_executable(layernorm_simulator layernorm_simulator.cpp)
+target_link_libraries(layernorm_simulator PRIVATE kpu_simulator)
+set_target_properties(layernorm_simulator PROPERTIES FOLDER "Examples/Schedule")
+if(KPU_BUILD_TESTS)
+    add_test(NAME layernorm_simulator COMMAND layernorm_simulator)
+    set_tests_properties(layernorm_simulator PROPERTIES
+        LABELS "timing;layernorm;tracker;example;v0.9"
+    )
+endif()

--- a/examples/schedule/layernorm_simulator.cpp
+++ b/examples/schedule/layernorm_simulator.cpp
@@ -22,6 +22,7 @@
 #include <sw/kpu/timing/tile_tracker.hpp>
 #include <sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -76,13 +77,15 @@ long arg(int argc, char** argv, const char* flag, long def) {
 
 int main(int argc, char** argv) {
     struct Opt { const char* flag; long def; };
-    long vals[3];
-    const Opt opts[3] = {{"--rows", 1}, {"--len", 512}, {"--tile", 256}};
-    for (int i = 0; i < 3; ++i) {
+    long vals[4];
+    const Opt opts[4] = {{"--rows", 1}, {"--len", 512}, {"--tile", 256},
+                         {"--max-cycles", 2'000'000}};
+    for (int i = 0; i < 4; ++i) {
         vals[i] = arg(argc, argv, opts[i].flag, opts[i].def);
         if (vals[i] <= 0) {
             std::cerr << "error: " << opts[i].flag << " must be a positive integer\n"
-                      << "usage: layernorm_simulator [--rows R] [--len N] [--tile T]\n";
+                      << "usage: layernorm_simulator [--rows R] [--len N] [--tile T]"
+                         " [--max-cycles C]\n";
             return 2;
         }
     }
@@ -117,7 +120,7 @@ int main(int argc, char** argv) {
               << ", eps " << kEps << ")\n\n";
 
     ConcurrentTimingExecutor::Config ecfg;
-    ecfg.max_cycles = 2'000'000;
+    ecfg.max_cycles = static_cast<Cycle>(vals[3]);   // --max-cycles
     ConcurrentTimingExecutor exec(ecfg);
 
     // Seed the input row tiles (matrix A) from the data
@@ -188,30 +191,38 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    // Correctness: each output tile matches the host LayerNorm reference
+    // Correctness: every output element matches the host LayerNorm reference.
+    // Fail closed - a NaN, a missing tile, or a duplicated store must not pass.
     std::cout << "Result: y = gamma * (x - mean)/sqrt(var + eps) + beta\n";
     double max_err = 0.0;
-    for (Size r = 0; r < R; ++r) {
-        // host mean/var over the row
+    bool finite_ok = true;
+    std::vector<int> covered(static_cast<std::size_t>(R) * F, 0);  // times each element was stored
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        if (id.matrix != MatrixID::C) continue;
+        const Size r = id.ti, off = id.tj * T;
+        // host mean/var for this row
         double sum = 0.0, sumsq = 0.0;
         for (Size i = 0; i < F; ++i) { sum += data[r * F + i]; sumsq += static_cast<double>(data[r*F+i]) * data[r*F+i]; }
-        const double mean = sum / F;
-        const double var = std::max(0.0, sumsq / F - mean * mean);
+        const double mean = sum / F, var = std::max(0.0, sumsq / F - mean * mean);
         const double inv = 1.0 / std::sqrt(var + kEps);
-        for (const auto& op : schedule.operations) {
-            if (op.type != ScheduleOpType::STORE) continue;
-            const auto id = op.tile.tile_id;
-            if (id.matrix != MatrixID::C || id.ti != r) continue;
-            const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
-            const Size off = id.tj * T;
-            for (std::size_t i = 0; i < p.values.size(); ++i) {
-                const double want = gamma[off + i] * (data[r * F + off + i] - mean) * inv + beta[off + i];
-                max_err = std::max(max_err, std::abs(p.values[i] - want));
-            }
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        for (std::size_t i = 0; i < p.values.size(); ++i) {
+            if (!std::isfinite(p.values[i])) finite_ok = false;
+            const double want = gamma[off + i] * (data[r * F + off + i] - mean) * inv + beta[off + i];
+            max_err = std::max(max_err, std::abs(static_cast<double>(p.values[i]) - want));
+            ++covered[r * F + off + i];
         }
     }
-    const bool ok = max_err < 1e-3;
+    // Every output element must be stored exactly once
+    bool coverage_ok = true;
+    for (int c : covered) if (c != 1) { coverage_ok = false; break; }
+
+    const bool ok = finite_ok && coverage_ok && max_err < 1e-3;
     std::cout << "  max abs error vs host oracle: " << max_err
+              << (finite_ok ? "" : "  [non-finite output]")
+              << (coverage_ok ? "" : "  [missing/duplicate output tile]")
               << (ok ? "  [OK]" : "  [FAIL]") << "\n";
     std::cout << "\n" << (ok ? "LAYERNORM OK" : "LAYERNORM MISMATCH") << "\n";
     return ok ? 0 : 1;

--- a/examples/schedule/layernorm_simulator.cpp
+++ b/examples/schedule/layernorm_simulator.cpp
@@ -1,0 +1,222 @@
+// ============================================================================
+// examples/schedule/layernorm_simulator.cpp
+// Standalone LayerNorm simulator with a horizontal tile-state debug log
+// (companion to softmax_simulator; see docs/tile-state-tracking.md).
+//
+// LayerNorm over the feature dimension: y = gamma * (x - mean)/sqrt(var + eps)
+//   + beta, per row. Like softmax it is a row-streaming reduction whose (mean,
+// var) statistic is handed to the apply computes as a compute-RESIDENT
+// dependency (the E8 mechanism, no DRAM round-trip) - the SAME P3 movement
+// pattern, so it reuses the online row-reduction schedule; only the value ops
+// differ (VAR-moment stats + an affine normalize instead of softmax's
+// max/exp-sum). Runs one executor cycle at a time and tracks every occupancy
+// transition. Ends on a host-oracle check.
+//
+// Usage: layernorm_simulator [--rows R] [--len N] [--tile T]
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/tile_tracker.hpp>
+#include <sw/kpu/timing/schedule/online_softmax_schedule_generator.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+constexpr float kEps = 1e-5f;
+
+// Stats op: reduce a row's tiles to (mean, var) - population variance,
+// clamped >= 0 (the E3 VAR-moment semantics). Result rides lanes [mean, var].
+TilePayload layernorm_stats(const std::vector<TilePayload>& inputs) {
+    double sum = 0.0, sumsq = 0.0;
+    std::size_t n = 0;
+    for (const auto& tile : inputs)
+        for (float v : tile.values) { sum += v; sumsq += static_cast<double>(v) * v; ++n; }
+    const double mean = n ? sum / n : 0.0;
+    const double var = n ? std::max(0.0, sumsq / n - mean * mean) : 0.0;
+    return TilePayload{2, 1, {static_cast<float>(mean), static_cast<float>(var)}};
+}
+
+// Apply op: y = gamma * (x - mean)/sqrt(var + eps) + beta, elementwise, with
+// per-feature gamma/beta slices for this tile. inputs = [x (fed), (mean,var)
+// (resident)].
+TilePayload layernorm_apply(const std::vector<TilePayload>& inputs,
+                            const std::vector<float>& gamma,
+                            const std::vector<float>& beta) {
+    const auto& x = inputs.at(0);
+    const float mean = inputs.at(1).values.at(0);
+    const float var = inputs.at(1).values.at(1);
+    const float inv = 1.0f / std::sqrt(var + kEps);
+    TilePayload out{x.rows, x.cols, std::vector<float>(x.values.size())};
+    for (std::size_t i = 0; i < x.values.size(); ++i)
+        out.values[i] = gamma[i] * (x.values[i] - mean) * inv + beta[i];
+    return out;
+}
+
+long arg(int argc, char** argv, const char* flag, long def) {
+    for (int i = 1; i + 1 < argc; ++i)
+        if (std::strcmp(argv[i], flag) == 0) return std::atol(argv[i + 1]);
+    return def;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    struct Opt { const char* flag; long def; };
+    long vals[3];
+    const Opt opts[3] = {{"--rows", 1}, {"--len", 512}, {"--tile", 256}};
+    for (int i = 0; i < 3; ++i) {
+        vals[i] = arg(argc, argv, opts[i].flag, opts[i].def);
+        if (vals[i] <= 0) {
+            std::cerr << "error: " << opts[i].flag << " must be a positive integer\n"
+                      << "usage: layernorm_simulator [--rows R] [--len N] [--tile T]\n";
+            return 2;
+        }
+    }
+
+    try {
+    OnlineSoftmaxScheduleGenerator::Config cfg;   // shared row-reduction movement
+    cfg.num_rows = static_cast<Size>(vals[0]);
+    cfg.reduction_elems = static_cast<Size>(vals[1]);
+    cfg.tile_elems = static_cast<Size>(vals[2]);
+    cfg.in_base = 0x100000; cfg.stat_base = 0x200000; cfg.out_base = 0x300000;
+
+    auto schedule = OnlineSoftmaxScheduleGenerator(cfg).generate();
+    if (!schedule.valid) {
+        std::cerr << "schedule refused: " << schedule.error_message << "\n";
+        return 1;
+    }
+
+    const Size R = cfg.num_rows, F = cfg.reduction_elems, T = cfg.tile_elems;
+
+    // Deterministic input + affine parameters (gamma/beta are per-feature)
+    std::vector<float> data(R * F), gamma(F), beta(F);
+    for (Size r = 0; r < R; ++r)
+        for (Size i = 0; i < F; ++i)
+            data[r * F + i] = static_cast<float>(r) - 0.5f + 0.02f * static_cast<float>(i % 40);
+    for (Size i = 0; i < F; ++i) {
+        gamma[i] = 1.0f + 0.001f * static_cast<float>(i % 16);
+        beta[i]  = 0.01f * static_cast<float>(i % 8);
+    }
+
+    std::cout << "LayerNorm simulator  —  " << schedule.metadata.strategy
+              << "  (" << R << " row(s) x " << F << " features, tile " << T
+              << ", eps " << kEps << ")\n\n";
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.max_cycles = 2'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+
+    // Seed the input row tiles (matrix A) from the data
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        if (op.tile.tile_id.matrix != MatrixID::A) continue;
+        const Size row = op.tile.tile_id.ti, t = op.tile.tile_id.tj;
+        const Size off = row * F + t * T;
+        const Size elems = op.tile.height;
+        exec.set_tile_payload(op.tile.tile_id,
+                              TilePayload{elems, 1,
+                                          std::vector<float>(data.begin() + off,
+                                                             data.begin() + off + elems)});
+    }
+
+    // Enqueue, binding the layernorm value ops. The apply for output tile
+    // C[row, t] uses the gamma/beta slice for feature block t.
+    for (const auto& op : schedule.operations) {
+        switch (op.type) {
+            case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+            case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+            case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+            case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+            case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+            case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+            case ScheduleOpType::COMPUTE: {
+                ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+                spec.input_tiles = op.dependency_tiles;
+                for (const auto& r : op.resident_tiles) spec.input_tiles.push_back(r);
+                spec.resident_tiles = op.resident_tiles;
+                if (op.tile.tile_id.matrix == MatrixID::B) {
+                    spec.operation = layernorm_stats;
+                } else {
+                    const Size t = op.tile.tile_id.tj;   // feature block
+                    const Size off = t * T;
+                    const Size len = std::min(T, F - off);
+                    std::vector<float> g(gamma.begin() + off, gamma.begin() + off + len);
+                    std::vector<float> b(beta.begin() + off, beta.begin() + off + len);
+                    spec.operation = [g, b](const std::vector<TilePayload>& in) {
+                        return layernorm_apply(in, g, b);
+                    };
+                }
+                exec.schedule_functional_compute(op.tile, spec);
+                break;
+            }
+        }
+    }
+
+    // Drive one cycle at a time, tracking every occupancy transition.
+    // Softmax/layernorm tiles index (row, feature-tile) in (ti, tj).
+    TileTracker::Config tcfg;
+    tcfg.label = [](const TileID& id) {
+        const char* m = id.matrix == MatrixID::A ? "A"
+                      : id.matrix == MatrixID::B ? "B" : "C";
+        return std::string(m) + "[" + std::to_string(id.ti) + "," +
+               std::to_string(id.tj) + "]";
+    };
+    TileTracker tracker(tcfg);
+    tracker.observe(exec);
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
+        exec.step();
+        tracker.observe(exec);
+    }
+    std::cout << tracker.log() << "\n";
+
+    if (!exec.is_complete()) {
+        std::cerr << "schedule did not complete (deadlock or max_cycles)\n";
+        return 1;
+    }
+
+    // Correctness: each output tile matches the host LayerNorm reference
+    std::cout << "Result: y = gamma * (x - mean)/sqrt(var + eps) + beta\n";
+    double max_err = 0.0;
+    for (Size r = 0; r < R; ++r) {
+        // host mean/var over the row
+        double sum = 0.0, sumsq = 0.0;
+        for (Size i = 0; i < F; ++i) { sum += data[r * F + i]; sumsq += static_cast<double>(data[r*F+i]) * data[r*F+i]; }
+        const double mean = sum / F;
+        const double var = std::max(0.0, sumsq / F - mean * mean);
+        const double inv = 1.0 / std::sqrt(var + kEps);
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::STORE) continue;
+            const auto id = op.tile.tile_id;
+            if (id.matrix != MatrixID::C || id.ti != r) continue;
+            const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+            const Size off = id.tj * T;
+            for (std::size_t i = 0; i < p.values.size(); ++i) {
+                const double want = gamma[off + i] * (data[r * F + off + i] - mean) * inv + beta[off + i];
+                max_err = std::max(max_err, std::abs(p.values[i] - want));
+            }
+        }
+    }
+    const bool ok = max_err < 1e-3;
+    std::cout << "  max abs error vs host oracle: " << max_err
+              << (ok ? "  [OK]" : "  [FAIL]") << "\n";
+    std::cout << "\n" << (ok ? "LAYERNORM OK" : "LAYERNORM MISMATCH") << "\n";
+    return ok ? 0 : 1;
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
The third tile-state-tracking companion (after softmax #168 and matmul #170): a standalone **LayerNorm** simulator, plus a discussion of how its tile log relates to the others.

## Sample output (default 1 row x 512, two tiles)

```text
cyc    | L3 buffers                         | L2 banks                           | L1 / array                        
-------+------------------------------------+------------------------------------+-----------------------------------
0      | -                                  | -                                  | -
36     | A[0,0]                             | -                                  | -
37     | A[0,0] A[0,1]                      | -                                  | -
60     | A[0,1]                             | A[0,0]                             | -
72     | A[0,1]                             | A[0,0]                             | A[0,0]*
84     | -                                  | A[0,1]                             | A[0,0]*
96     | -                                  | A[0,1]                             | A[0,0]* A[0,1]*
108    | -                                  | -                                  | A[0,0]* A[0,1]*
129    | -                                  | -                                  | A[0,0]* A[0,1]* B[0,0]=(-0.115,0.0525)*
162    | -                                  | -                                  | C[0,0]* C[0,1]*
174    | -                                  | C[0,0]                             | C[0,1]*
186    | -                                  | C[0,0] C[0,1]                      | -
199    | C[0,0]                             | C[0,1]                             | -
223    | C[0,0] C[0,1]                      | -                                  | -
250    | C[0,1]                             | -                                  | -
```

## What

- `examples/schedule/layernorm_simulator.cpp` drives a LayerNorm schedule **cycle-by-cycle**: the stats compute produces the `(mean, var)` statistic, handed to the apply computes **compute-resident** (the #155 mechanism, no DRAM round-trip), and the apply does `y = gamma*(x-mean)/sqrt(var+eps) + beta` with per-feature `gamma`/`beta`. Verified against a host oracle (max error ~1e-7). Configurable `--rows/--len/--tile`; CI smoke test.
- **LayerNorm is the same P3 movement as softmax** — stream the row, reduce to a small resident statistic, keep it on chip, stream the row past it again to apply, drain the result — so the simulator reuses the online row-reduction schedule. Only the **statistic content** and the **apply** differ:

  | | statistic tile B | apply |
  |---|---|---|
  | softmax | `(max, exp-sum)` | `exp(x-max)/sum` |
  | layernorm | `(mean, var)` | `gamma*(x-mean)/sqrt(var+eps)+beta` |

  The tracker makes that visible — the `B` cell shows `(mean, var)` (e.g. `B[0,0]=(-0.115,0.0525)`), and a batched run shows per-row stats (`B[1,0]=(0.885,0.0525)` — means differ per row). The same movement, told apart by what the tiles hold.
- `docs/tools/layernorm-simulator.md` covers the what/why/how and the softmax contrast; cross-linked from `docs/README.md`.

## Verification

Full suite **114/114** (incl. the new `layernorm_simulator` smoke test); the array retires/drains cleanly (the #171 liveness fix), and tiles use 2D [row, feature-tile] labels.

Note: the movement schedule is borrowed from `OnlineSoftmaxScheduleGenerator` (its schedule is the generic P3 pattern, not softmax-specific); a dedicated LayerNorm generator + functional executor is epic **E9 / #78**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
