### PR TITLE
feat(conv2d): im2col patchify helper + value-path closure (E6-T2, #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Conv2D im2col patchify helper — E6-T2 ISA/executor closure (#120).**
+  `include/sw/kpu/timing/schedule/conv2d_im2col.hpp` adds the only conv-specific
+  host-side capability the functional tier needs: `im2col_nchw` materializes the
+  `A_col` operand `[M=N·Hout·Wout, K=Cin·Kh·Kw]` from an NCHW input (explicit
+  zeros for padded taps), `filter_to_bw_nchw` reshapes the filter to `B_w`
+  `[K, Cout]` with a shared K ordering, and `conv2d_reference` is the direct-conv
+  host oracle. `Conv2DGeometry` carries the floored `Hout/Wout` and the GEMM
+  dims. Confirmed the value path needs **no new executor kernel**: the existing
+  `MatMulComputeSpec` bias (per output channel) + ReLU epilogue in
+  `execute_matmul` covers conv. Unit test `test_conv2d_im2col` cross-checks
+  `A_col @ B_w` against the independent direct-conv reference (stride, padding,
+  1×1, non-square kernel, batch, bias, ReLU) plus a hand-computed tiny case.
+  Coverage: `conv2d` design + isa_closure → done (generator/functional/regression
+  are T3/T4/T5). Gather-load (`DMA_LOAD_GATHER`) stays a placeholder follow-on.
+
 - **LayerNorm simulator + tile-log discussion.** `examples/schedule/layernorm_simulator`
   drives a LayerNorm schedule cycle-by-cycle through the `TileTracker`, showing
   the row streaming in, the stats compute producing the `(mean, var)` tile

--- a/include/sw/kpu/timing/schedule/conv2d_im2col.hpp
+++ b/include/sw/kpu/timing/schedule/conv2d_im2col.hpp
@@ -1,0 +1,244 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/conv2d_im2col.hpp
+// Host-side im2col patchify helper for the conv2d functional tier (E6-T2, #120)
+//
+// Conv2D is lowered to a single GEMM C_out = A_col @ B_w (see
+// docs/plans/e6_conv2d_pattern.md), reusing the value-producing matmul path.
+// The only conv-specific host-side capability the functional tier needs is the
+// im2col patchify: materialize the A_col operand from an NCHW input tensor
+// (writing explicit zeros for padded positions), and reshape the filter to the
+// B_w operand. The GEMM itself — K-accumulation, per-output-channel bias, and
+// ReLU — is already provided by ConcurrentTimingExecutor::MatMulComputeSpec.
+//
+// Orientation (matches src/schedules/conv2d_schedule.cpp and the timing
+// Conv2DScheduleGenerator):
+//   A = A_col : [M = N*Hout*Wout, K = Cin*Kh*Kw]   (im2col rows)
+//   B = B_w   : [K,               Ncols = Cout]    (reshaped weights)
+//   C = C_out : [M,               Cout]            (reshapes to y[n,co,ho,wo])
+//
+// Scope: groups = 1, dilation = 1 (the M2 ResNet subset), matching the
+// generator's K() = Cin*Kh*Kw. Depthwise/grouped/dilated conv are E6/M3
+// follow-ons (see the T1 design). Tensors are row-major fp32:
+//   input  : NCHW,   x[((n*Cin + ci)*Hin + h)*Win + w]
+//   filter : [Cout, Cin, Kh, Kw], f[((co*Cin + ci)*Kh + kh)*Kw + kw]
+// The K index ordering is shared by im2col and the weight reshape:
+//   k = (ci*Kh + kh)*Kw + kw
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/tile_descriptor.hpp>  // Size, TilePayload
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief Conv2D geometry (groups = 1, dilation = 1) and its GEMM lowering.
+ *
+ * Output spatial extents use an explicit floor (integer division on the
+ * non-negative padded extent), so no divisibility of the padded input by the
+ * stride is assumed. If the padded input is smaller than the kernel the output
+ * extent is 0 (an invalid, empty convolution) rather than an unsigned wrap.
+ */
+struct Conv2DGeometry {
+    Size N = 1;        ///< batch
+    Size C_in = 1;     ///< input channels
+    Size H_in = 1;     ///< input height
+    Size W_in = 1;     ///< input width
+    Size C_out = 1;    ///< output channels
+    Size Kh = 1;       ///< kernel height
+    Size Kw = 1;       ///< kernel width
+    Size stride_h = 1;
+    Size stride_w = 1;
+    Size pad_h = 0;
+    Size pad_w = 0;
+
+    [[nodiscard]] Size H_out() const {
+        if (H_in + 2 * pad_h < Kh) return 0;
+        return (H_in + 2 * pad_h - Kh) / stride_h + 1;  // floor
+    }
+    [[nodiscard]] Size W_out() const {
+        if (W_in + 2 * pad_w < Kw) return 0;
+        return (W_in + 2 * pad_w - Kw) / stride_w + 1;  // floor
+    }
+
+    /// GEMM M axis: batch x output spatial positions (A_col rows).
+    [[nodiscard]] Size M() const { return N * H_out() * W_out(); }
+    /// GEMM K axis: the receptive field (A_col cols / B_w rows).
+    [[nodiscard]] Size K() const { return C_in * Kh * Kw; }
+    /// GEMM N axis: output channels (B_w cols).
+    [[nodiscard]] Size Ncols() const { return C_out; }
+
+    /// Element count of a dense input tensor in NCHW layout.
+    [[nodiscard]] std::size_t input_elems() const {
+        return static_cast<std::size_t>(N) * C_in * H_in * W_in;
+    }
+    /// Element count of a dense filter tensor [Cout, Cin, Kh, Kw].
+    [[nodiscard]] std::size_t filter_elems() const {
+        return static_cast<std::size_t>(C_out) * C_in * Kh * Kw;
+    }
+
+    [[nodiscard]] bool valid() const {
+        return N && C_in && H_in && W_in && C_out && Kh && Kw &&
+               stride_h && stride_w && H_out() && W_out();
+    }
+};
+
+/**
+ * @brief Materialize the im2col A_col matrix from an NCHW input tensor.
+ *
+ * A_col has shape [M, K] with row m = (n*H_out + ho)*W_out + wo and column
+ * k = (ci*Kh + kh)*Kw + kw. Each entry is the input element covered by that
+ * (output position, filter tap); positions falling in the padding region
+ * contribute an explicit 0, so the downstream GEMM needs no special path.
+ *
+ * @param input NCHW fp32 tensor, size geom.input_elems()
+ * @return row-major [M, K] fp32 matrix
+ */
+[[nodiscard]] inline std::vector<float>
+im2col_nchw(const std::vector<float>& input, const Conv2DGeometry& geom) {
+    if (!geom.valid()) throw std::invalid_argument("im2col_nchw: invalid geometry");
+    if (input.size() != geom.input_elems())
+        throw std::invalid_argument("im2col_nchw: input size does not match geometry");
+
+    const Size Hout = geom.H_out(), Wout = geom.W_out();
+    const Size K = geom.K();
+    const Size M = geom.M();
+    std::vector<float> a_col(static_cast<std::size_t>(M) * K, 0.0f);
+
+    for (Size n = 0; n < geom.N; ++n) {
+        for (Size ho = 0; ho < Hout; ++ho) {
+            for (Size wo = 0; wo < Wout; ++wo) {
+                const Size m = (n * Hout + ho) * Wout + wo;
+                for (Size ci = 0; ci < geom.C_in; ++ci) {
+                    for (Size kh = 0; kh < geom.Kh; ++kh) {
+                        // Signed source coordinate; negative or >= extent is padding.
+                        const long ih = static_cast<long>(ho * geom.stride_h + kh) -
+                                        static_cast<long>(geom.pad_h);
+                        const bool h_in = ih >= 0 && ih < static_cast<long>(geom.H_in);
+                        for (Size kw = 0; kw < geom.Kw; ++kw) {
+                            const long iw = static_cast<long>(wo * geom.stride_w + kw) -
+                                            static_cast<long>(geom.pad_w);
+                            const bool w_in = iw >= 0 && iw < static_cast<long>(geom.W_in);
+                            const Size k = (ci * geom.Kh + kh) * geom.Kw + kw;
+                            if (h_in && w_in) {
+                                const std::size_t src =
+                                    ((static_cast<std::size_t>(n) * geom.C_in + ci) *
+                                         geom.H_in + static_cast<Size>(ih)) *
+                                        geom.W_in + static_cast<Size>(iw);
+                                a_col[static_cast<std::size_t>(m) * K + k] = input[src];
+                            }
+                            // else: padded position stays 0.0f
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return a_col;
+}
+
+/**
+ * @brief Reshape a [Cout, Cin, Kh, Kw] filter to the B_w GEMM operand [K, Cout].
+ *
+ * B_w[k, co] = filter[co, ci, kh, kw] with the same k = (ci*Kh + kh)*Kw + kw
+ * ordering used by im2col_nchw, so A_col @ B_w reproduces the convolution.
+ *
+ * @return row-major [K, Cout] fp32 matrix
+ */
+[[nodiscard]] inline std::vector<float>
+filter_to_bw_nchw(const std::vector<float>& filter, const Conv2DGeometry& geom) {
+    if (!geom.valid()) throw std::invalid_argument("filter_to_bw_nchw: invalid geometry");
+    if (filter.size() != geom.filter_elems())
+        throw std::invalid_argument("filter_to_bw_nchw: filter size does not match geometry");
+
+    const Size K = geom.K();
+    std::vector<float> b_w(static_cast<std::size_t>(K) * geom.C_out, 0.0f);
+    for (Size co = 0; co < geom.C_out; ++co) {
+        for (Size ci = 0; ci < geom.C_in; ++ci) {
+            for (Size kh = 0; kh < geom.Kh; ++kh) {
+                for (Size kw = 0; kw < geom.Kw; ++kw) {
+                    const Size k = (ci * geom.Kh + kh) * geom.Kw + kw;
+                    const std::size_t src =
+                        ((static_cast<std::size_t>(co) * geom.C_in + ci) * geom.Kh + kh) *
+                            geom.Kw + kw;
+                    b_w[static_cast<std::size_t>(k) * geom.C_out + co] = filter[src];
+                }
+            }
+        }
+    }
+    return b_w;
+}
+
+/**
+ * @brief Direct-convolution host reference (the functional oracle).
+ *
+ * y[n, co, ho, wo] = (bias ? bias[co] : 0) +
+ *     sum_{ci,kh,kw} x[n, ci, ho*sh + kh - ph, wo*sw + kw - pw] * f[co, ci, kh, kw]
+ * with an optional ReLU. Computed directly (no im2col) so it independently
+ * checks the A_col @ B_w lowering. Output is NCHW: [N, Cout, Hout, Wout].
+ *
+ * @param bias size Cout, or empty for no bias
+ * @param relu apply max(0, .) after bias
+ * @return row-major NCHW output, size N*Cout*Hout*Wout
+ */
+[[nodiscard]] inline std::vector<float>
+conv2d_reference(const std::vector<float>& input, const std::vector<float>& filter,
+                 const std::vector<float>& bias, const Conv2DGeometry& geom,
+                 bool relu = false) {
+    if (!geom.valid()) throw std::invalid_argument("conv2d_reference: invalid geometry");
+    if (input.size() != geom.input_elems())
+        throw std::invalid_argument("conv2d_reference: input size does not match geometry");
+    if (filter.size() != geom.filter_elems())
+        throw std::invalid_argument("conv2d_reference: filter size does not match geometry");
+    if (!bias.empty() && bias.size() != static_cast<std::size_t>(geom.C_out))
+        throw std::invalid_argument("conv2d_reference: bias size must be C_out or empty");
+
+    const Size Hout = geom.H_out(), Wout = geom.W_out();
+    std::vector<float> y(
+        static_cast<std::size_t>(geom.N) * geom.C_out * Hout * Wout, 0.0f);
+
+    for (Size n = 0; n < geom.N; ++n) {
+        for (Size co = 0; co < geom.C_out; ++co) {
+            for (Size ho = 0; ho < Hout; ++ho) {
+                for (Size wo = 0; wo < Wout; ++wo) {
+                    float acc = bias.empty() ? 0.0f : bias[co];
+                    for (Size ci = 0; ci < geom.C_in; ++ci) {
+                        for (Size kh = 0; kh < geom.Kh; ++kh) {
+                            const long ih = static_cast<long>(ho * geom.stride_h + kh) -
+                                            static_cast<long>(geom.pad_h);
+                            if (ih < 0 || ih >= static_cast<long>(geom.H_in)) continue;
+                            for (Size kw = 0; kw < geom.Kw; ++kw) {
+                                const long iw = static_cast<long>(wo * geom.stride_w + kw) -
+                                                static_cast<long>(geom.pad_w);
+                                if (iw < 0 || iw >= static_cast<long>(geom.W_in)) continue;
+                                const std::size_t xs =
+                                    ((static_cast<std::size_t>(n) * geom.C_in + ci) *
+                                         geom.H_in + static_cast<Size>(ih)) *
+                                        geom.W_in + static_cast<Size>(iw);
+                                const std::size_t fs =
+                                    ((static_cast<std::size_t>(co) * geom.C_in + ci) *
+                                         geom.Kh + kh) * geom.Kw + kw;
+                                acc += input[xs] * filter[fs];
+                            }
+                        }
+                    }
+                    if (relu && acc < 0.0f) acc = 0.0f;
+                    const std::size_t ys =
+                        ((static_cast<std::size_t>(n) * geom.C_out + co) * Hout + ho) *
+                            Wout + wo;
+                    y[ys] = acc;
+                }
+            }
+        }
+    }
+    return y;
+}
+
+} // namespace sw::kpu::timing::schedule

--- a/include/sw/kpu/timing/schedule/conv2d_im2col.hpp
+++ b/include/sw/kpu/timing/schedule/conv2d_im2col.hpp
@@ -33,10 +33,35 @@
 #include <sw/kpu/timing/tile_descriptor.hpp>  // Size, TilePayload
 
 #include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
 namespace sw::kpu::timing::schedule {
+
+namespace detail {
+
+/**
+ * @brief Map an output position + filter tap to its (padded) input coordinate.
+ *
+ * Computes the signed source coordinate `out*stride + k - pad` and reports
+ * whether it lands inside `[0, extent)`. On an in-bounds hit `coord` is set;
+ * an out-of-bounds coordinate is a padding position (returns false, `coord`
+ * untouched). The signed intermediate is `std::int64_t` (not `long`, which is
+ * only 32-bit on LLP64/Windows) so the range is independent of `Size`'s width.
+ * Shared by im2col_nchw and conv2d_reference so the two stay in lock-step when
+ * dilation/grouped conv extend this logic (E6/M3 follow-ons).
+ */
+[[nodiscard]] inline bool padded_coord(Size out, Size stride, Size k, Size pad,
+                                       Size extent, Size& coord) {
+    const std::int64_t c = static_cast<std::int64_t>(out * stride + k) -
+                           static_cast<std::int64_t>(pad);
+    if (c < 0 || c >= static_cast<std::int64_t>(extent)) return false;
+    coord = static_cast<Size>(c);
+    return true;
+}
+
+} // namespace detail
 
 /**
  * @brief Conv2D geometry (groups = 1, dilation = 1) and its GEMM lowering.
@@ -118,20 +143,18 @@ im2col_nchw(const std::vector<float>& input, const Conv2DGeometry& geom) {
                 const Size m = (n * Hout + ho) * Wout + wo;
                 for (Size ci = 0; ci < geom.C_in; ++ci) {
                     for (Size kh = 0; kh < geom.Kh; ++kh) {
-                        // Signed source coordinate; negative or >= extent is padding.
-                        const long ih = static_cast<long>(ho * geom.stride_h + kh) -
-                                        static_cast<long>(geom.pad_h);
-                        const bool h_in = ih >= 0 && ih < static_cast<long>(geom.H_in);
+                        Size ih = 0;  // padding positions leave a_col at 0
+                        const bool h_in = detail::padded_coord(
+                            ho, geom.stride_h, kh, geom.pad_h, geom.H_in, ih);
                         for (Size kw = 0; kw < geom.Kw; ++kw) {
-                            const long iw = static_cast<long>(wo * geom.stride_w + kw) -
-                                            static_cast<long>(geom.pad_w);
-                            const bool w_in = iw >= 0 && iw < static_cast<long>(geom.W_in);
+                            Size iw = 0;
+                            const bool w_in = detail::padded_coord(
+                                wo, geom.stride_w, kw, geom.pad_w, geom.W_in, iw);
                             const Size k = (ci * geom.Kh + kh) * geom.Kw + kw;
                             if (h_in && w_in) {
                                 const std::size_t src =
                                     ((static_cast<std::size_t>(n) * geom.C_in + ci) *
-                                         geom.H_in + static_cast<Size>(ih)) *
-                                        geom.W_in + static_cast<Size>(iw);
+                                         geom.H_in + ih) * geom.W_in + iw;
                                 a_col[static_cast<std::size_t>(m) * K + k] = input[src];
                             }
                             // else: padded position stays 0.0f
@@ -211,17 +234,18 @@ conv2d_reference(const std::vector<float>& input, const std::vector<float>& filt
                     float acc = bias.empty() ? 0.0f : bias[co];
                     for (Size ci = 0; ci < geom.C_in; ++ci) {
                         for (Size kh = 0; kh < geom.Kh; ++kh) {
-                            const long ih = static_cast<long>(ho * geom.stride_h + kh) -
-                                            static_cast<long>(geom.pad_h);
-                            if (ih < 0 || ih >= static_cast<long>(geom.H_in)) continue;
+                            Size ih = 0;
+                            if (!detail::padded_coord(ho, geom.stride_h, kh,
+                                                      geom.pad_h, geom.H_in, ih))
+                                continue;
                             for (Size kw = 0; kw < geom.Kw; ++kw) {
-                                const long iw = static_cast<long>(wo * geom.stride_w + kw) -
-                                                static_cast<long>(geom.pad_w);
-                                if (iw < 0 || iw >= static_cast<long>(geom.W_in)) continue;
+                                Size iw = 0;
+                                if (!detail::padded_coord(wo, geom.stride_w, kw,
+                                                          geom.pad_w, geom.W_in, iw))
+                                    continue;
                                 const std::size_t xs =
                                     ((static_cast<std::size_t>(n) * geom.C_in + ci) *
-                                         geom.H_in + static_cast<Size>(ih)) *
-                                        geom.W_in + static_cast<Size>(iw);
+                                         geom.H_in + ih) * geom.W_in + iw;
                                 const std::size_t fs =
                                     ((static_cast<std::size_t>(co) * geom.C_in + ci) *
                                          geom.Kh + kh) * geom.Kw + kw;

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -76,13 +76,13 @@
         "cv"
       ],
       "stages": {
-        "design": "partial",
-        "isa_closure": "partial",
+        "design": "done",
+        "isa_closure": "done",
         "generator": "partial",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "im2col+GEMM lowering exists (kernel factory, intentional per #18/#142); CSP schedule generator emits DRAIN without COMPUTE (#139); direct sliding-window/halo path missing."
+      "notes": "Design: im2col+GEMM lowering (T1 #119). ISA/executor closure (T2 #120): host-side im2col patchify helper (conv2d_im2col.hpp) materializes A_col; value path's MatMulComputeSpec bias+ReLU epilogue covers conv, no new executor kernel. Remaining: generator emits DRAIN without COMPUTE (#139, T3 #121); functional/regression = T4/T5. Gather-load (DMA_LOAD_GATHER) and direct sliding-window/halo path are placeholders/follow-ons."
     },
     {
       "name": "pooling",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -129,6 +129,16 @@ set_tests_properties(test_multi_tile_execution PROPERTIES
     LABELS "timing;executor;regression;v0.9"
 )
 
+# Conv2D im2col patchify helper unit tests (issue #120, epic E6):
+# geometry, padding zeros, and A_col @ B_w vs. a direct-conv reference
+kpu_add_component_test(test_conv2d_im2col "timing"
+    test_conv2d_im2col.cpp
+)
+
+set_tests_properties(test_conv2d_im2col PROPERTIES
+    LABELS "timing;functional;conv2d;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_conv2d_im2col.cpp
+++ b/tests/timing/test_conv2d_im2col.cpp
@@ -119,6 +119,46 @@ TEST_CASE("conv2d geometry: floored output extents and GEMM dims", "[conv2d][im2
     }
 }
 
+TEST_CASE("conv2d im2col: public guards reject malformed input", "[conv2d][im2col]") {
+    Conv2DGeometry g;
+    g.C_in = 2; g.H_in = 4; g.W_in = 4; g.C_out = 3; g.Kh = 3; g.Kw = 3;
+    REQUIRE(g.valid());
+
+    const auto input = ramp(g.input_elems());
+    const auto filter = ramp(g.filter_elems());
+
+    SECTION("invalid geometry throws") {
+        Conv2DGeometry bad = g;
+        bad.Kh = 9;  // kernel larger than padded input -> H_out() == 0
+        REQUIRE_FALSE(bad.valid());
+        REQUIRE_THROWS_AS(im2col_nchw(std::vector<float>(bad.input_elems()), bad),
+                          std::invalid_argument);
+        REQUIRE_THROWS_AS(filter_to_bw_nchw(std::vector<float>(bad.filter_elems()), bad),
+                          std::invalid_argument);
+        REQUIRE_THROWS_AS(conv2d_reference(std::vector<float>(bad.input_elems()),
+                                           std::vector<float>(bad.filter_elems()), {}, bad),
+                          std::invalid_argument);
+    }
+    SECTION("input size mismatch throws") {
+        REQUIRE_THROWS_AS(im2col_nchw(std::vector<float>(input.size() + 1), g),
+                          std::invalid_argument);
+        REQUIRE_THROWS_AS(conv2d_reference(std::vector<float>(input.size() + 1), filter, {}, g),
+                          std::invalid_argument);
+    }
+    SECTION("filter size mismatch throws") {
+        REQUIRE_THROWS_AS(filter_to_bw_nchw(std::vector<float>(filter.size() - 1), g),
+                          std::invalid_argument);
+        REQUIRE_THROWS_AS(conv2d_reference(input, std::vector<float>(filter.size() - 1), {}, g),
+                          std::invalid_argument);
+    }
+    SECTION("bias must be C_out or empty") {
+        REQUIRE_THROWS_AS(conv2d_reference(input, filter, std::vector<float>(g.C_out + 1), g),
+                          std::invalid_argument);
+        REQUIRE_NOTHROW(conv2d_reference(input, filter, {}, g));
+        REQUIRE_NOTHROW(conv2d_reference(input, filter, std::vector<float>(g.C_out), g));
+    }
+}
+
 TEST_CASE("conv2d im2col: padding produces explicit zeros", "[conv2d][im2col]") {
     // 1 batch, 1 channel, 3x3 input, 3x3 kernel, pad 1 -> 3x3 output. The
     // top-left output position's receptive field has its top row and left

--- a/tests/timing/test_conv2d_im2col.cpp
+++ b/tests/timing/test_conv2d_im2col.cpp
@@ -1,0 +1,213 @@
+// ============================================================================
+// tests/timing/test_conv2d_im2col.cpp
+// Unit tests for the conv2d im2col patchify helper (E6-T2, issue #120).
+//
+// The helper lowers conv2d to a single GEMM C_out = A_col @ B_w. These tests
+// verify (1) the conv geometry (floored Hout/Wout, GEMM M/K/N), (2) that
+// im2col writes explicit zeros in the padding region, (3) a hand-computed tiny
+// case (guards against a convention bug shared by both helper functions), and
+// (4) that A_col @ B_w reproduces the independent direct-conv reference across a
+// stride/padding/non-square/batch/bias/ReLU matrix.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::Size;
+
+namespace {
+
+// C_out = A_col @ B_w, a plain reference GEMM: A_col is [M, K], B_w is [K, Ncols].
+std::vector<float> gemm(const std::vector<float>& a, const std::vector<float>& b,
+                        Size M, Size K, Size Ncols) {
+    std::vector<float> c(static_cast<std::size_t>(M) * Ncols, 0.0f);
+    for (Size i = 0; i < M; ++i)
+        for (Size k = 0; k < K; ++k) {
+            const float av = a[static_cast<std::size_t>(i) * K + k];
+            for (Size j = 0; j < Ncols; ++j)
+                c[static_cast<std::size_t>(i) * Ncols + j] +=
+                    av * b[static_cast<std::size_t>(k) * Ncols + j];
+        }
+    return c;
+}
+
+// Deterministic non-trivial fill.
+std::vector<float> ramp(std::size_t n, float start = 1.0f, float step = 1.0f) {
+    std::vector<float> v(n);
+    for (std::size_t i = 0; i < n; ++i) v[i] = start + step * static_cast<float>(i);
+    return v;
+}
+
+// Check that the im2col lowering reproduces the direct-conv reference.
+void check_lowering(const Conv2DGeometry& g, const std::vector<float>& bias,
+                    bool relu) {
+    auto input = ramp(g.input_elems(), 1.0f, 0.5f);
+    auto filter = ramp(g.filter_elems(), -0.5f, 0.25f);
+
+    const auto a_col = im2col_nchw(input, g);
+    const auto b_w = filter_to_bw_nchw(filter, g);
+    REQUIRE(a_col.size() == static_cast<std::size_t>(g.M()) * g.K());
+    REQUIRE(b_w.size() == static_cast<std::size_t>(g.K()) * g.C_out);
+
+    auto c = gemm(a_col, b_w, g.M(), g.K(), g.Ncols());
+    // Apply the epilogue the executor's MatMulComputeSpec would apply.
+    for (Size i = 0; i < g.M(); ++i)
+        for (Size co = 0; co < g.C_out; ++co) {
+            float& v = c[static_cast<std::size_t>(i) * g.C_out + co];
+            if (!bias.empty()) v += bias[co];
+            if (relu && v < 0.0f) v = 0.0f;
+        }
+
+    const auto ref = conv2d_reference(input, filter, bias, g, relu);
+
+    // Map GEMM [m, co] (m = (n*Hout+ho)*Wout+wo) to NCHW y[n, co, ho, wo].
+    const Size Hout = g.H_out(), Wout = g.W_out();
+    for (Size n = 0; n < g.N; ++n)
+        for (Size co = 0; co < g.C_out; ++co)
+            for (Size ho = 0; ho < Hout; ++ho)
+                for (Size wo = 0; wo < Wout; ++wo) {
+                    const Size m = (n * Hout + ho) * Wout + wo;
+                    const std::size_t gi = static_cast<std::size_t>(m) * g.C_out + co;
+                    const std::size_t yi =
+                        ((static_cast<std::size_t>(n) * g.C_out + co) * Hout + ho) *
+                            Wout + wo;
+                    REQUIRE_THAT(c[gi],
+                        Catch::Matchers::WithinAbs(ref[yi], 1e-4));
+                }
+}
+
+} // namespace
+
+TEST_CASE("conv2d geometry: floored output extents and GEMM dims", "[conv2d][im2col]") {
+    // (H+2p-Kh)/s + 1 with an explicit floor.
+    Conv2DGeometry g;
+    g.N = 2; g.C_in = 3; g.H_in = 5; g.W_in = 7;
+    g.C_out = 4; g.Kh = 3; g.Kw = 3;
+
+    SECTION("no padding, unit stride") {
+        REQUIRE(g.H_out() == 3);   // (5-3)/1+1
+        REQUIRE(g.W_out() == 5);   // (7-3)/1+1
+        REQUIRE(g.M() == 2 * 3 * 5);
+        REQUIRE(g.K() == 3 * 3 * 3);
+        REQUIRE(g.Ncols() == 4);
+        REQUIRE(g.valid());
+    }
+    SECTION("stride 2 requires a floor") {
+        g.stride_h = 2; g.stride_w = 2;
+        REQUIRE(g.H_out() == 2);   // floor((5-3)/2)+1 = 2
+        REQUIRE(g.W_out() == 3);   // floor((7-3)/2)+1 = 3
+    }
+    SECTION("same padding") {
+        g.pad_h = 1; g.pad_w = 1;
+        REQUIRE(g.H_out() == 5);   // (5+2-3)/1+1
+        REQUIRE(g.W_out() == 7);
+    }
+    SECTION("kernel larger than padded input is invalid, not a wrap") {
+        g.H_in = 2; g.Kh = 3; g.pad_h = 0;
+        REQUIRE(g.H_out() == 0);
+        REQUIRE_FALSE(g.valid());
+    }
+}
+
+TEST_CASE("conv2d im2col: padding produces explicit zeros", "[conv2d][im2col]") {
+    // 1 batch, 1 channel, 3x3 input, 3x3 kernel, pad 1 -> 3x3 output. The
+    // top-left output position's receptive field has its top row and left
+    // column in the padding region, which must be exactly 0.
+    Conv2DGeometry g;
+    g.C_in = 1; g.H_in = 3; g.W_in = 3; g.C_out = 1;
+    g.Kh = 3; g.Kw = 3; g.pad_h = 1; g.pad_w = 1;
+
+    auto input = ramp(g.input_elems());  // 1..9
+    auto a_col = im2col_nchw(input, g);
+    const Size K = g.K();  // 9
+
+    // Row m = 0 is output (ho=0, wo=0). Column k = (kh*3 + kw).
+    // Padded taps: kh==0 (top row) or kw==0 (left col).
+    for (Size kh = 0; kh < 3; ++kh)
+        for (Size kw = 0; kw < 3; ++kw) {
+            const Size k = kh * 3 + kw;
+            const float v = a_col[k];  // m=0
+            if (kh == 0 || kw == 0) {
+                REQUIRE(v == 0.0f);           // padding
+            } else {
+                // interior tap maps to input[(kh-1)*3 + (kw-1)]
+                REQUIRE(v == input[(kh - 1) * 3 + (kw - 1)]);
+            }
+        }
+    REQUIRE(a_col.size() == static_cast<std::size_t>(g.M()) * K);
+}
+
+TEST_CASE("conv2d im2col: hand-computed tiny case", "[conv2d][im2col]") {
+    // 1x1x3x3 input, one 2x2 kernel, stride 1, no pad -> 1x1x2x2 output.
+    // input =            filter =
+    //   1 2 3              1 0
+    //   4 5 6              0 1
+    //   7 8 9
+    // y[0,0] = 1*1 + 5*1 = 6 ; y[0,1] = 2 + 6 = 8
+    // y[1,0] = 4 + 8 = 12     ; y[1,1] = 5 + 9 = 14
+    Conv2DGeometry g;
+    g.C_in = 1; g.H_in = 3; g.W_in = 3; g.C_out = 1; g.Kh = 2; g.Kw = 2;
+
+    std::vector<float> input = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<float> filter = {1, 0, 0, 1};
+
+    auto a_col = im2col_nchw(input, g);
+    auto b_w = filter_to_bw_nchw(filter, g);
+    auto c = gemm(a_col, b_w, g.M(), g.K(), g.Ncols());
+    REQUIRE(c.size() == 4);
+    REQUIRE(c[0] == 6.0f);
+    REQUIRE(c[1] == 8.0f);
+    REQUIRE(c[2] == 12.0f);
+    REQUIRE(c[3] == 14.0f);
+
+    auto ref = conv2d_reference(input, filter, {}, g, false);
+    REQUIRE(ref == c);  // both lowerings agree exactly on integers
+}
+
+TEST_CASE("conv2d im2col lowering matches direct conv reference", "[conv2d][im2col]") {
+    auto base = [] {
+        Conv2DGeometry g;
+        g.N = 1; g.C_in = 3; g.H_in = 8; g.W_in = 8; g.C_out = 5;
+        g.Kh = 3; g.Kw = 3;
+        return g;
+    };
+
+    SECTION("3x3 stride1 pad1 (ResNet-style)") {
+        auto g = base(); g.pad_h = 1; g.pad_w = 1;
+        check_lowering(g, {}, false);
+    }
+    SECTION("1x1 pointwise") {
+        auto g = base(); g.Kh = 1; g.Kw = 1;
+        check_lowering(g, {}, false);
+    }
+    SECTION("stride 2, no pad") {
+        auto g = base(); g.stride_h = 2; g.stride_w = 2;
+        check_lowering(g, {}, false);
+    }
+    SECTION("non-square kernel 3x5, asymmetric pad") {
+        auto g = base(); g.Kh = 3; g.Kw = 5; g.pad_h = 1; g.pad_w = 2;
+        check_lowering(g, {}, false);
+    }
+    SECTION("batch > 1") {
+        auto g = base(); g.N = 3; g.pad_h = 1; g.pad_w = 1;
+        check_lowering(g, {}, false);
+    }
+    SECTION("with per-channel bias") {
+        auto g = base(); g.pad_h = 1; g.pad_w = 1;
+        check_lowering(g, {0.5f, -1.0f, 2.0f, -0.25f, 10.0f}, false);
+    }
+    SECTION("with bias and ReLU (exercises the negative clamp)") {
+        auto g = base(); g.pad_h = 1; g.pad_w = 1;
+        check_lowering(g, {-100.0f, -100.0f, -100.0f, -100.0f, -100.0f}, true);
+    }
+}


### PR DESCRIPTION
## Summary

E6-T2 (conv2d ISA/executor capability closure, #120) — the second task of the
Conv2D epic, following the merged T1 design (#173). It adds the only
conv-specific host-side capability the functional tier needs to run conv2d as
**im2col + GEMM on the existing value-producing matmul path**, and confirms the
value path needs **no new executor kernel**.

## What landed

- **`include/sw/kpu/timing/schedule/conv2d_im2col.hpp`** (new)
  - `Conv2DGeometry` — floored `Hout/Wout` (guards kernel > padded input → 0,
    not an unsigned wrap) + GEMM dims `M=N·Hout·Wout`, `K=Cin·Kh·Kw`, `Ncols=Cout`
    (the orientation used by `conv2d_schedule.cpp`).
  - `im2col_nchw` — materializes the `A_col` operand `[M, K]` from an NCHW input,
    writing **explicit zeros** for padded taps so the GEMM has no special border path.
  - `filter_to_bw_nchw` — reshapes `[Cout, Cin, Kh, Kw]` → `B_w [K, Cout]` with a
    shared `k = (ci·Kh + kh)·Kw + kw` ordering, so `A_col @ B_w` = conv.
  - `conv2d_reference` — an independent direct-conv host oracle (bias + optional ReLU).
  - Scope: `groups=1, dilation=1` (the M2 ResNet subset), matching the generator's `K()`.

- **No new executor kernel.** Confirmed `MatMulComputeSpec`'s per-output-channel
  `bias` + `RELU` epilogue in `execute_matmul` already covers conv. T2 adds no
  executor code — only the host-side lowering helper.

- **`tests/timing/test_conv2d_im2col.cpp`** (new) — geometry (floor / M / K / N),
  padding-zeros, a hand-computed tiny case (guards against a convention bug shared
  by both helper functions), and `A_col @ B_w` vs. the direct-conv reference across
  stride / padding / 1×1 / non-square kernel / batch / bias / ReLU. **2647 assertions.**

## Test results

| Check | Result |
|-------|--------|
| `test_conv2d_im2col` (gcc) | PASS — 2647 assertions, 4 cases |
| Full `timing` suite | PASS — 29/29, no regressions |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Wconversion -Wshadow -Werror` | clean |

## Coverage manifest (#93 contract)

`conv2d`: `design` + `isa_closure` → **done** (T1 #119 design merged; this T2
delivers the closure). `generator` / `functional` / `regression` remain
T3 #121 / T4 #122 / T5 #123. `#139` (generator emits DRAIN without COMPUTE) is
T3's fix. Gather-load (`DMA_LOAD_GATHER`) stays a placeholder follow-on.

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #120

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added host-side Conv2D im2col-style patchification to lower Conv2D into the existing matrix-multiplication execution flow, including stride/padding and correct output shaping.
  - Maintains support for batched inputs, per-channel bias, and optional ReLU.

- **Bug Fixes**
  - Ensures padding regions are explicitly zero-filled and invalid convolution geometry is rejected.

- **Tests**
  - Added `test_conv2d_im2col` with geometry validation, padding correctness, hand-checked examples, and comparisons against a direct convolution reference.

- **Documentation**
  - Updated changelog and conv2d coverage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->