### PR TITLE
fix(conv2d): generator emits executable COMPUTE (E6-T3, #121; resolves #139 conv2d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Conv2D schedule generator emitted DRAIN without COMPUTE (conv2d half of
+  #139) — E6-T3 (#121).** `Conv2DScheduleGenerator` now emits
+  `ScheduleOperation::compute(c_tile, ...)` with the full A/B K-slice dependency
+  set before each drain, in both `IM2COL_INTERLEAVED` and
+  `IM2COL_OUTPUT_STATIONARY` paths (mirroring the matmul generator, since conv2d
+  lowers to that GEMM). Before this the drain had no producer, so an executed
+  conv2d schedule deadlocked. New regression `test_conv2d_execution` runs the
+  generated schedules through the `ConcurrentTimingExecutor` (timing-only) across
+  both strategies × 3×3-s1p1 / 1×1-pointwise / 3×3-strided cases, asserting a
+  COMPUTE per output tile and livelock-free completion. Coverage: `conv2d`
+  generator stage → done (functional/regression remain T4 #122 / T5 #123).
+
 ### Added
 
 - **Conv2D im2col patchify helper — E6-T2 ISA/executor closure (#120).**

--- a/include/sw/kpu/timing/schedule/conv2d_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/conv2d_schedule_generator.hpp
@@ -295,8 +295,12 @@ private:
                     result.operations.push_back(ScheduleOperation::feed(b_tile));
                 }
 
-                // Drain and store output tile
+                // Compute the output tile, then drain and store it. COMPUTE
+                // depends on every K-slice A and B feed for this C tile; without
+                // it the DRAIN has no producer (the conv2d half of #139).
                 auto c_tile = make_tile(isa::MatrixID::C, ti, tj, 0);
+                result.operations.push_back(ScheduleOperation::compute(
+                    c_tile, make_compute_dependencies(ti, tj, k_tiles)));
                 result.operations.push_back(ScheduleOperation::drain(c_tile));
                 result.operations.push_back(ScheduleOperation::writeback(c_tile));
                 result.operations.push_back(ScheduleOperation::store(c_tile));
@@ -328,13 +332,42 @@ private:
                     result.operations.push_back(ScheduleOperation::feed(b_tile));
                 }
 
-                // Output tile
+                // Compute, then drain and store the output tile (see #139).
                 auto c_tile = make_tile(isa::MatrixID::C, ti, tj, 0);
+                result.operations.push_back(ScheduleOperation::compute(
+                    c_tile, make_compute_dependencies(ti, tj, k_tiles)));
                 result.operations.push_back(ScheduleOperation::drain(c_tile));
                 result.operations.push_back(ScheduleOperation::writeback(c_tile));
                 result.operations.push_back(ScheduleOperation::store(c_tile));
             }
         }
+    }
+
+    /**
+     * @brief Build the COMPUTE dependency set for output tile C[ti, tj]:
+     *        every K-slice A[ti, 0, tk] and B[0, tj, tk] feed (matches the
+     *        matmul generator, since conv2d lowers to that GEMM).
+     */
+    std::vector<TileID> make_compute_dependencies(Size ti, Size tj,
+                                                  Size k_tiles) const {
+        std::vector<TileID> deps;
+        deps.reserve(2 * k_tiles);
+        for (Size tk = 0; tk < k_tiles; ++tk) {
+            TileID a;
+            a.matrix = isa::MatrixID::A;
+            a.ti = ti;
+            a.tj = 0;
+            a.tk = tk;
+            deps.push_back(a);
+
+            TileID b;
+            b.matrix = isa::MatrixID::B;
+            b.ti = 0;
+            b.tj = tj;
+            b.tk = tk;
+            deps.push_back(b);
+        }
+        return deps;
     }
 
     /**

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -78,11 +78,11 @@
       "stages": {
         "design": "done",
         "isa_closure": "done",
-        "generator": "partial",
+        "generator": "done",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "Design: im2col+GEMM lowering (T1 #119). ISA/executor closure (T2 #120): host-side im2col patchify helper (conv2d_im2col.hpp) materializes A_col; value path's MatMulComputeSpec bias+ReLU epilogue covers conv, no new executor kernel. Remaining: generator emits DRAIN without COMPUTE (#139, T3 #121); functional/regression = T4/T5. Gather-load (DMA_LOAD_GATHER) and direct sliding-window/halo path are placeholders/follow-ons."
+      "notes": "Design: im2col+GEMM lowering (T1 #119). ISA/executor closure (T2 #120): host-side im2col patchify helper (conv2d_im2col.hpp) materializes A_col; value path's MatMulComputeSpec bias+ReLU epilogue covers conv, no new executor kernel. Generator (T3 #121): Conv2DScheduleGenerator now emits executable COMPUTE with the full A/B K-slice dependency set (resolves the conv2d half of #139), so generated schedules execute livelock-free; envelope stamping + working-set validation already present. Remaining: functional value oracle (T4 #122) and regression matrix (T5 #123). Gather-load (DMA_LOAD_GATHER) and direct sliding-window/halo path are placeholders/follow-ons."
     },
     {
       "name": "pooling",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -139,6 +139,17 @@ set_tests_properties(test_conv2d_im2col PROPERTIES
     LABELS "timing;functional;conv2d;v0.9"
 )
 
+# Conv2D schedule execution regression (issue #121, epic E6): the generator
+# now emits COMPUTE (resolving the conv2d half of #139), so generated schedules
+# execute livelock-free through the executor
+kpu_add_component_test(test_conv2d_execution "timing"
+    test_conv2d_execution.cpp
+)
+
+set_tests_properties(test_conv2d_execution PROPERTIES
+    LABELS "timing;conv2d;executor;regression;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_conv2d_execution.cpp
+++ b/tests/timing/test_conv2d_execution.cpp
@@ -1,0 +1,142 @@
+// ============================================================================
+// tests/timing/test_conv2d_execution.cpp
+// End-to-end execution regression for Conv2DScheduleGenerator (E6-T3, #121).
+//
+// Locks in the conv2d half of #139: before T3 the generator emitted DRAIN with
+// no COMPUTE, so an executed conv2d schedule had a drain with no producer and
+// would deadlock. T3 emits COMPUTE with the full A/B K-slice dependency set;
+// this test EXECUTES the generated schedules (timing-only, mirroring
+// test_multi_tile_execution) and asserts livelock-free completion, plus that a
+// COMPUTE is present for every output tile. Functional value correctness is
+// T4 (#122).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+ConcurrentTimingExecutor::Config make_executor_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.num_memory_controllers = 1;
+    config.l3_buffer_count = 32;
+    config.num_block_movers = 4;
+    config.l2_bank_count = 64;
+    config.num_row_streamers = 2;
+    config.num_col_streamers = 2;
+    config.max_cycles = 1'000'000;
+    config.enable_livelock_detection = true;
+    config.livelock_threshold = 10000;
+    return config;
+}
+
+struct ConvCase {
+    const char* name;
+    Size H, W, C_in, C_out, Kh, Kw, stride, pad;
+};
+
+// Tile size 16; dims chosen so M, C_out, and K = Kh*Kw*C_in are multiples of 16.
+constexpr ConvCase kConvCases[] = {
+    {"3x3_s1_p1",   8, 8, 16, 16, 3, 3, 1, 1},  // M=64,  K=144, N=16
+    {"1x1_pointwise", 8, 8, 32, 16, 1, 1, 1, 0}, // M=64,  K=32,  N=16
+    {"3x3_s2_p1",   8, 8, 16, 32, 3, 3, 2, 1},  // strided: M=16, K=144, N=32
+};
+
+struct StrategyCase {
+    Conv2DScheduleGenerator::Strategy strategy;
+    const char* name;
+};
+
+constexpr StrategyCase kStrategies[] = {
+    {Conv2DScheduleGenerator::Strategy::IM2COL_INTERLEAVED,       "im2col_interleaved"},
+    {Conv2DScheduleGenerator::Strategy::IM2COL_OUTPUT_STATIONARY, "im2col_output_stationary"},
+};
+
+Conv2DScheduleGenerator::Config make_config(const ConvCase& c,
+                                            Conv2DScheduleGenerator::Strategy s) {
+    Conv2DScheduleGenerator::Config config;
+    config.N = 1;
+    config.H_in = c.H; config.W_in = c.W; config.C_in = c.C_in;
+    config.C_out = c.C_out;
+    config.Kh = c.Kh; config.Kw = c.Kw;
+    config.stride_h = c.stride; config.stride_w = c.stride;
+    config.padding_h = c.pad; config.padding_w = c.pad;
+    config.Ti = 16; config.Tj = 16; config.Tk = 16;
+    config.strategy = s;
+    config.input_base = 0x00001000;
+    config.filter_base = 0x00100000;
+    config.output_base = 0x00200000;
+    return config;
+}
+
+} // namespace
+
+TEST_CASE("Conv2D generator emits an executable COMPUTE for every output tile",
+          "[timing][conv2d][generator]") {
+    for (const auto& strat : kStrategies) {
+        for (const auto& conv : kConvCases) {
+            DYNAMIC_SECTION(strat.name << " " << conv.name) {
+                auto schedule =
+                    Conv2DScheduleGenerator(make_config(conv, strat.strategy)).generate();
+                REQUIRE(schedule.valid);
+
+                // #139 regression: a COMPUTE exists for each C tile, so no DRAIN
+                // is left without a producer.
+                const auto n_compute = schedule.count_ops(ScheduleOpType::COMPUTE);
+                const auto n_drain   = schedule.count_ops(ScheduleOpType::DRAIN);
+                const auto n_store   = schedule.count_ops(ScheduleOpType::STORE);
+                REQUIRE(n_compute > 0);
+                REQUIRE(n_compute == n_drain);
+                REQUIRE(n_compute == n_store);
+
+                // LOAD:MOVE pair 1:1 (schedule invariant).
+                REQUIRE(schedule.count_ops(ScheduleOpType::LOAD) ==
+                        schedule.count_ops(ScheduleOpType::MOVE));
+            }
+        }
+    }
+}
+
+TEST_CASE("Conv2D schedules execute livelock-free through the executor",
+          "[timing][conv2d][executor][regression]") {
+    for (const auto& strat : kStrategies) {
+        for (const auto& conv : kConvCases) {
+            DYNAMIC_SECTION(strat.name << " " << conv.name) {
+                auto schedule =
+                    Conv2DScheduleGenerator(make_config(conv, strat.strategy)).generate();
+                REQUIRE(schedule.valid);
+
+                ConcurrentTimingExecutor executor(make_executor_config());
+                ScheduleExecutor sched_exec(executor);
+                auto result = sched_exec.execute(schedule);
+
+                INFO("strategy=" << strat.name << " case=" << conv.name
+                     << " cycles=" << result.total_cycles
+                     << " error=" << result.error_message);
+
+                // The #139 surface: before COMPUTE was emitted, the drain had no
+                // producer and this deadlocked. Now it completes.
+                REQUIRE(result.success);
+                REQUIRE_FALSE(result.livelock_detected);
+                REQUIRE(result.total_cycles > 0);
+
+                auto stats = executor.get_statistics();
+                REQUIRE(stats.tiles_drained ==
+                        schedule.count_ops(ScheduleOpType::DRAIN));
+                REQUIRE(stats.tiles_fed ==
+                        schedule.count_ops(ScheduleOpType::FEED));
+                REQUIRE(stats.tiles_writeback ==
+                        schedule.count_ops(ScheduleOpType::WRITEBACK));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

E6-T3 (conv2d envelope-aware schedule generator, #121) — the third Conv2D task,
following the merged T1 design (#173) and T2 closure (#174). It **resolves the
conv2d half of #139**: `Conv2DScheduleGenerator` emitted `DRAIN` with no
`COMPUTE`, so an executed conv2d schedule had a drain with no producer and would
deadlock.

## What changed

- **`Conv2DScheduleGenerator`** now emits
  `ScheduleOperation::compute(c_tile, make_compute_dependencies(ti, tj, k_tiles))`
  before each drain, in **both** `IM2COL_INTERLEAVED` and
  `IM2COL_OUTPUT_STATIONARY` paths. The dependency set is every K-slice
  `A[ti,0,tk]` + `B[0,tj,tk]` feed — identical to the matmul generator, since
  conv2d lowers to that GEMM. (Envelope stamping + working-set validation were
  already present, per T2's design note.)

- **`test_conv2d_execution`** (new) executes the generated schedules through the
  `ConcurrentTimingExecutor` (timing-only, as `test_multi_tile_execution` does)
  across both strategies × {3×3 s1p1, 1×1 pointwise, 3×3 strided}, asserting:
  - a `COMPUTE` for every output tile (`n_compute == n_drain == n_store > 0`),
  - `LOAD:MOVE` pair 1:1,
  - livelock-free completion with drain/feed/writeback counts matching the schedule.

  Before the fix this test would deadlock at the first drain.

## Test results

| Check | Result |
|-------|--------|
| `test_conv2d_execution` | PASS — 72 assertions, 2 cases |
| Full `timing` suite | PASS — 30/30, no regressions |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Werror` | clean |

## Coverage manifest (#93 contract)

`conv2d` `generator` → **done**. `functional` / `regression` remain
T4 #122 / T5 #123 (value oracle + regression matrix). Gather-load and the direct
sliding-window/halo path stay follow-ons.

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #121
Relates to #139

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Conv2D schedule execution to prevent deadlocks and livelocks during processing.
  * Ensured output tiles are computed correctly before being drained and stored.

* **Tests**
  * Added regression coverage for Conv2D execution across supported scheduling strategies and multiple input configurations.
  * Verified successful completion and consistent execution statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->