### PR TITLE
feat(batchnorm): scale/shift fold helper + oracle (E9-T2, #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BatchNorm-inference scale/shift fold helper — E9-T2 (#179).** BN inference
+  folds exactly to a per-channel affine `y = x·scale[c] + shift[c]`
+  (`scale = γ/√(var+ε)`, `shift = β − mean·scale`), so it is a per-channel
+  broadcast op on the existing `FunctionalComputeSpec` value path — **no new
+  executor kernel**. New `include/sw/kpu/timing/schedule/batchnorm_affine.hpp`:
+  `bn_fold` (4 raw params → scale/shift, halving resident params `4C+1 → 2C+1`),
+  `batchnorm_apply` (the fast path), and `batchnorm_reference` (an independent
+  direct 4-param oracle). `test_batchnorm_affine` verifies the fold math, that
+  the folded apply reproduces the direct reference, a hand-computed case,
+  per-channel application, and the guards. Coverage: `batchnorm` design (T1 #178)
+  + isa_closure → done. This is the same fold conv2d T4 uses for conv+BN.
+
 - **Conv2D regression matrix + characterization — E6-T5 (#123); completes the
   conv2d coverage row.** `test_conv2d_regression` executes a shape × strategy ×
   envelope matrix (6 shapes incl. 1×1, strided, 5×5, batched, non-tile-aligned ×

--- a/include/sw/kpu/timing/schedule/batchnorm_affine.hpp
+++ b/include/sw/kpu/timing/schedule/batchnorm_affine.hpp
@@ -1,0 +1,171 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/batchnorm_affine.hpp
+// Host-side BatchNorm-inference scale/shift fold + oracle (E9-T2, #179)
+//
+// BatchNorm at inference is a per-channel affine with precomputed running
+// statistics (see docs/plans/e9_batchnorm_pattern.md):
+//
+//   y[n,c,h,w] = gamma[c] * (x[n,c,h,w] - mean[c]) / sqrt(var[c] + eps) + beta[c]
+//
+// which folds exactly into a single scale/shift pair per channel:
+//
+//   scale[c] = gamma[c] / sqrt(var[c] + eps)
+//   shift[c] = beta[c] - mean[c] * scale[c]
+//   =>  y[n,c,h,w] = x[n,c,h,w] * scale[c] + shift[c]
+//
+// So BN inference is a per-channel broadcast-affine — a Vector Engine op on the
+// existing FunctionalComputeSpec value path, no new compute kernel. This header
+// provides the host-side fold (the T3 generator loads scale/shift instead of the
+// four raw params, halving resident params to 2C+1) and a direct BN reference
+// oracle. Tensors are row-major NCHW fp32: x[((n*C + c)*H + h)*W + w].
+//
+// Scope: inference only (the M2 path). Training (which computes batch mean/var,
+// a P3 reduction) is an E9 follow-on. This is the same fold conv2d T4 applies
+// for conv+BN folding.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/tile_descriptor.hpp>  // Size, TilePayload
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+/**
+ * @brief BatchNorm tensor geometry (NCHW).
+ */
+struct BatchNormGeometry {
+    Size N = 1;  ///< batch
+    Size C = 1;  ///< channels
+    Size H = 1;  ///< height
+    Size W = 1;  ///< width
+
+    [[nodiscard]] Size spatial() const { return H * W; }
+    [[nodiscard]] std::size_t elems() const {
+        return static_cast<std::size_t>(N) * C * H * W;
+    }
+    [[nodiscard]] bool valid() const { return N && C && H && W; }
+};
+
+/**
+ * @brief The folded per-channel affine: y = x * scale[c] + shift[c].
+ */
+struct BatchNormAffine {
+    std::vector<float> scale;  ///< size C
+    std::vector<float> shift;  ///< size C
+};
+
+/**
+ * @brief Fold the four per-channel BN params into a scale/shift affine.
+ *
+ * scale[c] = gamma[c] / sqrt(var[c] + eps)
+ * shift[c] = beta[c]  - mean[c] * scale[c]
+ *
+ * eps guards the variance (as in the E3/E8 clamped-variance discipline); a
+ * non-positive var+eps is a malformed input and throws rather than producing a
+ * NaN/Inf scale.
+ *
+ * @param gamma,beta,mean,var per-channel vectors, each size C
+ * @param eps  numerical-stability epsilon (> 0)
+ */
+[[nodiscard]] inline BatchNormAffine
+bn_fold(const std::vector<float>& gamma, const std::vector<float>& beta,
+        const std::vector<float>& mean, const std::vector<float>& var,
+        float eps) {
+    const std::size_t C = gamma.size();
+    if (C == 0)
+        throw std::invalid_argument("bn_fold: C must be non-zero");
+    if (beta.size() != C || mean.size() != C || var.size() != C)
+        throw std::invalid_argument("bn_fold: gamma/beta/mean/var sizes must match");
+    if (!(eps > 0.0f))
+        throw std::invalid_argument("bn_fold: eps must be > 0");
+
+    BatchNormAffine a;
+    a.scale.resize(C);
+    a.shift.resize(C);
+    for (std::size_t c = 0; c < C; ++c) {
+        const float denom = var[c] + eps;
+        if (!(denom > 0.0f))
+            throw std::invalid_argument("bn_fold: var[c] + eps must be > 0");
+        a.scale[c] = gamma[c] / std::sqrt(denom);
+        a.shift[c] = beta[c] - mean[c] * a.scale[c];
+    }
+    return a;
+}
+
+/**
+ * @brief Apply a folded per-channel affine to an NCHW input (the fast path).
+ *
+ * y[n,c,h,w] = x[n,c,h,w] * scale[c] + shift[c].
+ *
+ * @return row-major NCHW output, size geom.elems()
+ */
+[[nodiscard]] inline std::vector<float>
+batchnorm_apply(const std::vector<float>& input, const BatchNormAffine& affine,
+                const BatchNormGeometry& geom) {
+    if (!geom.valid()) throw std::invalid_argument("batchnorm_apply: invalid geometry");
+    if (input.size() != geom.elems())
+        throw std::invalid_argument("batchnorm_apply: input size does not match geometry");
+    if (affine.scale.size() != static_cast<std::size_t>(geom.C) ||
+        affine.shift.size() != static_cast<std::size_t>(geom.C))
+        throw std::invalid_argument("batchnorm_apply: scale/shift size must be C");
+
+    const Size spatial = geom.spatial();
+    std::vector<float> y(geom.elems());
+    for (Size n = 0; n < geom.N; ++n)
+        for (Size c = 0; c < geom.C; ++c) {
+            const float sc = affine.scale[c], sh = affine.shift[c];
+            const std::size_t base =
+                (static_cast<std::size_t>(n) * geom.C + c) * spatial;
+            for (Size s = 0; s < spatial; ++s)
+                y[base + s] = input[base + s] * sc + sh;
+        }
+    return y;
+}
+
+/**
+ * @brief Direct BatchNorm-inference reference (the functional oracle).
+ *
+ * Computes y = gamma*(x - mean)/sqrt(var + eps) + beta directly from the four
+ * raw params (not via the fold), so it independently checks the fold + apply.
+ *
+ * @return row-major NCHW output, size geom.elems()
+ */
+[[nodiscard]] inline std::vector<float>
+batchnorm_reference(const std::vector<float>& input, const std::vector<float>& gamma,
+                    const std::vector<float>& beta, const std::vector<float>& mean,
+                    const std::vector<float>& var, float eps,
+                    const BatchNormGeometry& geom) {
+    if (!geom.valid()) throw std::invalid_argument("batchnorm_reference: invalid geometry");
+    if (input.size() != geom.elems())
+        throw std::invalid_argument("batchnorm_reference: input size does not match geometry");
+    const std::size_t C = static_cast<std::size_t>(geom.C);
+    if (gamma.size() != C || beta.size() != C || mean.size() != C || var.size() != C)
+        throw std::invalid_argument("batchnorm_reference: param sizes must be C");
+    if (!(eps > 0.0f))
+        throw std::invalid_argument("batchnorm_reference: eps must be > 0");
+
+    const Size spatial = geom.spatial();
+    std::vector<float> y(geom.elems());
+    for (Size n = 0; n < geom.N; ++n)
+        for (Size c = 0; c < geom.C; ++c) {
+            const float denom = var[c] + eps;
+            if (!(denom > 0.0f))
+                throw std::invalid_argument("batchnorm_reference: var[c] + eps must be > 0");
+            const float inv = 1.0f / std::sqrt(denom);
+            const std::size_t base =
+                (static_cast<std::size_t>(n) * geom.C + c) * spatial;
+            for (Size s = 0; s < spatial; ++s)
+                y[base + s] = gamma[c] * (input[base + s] - mean[c]) * inv + beta[c];
+        }
+    return y;
+}
+
+} // namespace sw::kpu::timing::schedule

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -174,13 +174,13 @@
         "cv"
       ],
       "stages": {
-        "design": "partial",
-        "isa_closure": "partial",
+        "design": "done",
+        "isa_closure": "done",
         "generator": "partial",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "Multi-pass generator (envelope-checked incl. all-channel preload residency, #90/#140; #139 applies); inference fold is the epic's target."
+      "notes": "Design (T1 #178): BN inference folds to a per-channel affine y=x*scale+shift (scale=gamma/sqrt(var+eps), shift=beta-mean*scale) on the FunctionalComputeSpec broadcast path, no new kernel; docs/plans/e9_batchnorm_pattern.md. ISA/executor closure (T2 #179): host-side fold helper batchnorm_affine.hpp (bn_fold, batchnorm_apply, batchnorm_reference oracle); confirmed the broadcast-affine value path covers BN, no new executor kernel; fold halves resident params 4C+1->2C+1. Remaining: generator emits DRAIN without COMPUTE (#139 applies, T3 #180); functional T4 #181, regression T5 #182. Training (P3 reduction) is an E9 follow-on."
     },
     {
       "name": "elementwise",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -170,6 +170,16 @@ set_tests_properties(test_conv2d_regression PROPERTIES
     LABELS "timing;regression;conv2d;v0.9"
 )
 
+# BatchNorm-inference scale/shift fold helper unit tests (issue #179, epic E9):
+# fold math, folded-apply vs the direct 4-param reference, and guards
+kpu_add_component_test(test_batchnorm_affine "timing"
+    test_batchnorm_affine.cpp
+)
+
+set_tests_properties(test_batchnorm_affine PROPERTIES
+    LABELS "timing;functional;batchnorm;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_batchnorm_affine.cpp
+++ b/tests/timing/test_batchnorm_affine.cpp
@@ -1,0 +1,120 @@
+// ============================================================================
+// tests/timing/test_batchnorm_affine.cpp
+// Unit tests for the BatchNorm-inference scale/shift fold helper (E9-T2, #179).
+//
+// BatchNorm inference folds to y = x*scale[c] + shift[c] (see
+// docs/plans/e9_batchnorm_pattern.md). These tests verify (1) the fold math,
+// (2) that the folded apply reproduces the independent 4-param direct reference,
+// (3) a hand-computed tiny case, and (4) the public guards.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+
+#include <cmath>
+#include <vector>
+
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::Size;
+
+namespace {
+
+std::vector<float> fill(std::size_t n, int period, float base, float step) {
+    std::vector<float> v(n);
+    for (std::size_t i = 0; i < n; ++i)
+        v[i] = base + step * static_cast<float>(i % static_cast<std::size_t>(period));
+    return v;
+}
+
+} // namespace
+
+TEST_CASE("bn_fold: scale/shift math", "[batchnorm][affine]") {
+    // Single channel, hand-checked. gamma=2, beta=1, mean=3, var=3, eps=1.
+    // scale = 2/sqrt(4) = 1 ; shift = 1 - 3*1 = -2.
+    auto a = bn_fold({2.0f}, {1.0f}, {3.0f}, {3.0f}, 1.0f);
+    REQUIRE(a.scale.size() == 1);
+    REQUIRE(a.shift.size() == 1);
+    REQUIRE_THAT(a.scale[0], Catch::Matchers::WithinAbs(1.0f, 1e-6));
+    REQUIRE_THAT(a.shift[0], Catch::Matchers::WithinAbs(-2.0f, 1e-6));
+}
+
+TEST_CASE("batchnorm apply == direct 4-param reference", "[batchnorm][affine]") {
+    BatchNormGeometry g;
+    g.N = 2; g.C = 4; g.H = 3; g.W = 5;
+    const float eps = 1e-3f;
+
+    auto input = fill(g.elems(), 7, -1.0f, 0.5f);
+    auto gamma = fill(g.C, 4, 0.5f, 0.5f);
+    auto beta  = fill(g.C, 3, -1.0f, 0.75f);
+    auto mean  = fill(g.C, 5, 0.25f, 0.5f);
+    auto var   = fill(g.C, 4, 0.5f, 0.25f);  // all > 0
+
+    const auto affine = bn_fold(gamma, beta, mean, var, eps);
+    const auto folded = batchnorm_apply(input, affine, g);
+    const auto ref = batchnorm_reference(input, gamma, beta, mean, var, eps, g);
+
+    REQUIRE(folded.size() == ref.size());
+    for (std::size_t i = 0; i < ref.size(); ++i)
+        REQUIRE_THAT(folded[i], Catch::Matchers::WithinAbs(ref[i], 1e-5));
+}
+
+TEST_CASE("batchnorm hand-computed tiny case", "[batchnorm][affine]") {
+    // 1x1x1x3 input [1,2,3]; gamma=2, beta=1, mean=1, var=3, eps=1.
+    // scale=2/2=1, shift=1-1*1=0 -> y = x*1 + 0 = [1,2,3].
+    BatchNormGeometry g; g.N = 1; g.C = 1; g.H = 1; g.W = 3;
+    std::vector<float> x = {1.0f, 2.0f, 3.0f};
+    auto a = bn_fold({2.0f}, {1.0f}, {1.0f}, {3.0f}, 1.0f);
+    auto y = batchnorm_apply(x, a, g);
+    REQUIRE(y == std::vector<float>{1.0f, 2.0f, 3.0f});
+
+    auto ref = batchnorm_reference(x, {2.0f}, {1.0f}, {1.0f}, {3.0f}, 1.0f, g);
+    REQUIRE(ref == y);
+}
+
+TEST_CASE("batchnorm per-channel affine is applied per channel", "[batchnorm][affine]") {
+    // 2 channels, distinct scale/shift; a constant input isolates the channel map.
+    BatchNormGeometry g; g.N = 1; g.C = 2; g.H = 1; g.W = 2;
+    std::vector<float> x = {10.0f, 10.0f,   // channel 0
+                            10.0f, 10.0f};  // channel 1
+    BatchNormAffine a; a.scale = {2.0f, 3.0f}; a.shift = {1.0f, -1.0f};
+    auto y = batchnorm_apply(x, a, g);
+    // channel 0: 10*2+1 = 21 ; channel 1: 10*3-1 = 29
+    REQUIRE(y == std::vector<float>{21.0f, 21.0f, 29.0f, 29.0f});
+}
+
+TEST_CASE("batchnorm public guards reject malformed input", "[batchnorm][affine]") {
+    BatchNormGeometry g; g.N = 1; g.C = 3; g.H = 2; g.W = 2;
+    auto input = fill(g.elems(), 5, 0.0f, 1.0f);
+    std::vector<float> p3 = {1.0f, 1.0f, 1.0f};
+
+    SECTION("bn_fold size mismatch") {
+        REQUIRE_THROWS_AS(bn_fold({1.0f, 1.0f}, p3, p3, p3, 1e-3f), std::invalid_argument);
+    }
+    SECTION("bn_fold non-positive eps") {
+        REQUIRE_THROWS_AS(bn_fold(p3, p3, p3, p3, 0.0f), std::invalid_argument);
+    }
+    SECTION("bn_fold var + eps <= 0") {
+        REQUIRE_THROWS_AS(bn_fold(p3, p3, p3, {-2.0f, 0.0f, 0.0f}, 1e-3f),
+                          std::invalid_argument);
+    }
+    SECTION("apply geometry/size mismatch") {
+        BatchNormAffine a; a.scale = p3; a.shift = p3;
+        REQUIRE_THROWS_AS(batchnorm_apply(std::vector<float>(input.size() + 1), a, g),
+                          std::invalid_argument);
+        BatchNormAffine bad; bad.scale = {1.0f}; bad.shift = {1.0f};
+        REQUIRE_THROWS_AS(batchnorm_apply(input, bad, g), std::invalid_argument);
+    }
+    SECTION("reference param/size guards") {
+        REQUIRE_THROWS_AS(
+            batchnorm_reference(input, {1.0f}, p3, p3, p3, 1e-3f, g),
+            std::invalid_argument);
+        REQUIRE_THROWS_AS(
+            batchnorm_reference(std::vector<float>(input.size() + 1), p3, p3, p3, p3, 1e-3f, g),
+            std::invalid_argument);
+    }
+}


### PR DESCRIPTION
## Summary

E9-T2 (BatchNorm ISA/executor capability closure, #179) — the second BatchNorm
task, following the merged T1 design (#178). It delivers the host-side capability
BN inference needs and confirms the value path requires **no new executor kernel**.

## What landed

- **`include/sw/kpu/timing/schedule/batchnorm_affine.hpp`** (new)
  - `bn_fold` — folds the four raw per-channel params into a single scale/shift
    pair: `scale = γ/√(var+ε)`, `shift = β − mean·scale`. Halves resident params
    (`4C+1 → 2C+1`). Guards `eps > 0` and `var+ε > 0` (the E3/E8 clamped-variance
    discipline).
  - `batchnorm_apply` — the folded fast path `y = x·scale[c] + shift[c]`.
  - `batchnorm_reference` — an **independent** direct 4-param oracle
    (`γ·(x−mean)/√(var+ε)+β`), so the fold + apply is cross-checked against a
    different implementation.
  - `BatchNormGeometry` (NCHW), `BatchNormAffine {scale, shift}`.

- **No new executor kernel.** BN inference is a per-channel broadcast-affine — a
  Vector Engine op expressible directly on the existing `FunctionalComputeSpec`
  value path. This is the same fold conv2d T4 applies for conv+BN.

- **`test_batchnorm_affine.cpp`** — fold math, folded-apply vs. the direct
  reference, a hand-computed tiny case, per-channel application, and the guards.

## Test results

| Check | Result |
|-------|--------|
| `test_batchnorm_affine` | PASS — 135 assertions, 5 cases |
| Full `timing` suite | PASS — 34/34 |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Wconversion -Wshadow -Werror` | clean |

## Coverage manifest (#93 contract)

`batchnorm` `design` (T1 #178) + `isa_closure` → **done**. Remaining:
`generator` (T3 #180 — the #139 COMPUTE-emission fix + load scale/shift),
`functional` (T4 #181), `regression` (T5 #182).

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #179

Generated with [Claude Code](https://claude.com/claude-code)