### PR TITLE
feat(conv2d): functional integration + host oracle (E6-T4, #122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Conv2D functional integration + host oracle — E6-T4 (#122).** Value-producing
+  conv2d on the CSP executor: the im2col `A_col` patches and reshaped `B_w`
+  weights (E6-T2 helpers) are seeded as tile payloads, the
+  `Conv2DScheduleGenerator` schedule runs through the value-producing matmul path
+  (`schedule_matmul_compute` with per-output-channel bias + ReLU on the COMPUTE),
+  and every drained C tile is checked elementwise against `conv2d_reference`.
+  `test_functional_conv2d` covers both strategies × {3×3 s1p1, 1×1 pointwise, 3×3
+  strided, per-channel bias, conv+bias+ReLU, batch N=2} (max error 0 with bounded
+  operands). New `examples/schedule/conv2d_simulator` drives the schedule
+  cycle-by-cycle through the `TileTracker`, showing im2col patch tiles
+  `A[patch,k]` and weight tiles `B[k,cout]` streaming L3→L2→L1/array, the
+  `C[patch,cout]` K-accumulate in the array, and the drain — ending on the oracle
+  check (`--bias`/`--relu`/geometry flags). Coverage: `conv2d.functional` → done
+  (the largest M2 gate cell); regression matrix remains T5 #123.
+
 ### Fixed
 
 - **Conv2D schedule generator emitted DRAIN without COMPUTE (conv2d half of

--- a/examples/schedule/CMakeLists.txt
+++ b/examples/schedule/CMakeLists.txt
@@ -86,3 +86,15 @@ if(KPU_BUILD_TESTS)
         LABELS "timing;layernorm;tracker;example;v0.9"
     )
 endif()
+
+# Conv2D simulator with tile-state tracker (im2col+GEMM; issue #122, epic E6)
+add_executable(conv2d_simulator conv2d_simulator.cpp)
+target_link_libraries(conv2d_simulator PRIVATE kpu_simulator)
+set_target_properties(conv2d_simulator PROPERTIES FOLDER "Examples/Schedule")
+if(KPU_BUILD_TESTS)
+    # Smoke test: runs the simulator and expects exit 0 (oracle match)
+    add_test(NAME conv2d_simulator COMMAND conv2d_simulator)
+    set_tests_properties(conv2d_simulator PROPERTIES
+        LABELS "timing;conv2d;tracker;example;v0.9"
+    )
+endif()

--- a/examples/schedule/conv2d_simulator.cpp
+++ b/examples/schedule/conv2d_simulator.cpp
@@ -1,0 +1,228 @@
+// ============================================================================
+// examples/schedule/conv2d_simulator.cpp
+// Standalone conv2d simulator with a horizontal tile-state debug log
+// (companion to matmul_simulator; see docs/tile-state-tracking.md).
+//
+// Conv2D is lowered to a single GEMM C = A_col @ B_w (im2col; see
+// docs/plans/e6_conv2d_pattern.md). This driver seeds the im2col A_col patches
+// and the reshaped B_w weights (the E6-T2 helpers), runs the generated conv2d
+// schedule one executor cycle at a time, and after each cycle records any change
+// in what tiles occupy L3 / L2 / L1 / array via the TileTracker. Watch the
+// im2col patch tiles A[patch,k] and weight tiles B[k,cout] stream
+// DRAM->L3->L2->L1/array, a C[patch,cout] accumulate over the K-slices in the
+// array, and the C result drain back out. Ends on a direct-conv host oracle
+// check (with optional bias + ReLU).
+//
+// Usage: conv2d_simulator [--cin C] [--h H] [--w W] [--cout O]
+//                         [--kh Kh] [--kw Kw] [--stride S] [--pad P]
+//                         [--tile T] [--bias] [--relu]
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/tile_tracker.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/conv2d_schedule_generator.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+long arg(int argc, char** argv, const char* flag, long def) {
+    for (int i = 1; i + 1 < argc; ++i)
+        if (std::strcmp(argv[i], flag) == 0) return std::atol(argv[i + 1]);
+    return def;
+}
+bool has_flag(int argc, char** argv, const char* flag) {
+    for (int i = 1; i < argc; ++i)
+        if (std::strcmp(argv[i], flag) == 0) return true;
+    return false;
+}
+
+// Extract the [T x T] block (br, bc) from a row-major [rows x cols] matrix.
+std::vector<float> block(const std::vector<float>& mat, Size cols,
+                         Size br, Size bc, Size T) {
+    std::vector<float> b(static_cast<std::size_t>(T) * T);
+    for (Size r = 0; r < T; ++r)
+        for (Size c = 0; c < T; ++c)
+            b[r * T + c] = mat[(br * T + r) * cols + (bc * T + c)];
+    return b;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        Conv2DGeometry g;
+        g.N = 1;
+        g.C_in  = static_cast<Size>(arg(argc, argv, "--cin", 4));
+        g.H_in  = static_cast<Size>(arg(argc, argv, "--h", 4));
+        g.W_in  = static_cast<Size>(arg(argc, argv, "--w", 4));
+        g.C_out = static_cast<Size>(arg(argc, argv, "--cout", 4));
+        g.Kh    = static_cast<Size>(arg(argc, argv, "--kh", 3));
+        g.Kw    = static_cast<Size>(arg(argc, argv, "--kw", 3));
+        g.stride_h = g.stride_w = static_cast<Size>(arg(argc, argv, "--stride", 1));
+        g.pad_h = g.pad_w = static_cast<Size>(arg(argc, argv, "--pad", 1));
+        const Size T = static_cast<Size>(arg(argc, argv, "--tile", 4));
+        const bool use_bias = has_flag(argc, argv, "--bias");
+        const bool use_relu = has_flag(argc, argv, "--relu");
+
+        if (!g.valid()) {
+            std::cerr << "error: invalid conv geometry (check sizes/padding)\n";
+            return 2;
+        }
+        if (g.M() % T || g.C_out % T || g.K() % T) {
+            std::cerr << "error: --tile " << T << " must divide M=" << g.M()
+                      << ", C_out=" << g.C_out << ", and K=" << g.K() << "\n";
+            return 2;
+        }
+
+        // Host operands (bounded, deterministic) and the im2col lowering.
+        std::vector<float> input(g.input_elems()), filter(g.filter_elems());
+        for (std::size_t i = 0; i < input.size(); ++i)
+            input[i] = 0.5f + 0.5f * static_cast<float>(i % 7);
+        for (std::size_t i = 0; i < filter.size(); ++i)
+            filter[i] = -1.0f + 0.5f * static_cast<float>(i % 5);
+        std::vector<float> bias;
+        if (use_bias) {
+            bias.resize(g.C_out);
+            for (Size i = 0; i < g.C_out; ++i)
+                bias[i] = -2.0f + 0.5f * static_cast<float>(i % 6);
+        }
+        const auto a_col = im2col_nchw(input, g);
+        const auto b_w = filter_to_bw_nchw(filter, g);
+        const auto ref = conv2d_reference(input, filter, bias, g, use_relu);
+
+        Conv2DScheduleGenerator::Config cfg;
+        cfg.N = g.N; cfg.H_in = g.H_in; cfg.W_in = g.W_in; cfg.C_in = g.C_in;
+        cfg.C_out = g.C_out; cfg.Kh = g.Kh; cfg.Kw = g.Kw;
+        cfg.stride_h = g.stride_h; cfg.stride_w = g.stride_w;
+        cfg.padding_h = g.pad_h; cfg.padding_w = g.pad_w;
+        cfg.Ti = T; cfg.Tj = T; cfg.Tk = T;
+        cfg.input_base = 0x100000; cfg.filter_base = 0x400000; cfg.output_base = 0x700000;
+        auto schedule = Conv2DScheduleGenerator(cfg).generate();
+        if (!schedule.valid) {
+            std::cerr << "schedule refused: " << schedule.error_message << "\n";
+            return 1;
+        }
+
+        std::cout << "Conv2D simulator  -  im2col+GEMM  (N" << g.N << " C" << g.C_in
+                  << " " << g.H_in << "x" << g.W_in << " -> C" << g.C_out << " "
+                  << g.H_out() << "x" << g.W_out() << ", k" << g.Kh << "x" << g.Kw
+                  << " s" << g.stride_h << " p" << g.pad_h << ", tile " << T << ")\n"
+                  << "  lowered GEMM: C[" << g.M() << "x" << g.C_out << "] = A_col["
+                  << g.M() << "x" << g.K() << "] @ B_w[" << g.K() << "x" << g.C_out
+                  << "]" << (use_bias ? " + bias" : "") << (use_relu ? " , ReLU" : "")
+                  << "\n\n";
+
+        ConcurrentTimingExecutor::Config ecfg;
+        ecfg.max_cycles = 2'000'000;
+        ConcurrentTimingExecutor exec(ecfg);
+
+        // Seed A_col patch tiles and B_w weight tiles from the host operands.
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::LOAD) continue;
+            const auto id = op.tile.tile_id;
+            if (id.matrix == MatrixID::A)
+                exec.set_tile_payload(id, TilePayload{T, T, block(a_col, g.K(), id.ti, id.tk, T)});
+            else
+                exec.set_tile_payload(id, TilePayload{T, T, block(b_w, g.C_out, id.tk, id.tj, T)});
+        }
+
+        // Enqueue; a COMPUTE becomes a value-producing MatMulComputeSpec carrying
+        // the tj-slice of the per-output-channel bias and the activation.
+        for (const auto& op : schedule.operations) {
+            switch (op.type) {
+                case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+                case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+                case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+                case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+                case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+                case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+                case ScheduleOpType::COMPUTE: {
+                    ConcurrentTimingExecutor::MatMulComputeSpec spec;
+                    for (const auto& dep : op.dependency_tiles) {
+                        if (dep.matrix == MatrixID::A) spec.a_tiles.push_back(dep);
+                        else                            spec.b_tiles.push_back(dep);
+                    }
+                    if (use_bias) {
+                        const Size tj = op.tile.tile_id.tj;
+                        spec.bias.assign(bias.begin() + static_cast<std::ptrdiff_t>(tj * T),
+                                         bias.begin() + static_cast<std::ptrdiff_t>(tj * T + T));
+                    }
+                    if (use_relu)
+                        spec.activation = ConcurrentTimingExecutor::FunctionalActivation::RELU;
+                    exec.schedule_matmul_compute(op.tile, spec);
+                    break;
+                }
+            }
+        }
+
+        // Label tiles by their 2D role: A = im2col patches [patch-row, k-slice],
+        // B = weights [k-slice, out-channel], C = output [patch-row, out-channel].
+        TileTracker::Config tcfg;
+        tcfg.label = [](const TileID& id) {
+            auto ij = [](Size a, Size b) {
+                return "[" + std::to_string(a) + "," + std::to_string(b) + "]";
+            };
+            switch (id.matrix) {
+                case MatrixID::A: return "A" + ij(id.ti, id.tk);
+                case MatrixID::B: return "B" + ij(id.tk, id.tj);
+                default:          return "C" + ij(id.ti, id.tj);
+            }
+        };
+        TileTracker tracker(tcfg);
+        tracker.observe(exec);
+        while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
+            exec.step();
+            tracker.observe(exec);
+        }
+        std::cout << tracker.log() << "\n";
+
+        if (!exec.is_complete()) {
+            std::cerr << "schedule did not complete (deadlock or max_cycles)\n";
+            return 1;
+        }
+
+        // Correctness: each stored C tile matches the direct-conv host oracle.
+        std::cout << "Result: C = conv2d(input, filter)"
+                  << (use_bias ? " + bias" : "") << (use_relu ? " , ReLU" : "") << "\n";
+        const Size Hout = g.H_out(), Wout = g.W_out();
+        double max_err = 0.0;
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::STORE) continue;
+            const auto id = op.tile.tile_id;
+            const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+            for (Size r = 0; r < T; ++r)
+                for (Size c = 0; c < T; ++c) {
+                    const Size m = id.ti * T + r, co = id.tj * T + c;
+                    const Size n = m / (Hout * Wout), rem = m % (Hout * Wout);
+                    const Size ho = rem / Wout, wo = rem % Wout;
+                    const double want =
+                        ref[((static_cast<std::size_t>(n) * g.C_out + co) * Hout + ho) *
+                                Wout + wo];
+                    max_err = std::max(max_err, std::abs(p.values[r * T + c] - want));
+                }
+        }
+        const bool ok = max_err < 1e-3;
+        std::cout << "  max abs error vs host oracle: " << max_err
+                  << (ok ? "  [OK]" : "  [FAIL]") << "\n\n"
+                  << (ok ? "CONV2D OK" : "CONV2D MISMATCH") << "\n";
+        return ok ? 0 : 1;
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n";
+        return 1;
+    }
+}

--- a/examples/schedule/conv2d_simulator.cpp
+++ b/examples/schedule/conv2d_simulator.cpp
@@ -83,6 +83,10 @@ int main(int argc, char** argv) {
             std::cerr << "error: invalid conv geometry (check sizes/padding)\n";
             return 2;
         }
+        if (T == 0) {
+            std::cerr << "error: --tile must be > 0\n";
+            return 2;
+        }
         if (g.M() % T || g.C_out % T || g.K() % T) {
             std::cerr << "error: --tile " << T << " must divide M=" << g.M()
                       << ", C_out=" << g.C_out << ", and K=" << g.K() << "\n";

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -79,10 +79,10 @@
         "design": "done",
         "isa_closure": "done",
         "generator": "done",
-        "functional": "missing",
+        "functional": "done",
         "regression": "missing"
       },
-      "notes": "Design: im2col+GEMM lowering (T1 #119). ISA/executor closure (T2 #120): host-side im2col patchify helper (conv2d_im2col.hpp) materializes A_col; value path's MatMulComputeSpec bias+ReLU epilogue covers conv, no new executor kernel. Generator (T3 #121): Conv2DScheduleGenerator now emits executable COMPUTE with the full A/B K-slice dependency set (resolves the conv2d half of #139), so generated schedules execute livelock-free; envelope stamping + working-set validation already present. Remaining: functional value oracle (T4 #122) and regression matrix (T5 #123). Gather-load (DMA_LOAD_GATHER) and direct sliding-window/halo path are placeholders/follow-ons."
+      "notes": "Design: im2col+GEMM lowering (T1 #119). ISA/executor closure (T2 #120): host-side im2col patchify helper (conv2d_im2col.hpp) materializes A_col; value path's MatMulComputeSpec bias+ReLU epilogue covers conv, no new executor kernel. Generator (T3 #121): Conv2DScheduleGenerator emits executable COMPUTE with the full A/B K-slice dependency set (resolves the conv2d half of #139), schedules execute livelock-free. Functional (T4 #122): value-producing conv2d on the CSP executor (seeded A_col/B_w, MatMulComputeSpec bias+ReLU) verified elementwise vs a direct-conv host oracle across stride/pad/1x1/bias/ReLU/batch (test_functional_conv2d); conv2d_simulator tile-log artifact. Remaining: regression matrix (T5 #123). Gather-load (DMA_LOAD_GATHER) and direct sliding-window/halo path are placeholders/follow-ons."
     },
     {
       "name": "pooling",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -150,6 +150,16 @@ set_tests_properties(test_conv2d_execution PROPERTIES
     LABELS "timing;conv2d;executor;regression;v0.9"
 )
 
+# Conv2D functional integration + host oracle (issue #122, epic E6):
+# value-producing im2col+GEMM conv2d on the CSP executor vs. a direct-conv oracle
+kpu_add_component_test(test_functional_conv2d "timing"
+    test_functional_conv2d.cpp
+)
+
+set_tests_properties(test_functional_conv2d PROPERTIES
+    LABELS "timing;functional;conv2d;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_functional_conv2d.cpp
+++ b/tests/timing/test_functional_conv2d.cpp
@@ -1,0 +1,213 @@
+// ============================================================================
+// tests/timing/test_functional_conv2d.cpp
+// Value-producing conv2d on the CSP executor vs. a host oracle (E6-T4, #122).
+//
+// Seeds the im2col A_col operand and the reshaped B_w weights (E6-T2 helpers)
+// as tile payloads, executes the Conv2DScheduleGenerator schedule through the
+// value-producing matmul path (schedule_matmul_compute, with per-output-channel
+// bias + ReLU on the COMPUTE), and checks every drained C tile elementwise
+// against conv2d_reference. This is the conv2d.functional coverage gate.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/conv2d_schedule_generator.hpp>
+
+#include <cmath>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+// Extract the [T x T] block (br, bc) from a row-major [rows x cols] matrix.
+std::vector<float> block(const std::vector<float>& mat, Size cols,
+                         Size br, Size bc, Size T) {
+    std::vector<float> b(static_cast<std::size_t>(T) * T);
+    for (Size r = 0; r < T; ++r)
+        for (Size c = 0; c < T; ++c)
+            b[r * T + c] = mat[(br * T + r) * cols + (bc * T + c)];
+    return b;
+}
+
+// Bounded deterministic fill. Values are kept small (a short repeating set) so
+// the K-reduction stays in a range where fp32 is exact-ish: the executor sums
+// the K products then adds bias, while the host reference seeds acc=bias first,
+// so with large partial sums the two rounding orders diverge by a few ULPs. A
+// bounded magnitude keeps that divergence well under the 1e-3 tolerance and
+// exercises the same functional path.
+std::vector<float> fill(std::size_t n, int period, float base, float step) {
+    std::vector<float> v(n);
+    for (std::size_t i = 0; i < n; ++i)
+        v[i] = base + step * static_cast<float>(i % static_cast<std::size_t>(period));
+    return v;
+}
+
+// Convert an NCHW conv2d_reference tensor into GEMM row-major [M x Cout], the
+// layout the C tiles are stored in (C[m, co], m = (n*Hout+ho)*Wout+wo).
+std::vector<float> ref_to_gemm(const std::vector<float>& y, const Conv2DGeometry& g) {
+    const Size Hout = g.H_out(), Wout = g.W_out();
+    std::vector<float> gemm(static_cast<std::size_t>(g.M()) * g.C_out);
+    for (Size n = 0; n < g.N; ++n)
+        for (Size co = 0; co < g.C_out; ++co)
+            for (Size ho = 0; ho < Hout; ++ho)
+                for (Size wo = 0; wo < Wout; ++wo) {
+                    const Size m = (n * Hout + ho) * Wout + wo;
+                    const std::size_t yi =
+                        ((static_cast<std::size_t>(n) * g.C_out + co) * Hout + ho) *
+                            Wout + wo;
+                    gemm[static_cast<std::size_t>(m) * g.C_out + co] = y[yi];
+                }
+    return gemm;
+}
+
+Conv2DScheduleGenerator::Config gen_config(const Conv2DGeometry& g, Size T,
+                                           Conv2DScheduleGenerator::Strategy s) {
+    Conv2DScheduleGenerator::Config c;
+    c.N = g.N; c.H_in = g.H_in; c.W_in = g.W_in; c.C_in = g.C_in;
+    c.C_out = g.C_out; c.Kh = g.Kh; c.Kw = g.Kw;
+    c.stride_h = g.stride_h; c.stride_w = g.stride_w;
+    c.padding_h = g.pad_h; c.padding_w = g.pad_w;
+    c.Ti = T; c.Tj = T; c.Tk = T;
+    c.strategy = s;
+    c.input_base = 0x00001000; c.filter_base = 0x00100000; c.output_base = 0x00200000;
+    return c;
+}
+
+// Execute one conv2d and return the max abs error vs. the host oracle.
+double run_and_compare(const Conv2DGeometry& g, Size T,
+                       Conv2DScheduleGenerator::Strategy strategy,
+                       const std::vector<float>& bias, bool relu) {
+    // Tile sizing must be square and dividing M/Cout/K for direct seeding.
+    REQUIRE(g.M() % T == 0);
+    REQUIRE(g.C_out % T == 0);
+    REQUIRE(g.K() % T == 0);
+
+    auto input = fill(g.input_elems(), 7, 0.5f, 0.5f);    // 0.5 .. 3.5
+    auto filter = fill(g.filter_elems(), 5, -1.0f, 0.5f);  // -1 .. 1
+    const auto a_col = im2col_nchw(input, g);        // [M, K]
+    const auto b_w = filter_to_bw_nchw(filter, g);   // [K, Cout]
+    const auto ref = ref_to_gemm(conv2d_reference(input, filter, bias, g, relu), g);
+
+    auto schedule = Conv2DScheduleGenerator(gen_config(g, T, strategy)).generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.max_cycles = 2'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+
+    // Seed A_col and B_w input tiles from the host operands.
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        if (id.matrix == MatrixID::A) {
+            exec.set_tile_payload(id, TilePayload{T, T, block(a_col, g.K(), id.ti, id.tk, T)});
+        } else {  // B_w block (tk, tj)
+            exec.set_tile_payload(id, TilePayload{T, T, block(b_w, g.C_out, id.tk, id.tj, T)});
+        }
+    }
+
+    // Enqueue; a COMPUTE becomes a value-producing MatMulComputeSpec carrying
+    // the tj-slice of the per-output-channel bias and the activation.
+    for (const auto& op : schedule.operations) {
+        switch (op.type) {
+            case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+            case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+            case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+            case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+            case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+            case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+            case ScheduleOpType::COMPUTE: {
+                ConcurrentTimingExecutor::MatMulComputeSpec spec;
+                for (const auto& dep : op.dependency_tiles) {
+                    if (dep.matrix == MatrixID::A) spec.a_tiles.push_back(dep);
+                    else                            spec.b_tiles.push_back(dep);
+                }
+                if (!bias.empty()) {
+                    const Size tj = op.tile.tile_id.tj;
+                    spec.bias.assign(bias.begin() + static_cast<std::ptrdiff_t>(tj * T),
+                                     bias.begin() + static_cast<std::ptrdiff_t>(tj * T + T));
+                }
+                if (relu) spec.activation = ConcurrentTimingExecutor::FunctionalActivation::RELU;
+                exec.schedule_matmul_compute(op.tile, spec);
+                break;
+            }
+        }
+    }
+
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles)
+        exec.step();
+    REQUIRE(exec.is_complete());
+
+    // Compare each stored C tile to the oracle.
+    double max_err = 0.0;
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        for (Size r = 0; r < T; ++r)
+            for (Size c = 0; c < T; ++c) {
+                const double got = p.values[r * T + c];
+                const double want =
+                    ref[(id.ti * T + r) * g.C_out + (id.tj * T + c)];
+                max_err = std::max(max_err, std::abs(got - want));
+            }
+    }
+    return max_err;
+}
+
+Conv2DGeometry base_geom() {
+    Conv2DGeometry g;
+    g.N = 1; g.C_in = 16; g.H_in = 8; g.W_in = 8; g.C_out = 16; g.Kh = 3; g.Kw = 3;
+    return g;  // M=64, K=144, Cout=16 -> all multiples of 16
+}
+
+constexpr Size T = 16;
+
+} // namespace
+
+TEST_CASE("Conv2D functional: im2col+GEMM on CSP executor matches host oracle",
+          "[timing][conv2d][functional]") {
+    using S = Conv2DScheduleGenerator::Strategy;
+    for (S strat : {S::IM2COL_INTERLEAVED, S::IM2COL_OUTPUT_STATIONARY}) {
+        DYNAMIC_SECTION("strategy=" << static_cast<int>(strat)) {
+            SECTION("3x3 stride1 pad1") {
+                auto g = base_geom(); g.pad_h = 1; g.pad_w = 1;
+                REQUIRE(run_and_compare(g, T, strat, {}, false) < 1e-3);
+            }
+            SECTION("1x1 pointwise, C_in=16") {
+                auto g = base_geom(); g.Kh = 1; g.Kw = 1;  // K=16
+                REQUIRE(run_and_compare(g, T, strat, {}, false) < 1e-3);
+            }
+            SECTION("3x3 stride2 pad1, C_out=32") {
+                auto g = base_geom(); g.stride_h = 2; g.stride_w = 2;
+                g.pad_h = 1; g.pad_w = 1; g.C_out = 32;  // M=16, Cout=32
+                REQUIRE(run_and_compare(g, T, strat, {}, false) < 1e-3);
+            }
+            SECTION("with per-output-channel bias") {
+                auto g = base_geom(); g.pad_h = 1; g.pad_w = 1;
+                auto bias = fill(g.C_out, 8, -2.0f, 0.5f);
+                REQUIRE(run_and_compare(g, T, strat, bias, false) < 1e-3);
+            }
+            SECTION("conv + bias + ReLU (fused epilogue)") {
+                auto g = base_geom(); g.pad_h = 1; g.pad_w = 1;
+                // filter averages 0, so pre-activation sums straddle 0; a mixed
+                // bias guarantees both signs, exercising the ReLU clamp.
+                auto bias = fill(g.C_out, 6, -6.0f, 2.0f);  // -6 .. 4
+                REQUIRE(run_and_compare(g, T, strat, bias, true) < 1e-3);
+            }
+            SECTION("batch N=2") {
+                auto g = base_geom(); g.N = 2; g.pad_h = 1; g.pad_w = 1;  // M=128
+                REQUIRE(run_and_compare(g, T, strat, {}, false) < 1e-3);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

E6-T4 (conv2d functional integration & oracle, #122) — the fourth Conv2D task,
following the merged T1/T2/T3 (#173/#174/#175). It delivers **value-producing
conv2d on the CSP executor, verified elementwise against a direct-conv host
oracle** — satisfying `conv2d.functional`, the largest M2 ResNet gate cell.

## What landed

- **`tests/timing/test_functional_conv2d.cpp`** (the coverage gate)
  - Seeds the im2col `A_col` patches and reshaped `B_w` weights (E6-T2 helpers)
    as tile payloads, runs the `Conv2DScheduleGenerator` schedule through the
    value-producing matmul path (`schedule_matmul_compute`), with the COMPUTE
    carrying the `tj`-slice of the per-output-channel `bias` + ReLU.
  - Checks every drained C tile elementwise against `conv2d_reference` across
    **both strategies × {3×3 s1p1, 1×1 pointwise, 3×3 strided, per-channel bias,
    conv+bias+ReLU, batch N=2}**. Max error 0.
  - Uses bounded operands: the executor adds bias *after* the K-sum while the
    reference seeds `acc = bias`, so large magnitudes diverge by a few fp32 ULPs;
    bounded values keep the reduction exact and the intent clear (a comment
    documents this).

- **`examples/schedule/conv2d_simulator.cpp`** (tile-log artifact, companion to
  the matmul/softmax/layernorm simulators). Drives the schedule cycle-by-cycle
  through `TileTracker`: im2col patch tiles `A[patch,k]` and weight tiles
  `B[k,cout]` stream L3→L2→L1/array, `C[patch,cout]` K-accumulates in the array,
  then drains — ending on the oracle check. Flags for geometry + `--bias`/`--relu`.
  CI smoke test asserts exit 0.

## Test results

| Check | Result |
|-------|--------|
| `test_functional_conv2d` | PASS — both strategies × 6 shapes, max err 0 |
| `conv2d_simulator` smoke | PASS — oracle match (incl. `--bias --relu`) |
| Full `timing` suite | PASS — 32/32 |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Werror` | clean |

## Coverage manifest (#93 contract)

`conv2d` `functional` → **done** — `conv2d.functional`, the largest M2 gate cell,
is satisfied. Only `regression` (T5 #123) remains for the conv2d row. Remaining M2
gate cells after E6: `pooling.functional` (E7), `batchnorm.functional` (E9),
`epilogue_fused.regression` (E10-T5).

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #122

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional Conv2D execution using im2col and tiled matrix multiplication.
  * Supports optional bias, ReLU activation, padding, stride, 1×1 convolutions, and batched inputs.
  * Added a cycle-by-cycle Conv2D scheduling simulator with tile tracking and correctness checks.

* **Tests**
  * Added functional coverage across multiple Conv2D configurations, validated against a reference implementation with zero reported error.
  * Added automated simulator execution and timing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->