### PR TITLE
fix(batchnorm): inference generator emits executable COMPUTE (E9-T3, #180; #139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BatchNorm inference generator emitted DRAIN without COMPUTE (batchnorm half
+  of #139) — E9-T3 (#180).** `BatchNormScheduleGenerator` inference now loads the
+  folded `scale/shift` (two `[C]` vectors, not four raw params) as per-channel
+  **broadcast operands** (`emit_broadcast_tile`, so each is delivered once and
+  held resident across its channel's `N·spatial-tile` consumptions), and emits an
+  executable per-channel affine COMPUTE (`y = x·scale[c] + shift[c]`, depending on
+  the streamed input tile + the channel's resident scale/shift) before each drain.
+  Before this the drain had no producer and an executed BN schedule deadlocked.
+  The fold halves the working set (`4C+1 → 2C+1`). New regression
+  `test_batchnorm_execution` runs the generated schedules through the executor
+  (timing-only) across batch/large-C/non-tile-aligned cases, asserting a COMPUTE
+  per output tile, livelock-free completion, and the exact `2C+1` envelope
+  boundary. Coverage: `batchnorm` generator stage → done (functional T4 #181,
+  regression T5 #182 remain).
+
 ### Added
 
 - **BatchNorm-inference scale/shift fold helper — E9-T2 (#179).** BN inference

--- a/include/sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <sw/kpu/timing/schedule/schedule_generator_interface.hpp>
+#include <sw/kpu/timing/schedule/elementwise_schedule_generator.hpp>  // emit_broadcast_tile
 
 #include <sstream>
 
@@ -76,6 +77,14 @@ public:
         // Base addresses
         Address input_base = 0;
         Address output_base = 0;
+        // Inference (folded) parameters: y = x*scale[c] + shift[c], where
+        // scale = gamma/sqrt(var+eps), shift = beta - mean*scale (see
+        // batchnorm_affine.hpp / docs/plans/e9_batchnorm_pattern.md). The fold
+        // is done at param-prep time so inference loads two [C] vectors, not
+        // four - halving resident params to 2C+1.
+        Address scale_base = 0;         ///< Folded scale parameter [C]
+        Address shift_base = 0;         ///< Folded shift parameter [C]
+        // Raw parameters (used by training mode, which computes batch stats).
         Address gamma_base = 0;         ///< Scale parameter [C]
         Address beta_base = 0;          ///< Bias parameter [C]
         Address running_mean_base = 0;  ///< Running mean [C]
@@ -120,14 +129,14 @@ public:
         /**
          * @brief Peak tile residency this schedule implies
          *
-         * Inference preloads gamma/beta/mean/var for EVERY channel up front
-         * and keeps them resident across all samples: 4*C tiles plus the
-         * streaming input. Training processes channels sequentially: per
-         * channel, the gamma/beta pair plus the mean/var scratch pair are
-         * live alongside the streaming input.
+         * Inference preloads the FOLDED scale/shift for EVERY channel up front
+         * and keeps them resident across all samples: 2*C tiles plus the
+         * streaming input (the fold halves this from the raw 4*C+1). Training
+         * processes channels sequentially: per channel, the gamma/beta pair
+         * plus the mean/var scratch pair are live alongside the streaming input.
          */
         [[nodiscard]] Size required_working_set() const {
-            return training ? 5 : 4 * C + 1;
+            return training ? 5 : 2 * C + 1;
         }
     };
 
@@ -179,7 +188,9 @@ public:
 
         Size input_tiles = config_.N * config_.C * config_.spatial_tiles();
         result.metadata.a_tiles = input_tiles;
-        result.metadata.b_tiles = config_.C;  // Parameters per channel
+        // Two folded params per channel at inference (scale + shift); training
+        // loads gamma + beta per channel (mean/var are computed into scratch).
+        result.metadata.b_tiles = 2 * config_.C;
         result.metadata.c_tiles = input_tiles;
 
         result.metadata.strategy = config_.training ? "training_batchnorm" : "inference_batchnorm";
@@ -218,47 +229,51 @@ private:
     /**
      * @brief Generate inference mode schedule
      *
-     * Uses pre-computed running_mean and running_var.
-     * For each channel: y = gamma * (x - mean) / sqrt(var + eps) + beta
+     * Uses the precomputed folded scale/shift: y = x*scale[c] + shift[c]. The
+     * per-channel scale/shift are broadcast operands (P5): each is delivered
+     * once (LOAD + MOVE with a consumer count) and stays resident across all
+     * N*spatial-tile consumptions of its channel. Every output tile is an
+     * executable per-channel affine COMPUTE depending on the streamed input
+     * tile plus that channel's resident scale/shift (resolving the batchnorm
+     * half of #139: the schedule no longer emits a DRAIN with no producer).
      */
     void generate_inference_mode(ScheduleResult& result) {
         Size spatial_tiles = config_.spatial_tiles();
+        Size consumers_per_channel = config_.N * spatial_tiles;
 
-        // Load all channel parameters once
+        // Preload the folded scale/shift for every channel (all-channel
+        // resident, 2C tiles). Broadcast delivery: one LOAD + one MOVE each,
+        // the MOVE carrying the consumer count so the operand holds a single
+        // L2 credit across its whole consumption span.
         for (Size c = 0; c < config_.C; ++c) {
-            auto gamma_tile = make_param_tile(c, ParamType::GAMMA);
-            auto beta_tile = make_param_tile(c, ParamType::BETA);
-            auto mean_tile = make_param_tile(c, ParamType::MEAN);
-            auto var_tile = make_param_tile(c, ParamType::VAR);
-
-            result.operations.push_back(ScheduleOperation::load(gamma_tile));
-            result.operations.push_back(ScheduleOperation::load(beta_tile));
-            result.operations.push_back(ScheduleOperation::load(mean_tile));
-            result.operations.push_back(ScheduleOperation::load(var_tile));
-
-            result.operations.push_back(ScheduleOperation::move(gamma_tile));
-            result.operations.push_back(ScheduleOperation::move(beta_tile));
-            result.operations.push_back(ScheduleOperation::move(mean_tile));
-            result.operations.push_back(ScheduleOperation::move(var_tile));
+            emit_broadcast_tile(result, make_param_tile(c, ParamType::SCALE),
+                                consumers_per_channel);
+            emit_broadcast_tile(result, make_param_tile(c, ParamType::SHIFT),
+                                consumers_per_channel);
         }
 
-        // Process each sample
+        // Stream the input; each output tile is a per-channel affine COMPUTE.
         for (Size n = 0; n < config_.N; ++n) {
-            // Process each channel
             for (Size c = 0; c < config_.C; ++c) {
-                // Load parameters for this channel (may be cached)
-                auto gamma_tile = make_param_tile(c, ParamType::GAMMA);
-                result.operations.push_back(ScheduleOperation::feed(gamma_tile));
+                auto scale_tile = make_param_tile(c, ParamType::SCALE);
+                auto shift_tile = make_param_tile(c, ParamType::SHIFT);
 
-                // Process spatial tiles for this (n, c)
                 for (Size si = 0; si < spatial_tiles; ++si) {
                     auto input_tile = make_input_tile(n, c, si);
                     result.operations.push_back(ScheduleOperation::load(input_tile));
                     result.operations.push_back(ScheduleOperation::move(input_tile));
                     result.operations.push_back(ScheduleOperation::feed(input_tile));
-                    // VE performs: (x - mean) * rsqrt(var + eps) * gamma + beta
 
+                    // The (n, si)-th consumption of this channel's resident
+                    // scale/shift broadcast operands.
+                    result.operations.push_back(ScheduleOperation::feed(scale_tile));
+                    result.operations.push_back(ScheduleOperation::feed(shift_tile));
+
+                    // y = x * scale[c] + shift[c] (a Vector Engine affine).
                     auto output_tile = make_output_tile(n, c, si);
+                    result.operations.push_back(ScheduleOperation::compute(
+                        output_tile, {input_tile.tile_id, scale_tile.tile_id,
+                                      shift_tile.tile_id}));
                     result.operations.push_back(ScheduleOperation::drain(output_tile));
                     result.operations.push_back(ScheduleOperation::writeback(output_tile));
                     result.operations.push_back(ScheduleOperation::store(output_tile));
@@ -342,7 +357,9 @@ private:
         }
     }
 
-    enum class ParamType { GAMMA, BETA, MEAN, VAR };
+    // GAMMA/BETA/MEAN/VAR are the raw params (training); SCALE/SHIFT are the
+    // folded inference params. tj distinguishes them within a channel's B tiles.
+    enum class ParamType { GAMMA, BETA, MEAN, VAR, SCALE, SHIFT };
 
     /**
      * @brief Create input tile descriptor
@@ -406,12 +423,14 @@ private:
         tile.element_size = config_.element_size;
         tile.size_bytes = config_.element_size;
 
-        Address base;
+        Address base = 0;
         switch (ptype) {
             case ParamType::GAMMA: base = config_.gamma_base; break;
             case ParamType::BETA:  base = config_.beta_base; break;
             case ParamType::MEAN:  base = config_.running_mean_base; break;
             case ParamType::VAR:   base = config_.running_var_base; break;
+            case ParamType::SCALE: base = config_.scale_base; break;
+            case ParamType::SHIFT: base = config_.shift_base; break;
         }
         tile.dram_address = base + c * config_.element_size;
 

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -176,11 +176,11 @@
       "stages": {
         "design": "done",
         "isa_closure": "done",
-        "generator": "partial",
+        "generator": "done",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "Design (T1 #178): BN inference folds to a per-channel affine y=x*scale+shift (scale=gamma/sqrt(var+eps), shift=beta-mean*scale) on the FunctionalComputeSpec broadcast path, no new kernel; docs/plans/e9_batchnorm_pattern.md. ISA/executor closure (T2 #179): host-side fold helper batchnorm_affine.hpp (bn_fold, batchnorm_apply, batchnorm_reference oracle); confirmed the broadcast-affine value path covers BN, no new executor kernel; fold halves resident params 4C+1->2C+1. Remaining: generator emits DRAIN without COMPUTE (#139 applies, T3 #180); functional T4 #181, regression T5 #182. Training (P3 reduction) is an E9 follow-on."
+      "notes": "Design (T1 #178): BN inference folds to a per-channel affine y=x*scale+shift (scale=gamma/sqrt(var+eps), shift=beta-mean*scale) on the FunctionalComputeSpec broadcast path, no new kernel; docs/plans/e9_batchnorm_pattern.md. ISA/executor closure (T2 #179): host-side fold helper batchnorm_affine.hpp (bn_fold, batchnorm_apply, batchnorm_reference oracle); no new executor kernel. Generator (T3 #180): BatchNormScheduleGenerator inference loads folded scale/shift as per-channel broadcast operands (emit_broadcast_tile, consumer_count) and emits an executable per-channel affine COMPUTE (input + resident scale/shift) before each drain (resolves the batchnorm half of #139); working set folded 4C+1->2C+1. Remaining: functional T4 #181, regression T5 #182. Training (P3 reduction) is an E9 follow-on."
     },
     {
       "name": "elementwise",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -180,6 +180,17 @@ set_tests_properties(test_batchnorm_affine PROPERTIES
     LABELS "timing;functional;batchnorm;v0.9"
 )
 
+# BatchNorm inference schedule execution regression (issue #180, epic E9): the
+# generator now emits COMPUTE (resolving the batchnorm half of #139), so
+# generated schedules execute livelock-free through the executor
+kpu_add_component_test(test_batchnorm_execution "timing"
+    test_batchnorm_execution.cpp
+)
+
+set_tests_properties(test_batchnorm_execution PROPERTIES
+    LABELS "timing;batchnorm;executor;regression;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_batchnorm_execution.cpp
+++ b/tests/timing/test_batchnorm_execution.cpp
@@ -1,0 +1,145 @@
+// ============================================================================
+// tests/timing/test_batchnorm_execution.cpp
+// End-to-end execution regression for BatchNormScheduleGenerator (E9-T3, #180).
+//
+// Locks in the batchnorm half of #139: before T3 the inference generator emitted
+// DRAIN with no COMPUTE, so an executed BN schedule had a drain with no producer
+// and would deadlock. T3 emits an executable per-channel affine COMPUTE (input +
+// resident scale/shift). This test EXECUTES the generated schedules (timing-only)
+// and asserts a COMPUTE per output tile and livelock-free completion. Functional
+// value correctness is T4 (#181).
+//
+// The all-channel-preload design makes the working set 2C+1, so each case sizes
+// its envelope to C (min(l3,l2)/4 >= 2C+1).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+struct BNCase {
+    const char* name;
+    Size N, C, H, W, Ti;
+};
+
+constexpr BNCase kCases[] = {
+    {"1x3x8x8",   1, 3,  8,  8, 16},   // 2C+1 = 7
+    {"2x3x4x4",   2, 3,  4,  4, 16},   // batch > 1
+    {"1x16x8x8",  1, 16, 8,  8, 16},   // larger C (needs bigger envelope)
+    {"1x8x7x7",   1, 8,  7,  7, 16},   // non-tile-aligned spatial (49)
+};
+
+// Size l3/l2 so min/4 >= 2C+1 (all-channel preload residency).
+Size envelope_for(Size C) {
+    Size need = 2 * C + 1;
+    Size credits = 4 * need + 4;  // margin above the 4x share bound
+    return credits < 32 ? 32 : credits;
+}
+
+BatchNormScheduleGenerator::Config gen_config(const BNCase& c) {
+    BatchNormScheduleGenerator::Config config;
+    config.N = c.N; config.C = c.C; config.H = c.H; config.W = c.W;
+    config.Ti = c.Ti; config.Tj = c.Ti;
+    config.training = false;
+    const Size credits = envelope_for(c.C);
+    config.l3_buffer_count = credits;
+    config.l2_bank_count = credits;
+    config.input_base  = 0x00100000;
+    config.output_base = 0x00400000;
+    config.scale_base  = 0x00010000;
+    config.shift_base  = 0x00020000;
+    return config;
+}
+
+ConcurrentTimingExecutor::Config exec_config(Size C) {
+    ConcurrentTimingExecutor::Config config;
+    const Size credits = envelope_for(C);
+    config.l3_buffer_count = credits;
+    config.l2_bank_count = credits;
+    config.max_cycles = 2'000'000;
+    config.enable_livelock_detection = true;
+    config.livelock_threshold = 20000;
+    return config;
+}
+
+} // namespace
+
+TEST_CASE("BatchNorm inference generator emits a COMPUTE per output tile",
+          "[timing][batchnorm][generator]") {
+    for (const auto& c : kCases) {
+        DYNAMIC_SECTION(c.name) {
+            auto schedule = BatchNormScheduleGenerator(gen_config(c)).generate();
+            REQUIRE(schedule.valid);
+
+            // #139 regression: a COMPUTE exists for every output tile, so no
+            // DRAIN is left without a producer.
+            const auto n_compute = schedule.count_ops(ScheduleOpType::COMPUTE);
+            const auto n_drain   = schedule.count_ops(ScheduleOpType::DRAIN);
+            const auto n_store   = schedule.count_ops(ScheduleOpType::STORE);
+            REQUIRE(n_compute > 0);
+            REQUIRE(n_compute == n_drain);
+            REQUIRE(n_compute == n_store);
+
+            // Every input/output tile is one (n, c, spatial-tile).
+            const Size spatial_tiles = (c.H * c.W + c.Ti - 1) / c.Ti;
+            REQUIRE(n_compute == c.N * c.C * spatial_tiles);
+        }
+    }
+}
+
+TEST_CASE("BatchNorm inference schedules execute livelock-free",
+          "[timing][batchnorm][executor][regression]") {
+    for (const auto& c : kCases) {
+        DYNAMIC_SECTION(c.name) {
+            auto schedule = BatchNormScheduleGenerator(gen_config(c)).generate();
+            REQUIRE(schedule.valid);
+
+            ConcurrentTimingExecutor executor(exec_config(c.C));
+            ScheduleExecutor sched_exec(executor);
+            auto result = sched_exec.execute(schedule);
+
+            INFO("case=" << c.name << " cycles=" << result.total_cycles
+                 << " error=" << result.error_message);
+
+            // The #139 surface: before COMPUTE was emitted, the drain had no
+            // producer and this deadlocked. Now it completes.
+            REQUIRE(result.success);
+            REQUIRE_FALSE(result.livelock_detected);
+            REQUIRE(result.total_cycles > 0);
+
+            auto stats = executor.get_statistics();
+            REQUIRE(stats.tiles_drained ==
+                    schedule.count_ops(ScheduleOpType::DRAIN));
+            REQUIRE(stats.tiles_fed ==
+                    schedule.count_ops(ScheduleOpType::FEED));
+        }
+    }
+}
+
+TEST_CASE("BatchNorm inference working set is 2C+1 (folded)",
+          "[timing][batchnorm][envelope]") {
+    // The fold halves residency from 4C+1 to 2C+1; the generator refuses a
+    // priori when the envelope share is one tile short.
+    BNCase c{"boundary", 1, 4, 8, 8, 16};  // 2C+1 = 9
+    auto cfg = gen_config(c);
+
+    // share = min(l3,l2)/4 = 9 -> generates (== working set)
+    cfg.l3_buffer_count = 36; cfg.l2_bank_count = 36;
+    REQUIRE(BatchNormScheduleGenerator(cfg).generate().valid);
+
+    // share = 8 -> refused (< working set)
+    cfg.l3_buffer_count = 32; cfg.l2_bank_count = 32;
+    auto refused = BatchNormScheduleGenerator(cfg).generate();
+    REQUIRE_FALSE(refused.valid);
+    REQUIRE(refused.error_message.find("working set") != std::string::npos);
+}

--- a/tests/timing/test_schedule_generators.cpp
+++ b/tests/timing/test_schedule_generators.cpp
@@ -603,8 +603,8 @@ TEST_CASE("BatchNorm and Conv2D carry the envelope and refuse degenerate shares"
     SECTION("batchnorm inference all-channel preload is refused at default envelope") {
         BatchNormScheduleGenerator::Config config;
         config.N = 4; config.C = 8; config.H = 16; config.W = 16;
-        config.training = false;   // preloads 4*C params: 33 > share 8
-        REQUIRE(config.required_working_set() == 33);
+        config.training = false;   // preloads folded 2*C params: 17 > share 8
+        REQUIRE(config.required_working_set() == 17);  // 2*C + 1, C = 8
         BatchNormScheduleGenerator gen(config);
         auto schedule = gen.generate();
         REQUIRE_FALSE(schedule.valid);
@@ -616,7 +616,7 @@ TEST_CASE("BatchNorm and Conv2D carry the envelope and refuse degenerate shares"
         config.N = 4; config.C = 8; config.H = 16; config.W = 16;
         config.training = false;
         config.l3_buffer_count = 256;
-        config.l2_bank_count = 256;   // share 64 >= 33
+        config.l2_bank_count = 256;   // share 64 >= 17
         BatchNormScheduleGenerator gen(config);
         REQUIRE(gen.generate().valid);
     }


### PR DESCRIPTION
## Summary

E9-T3 (BatchNorm envelope-aware schedule generator, #180), following the merged
T1/T2 (#178/#183). It **resolves the batchnorm half of #139**:
`BatchNormScheduleGenerator` inference emitted `DRAIN` with no `COMPUTE`, so an
executed BN schedule had a drain with no producer and would deadlock.

## What changed

- **Load folded `scale/shift`, not four raw params.** Inference now loads two
  `[C]` vectors (the E9-T2 fold) as **per-channel broadcast operands** via
  `emit_broadcast_tile` — each delivered once (LOAD+MOVE, `consumer_count =
  N·spatial_tiles`) and held resident across its channel's consumptions. This is
  the same P5 broadcast mechanism the elementwise generator uses; the helper is
  explicitly documented for norm generators' resident parameters.

- **Emit an executable per-channel affine COMPUTE** (`y = x·scale[c] + shift[c]`)
  before each drain, depending on the streamed input tile plus the channel's
  resident scale/shift. The drain now has a producer.

- **Fold halves the working set** `4C+1 → 2C+1`. `ParamType` gains `SCALE/SHIFT`;
  `Config` gains `scale_base/shift_base` (raw bases kept for training).

- **`test_batchnorm_execution`** (new) executes the generated schedules
  (timing-only) across batch / large-C / non-tile-aligned-spatial cases,
  asserting a COMPUTE per output tile, livelock-free completion, and the exact
  `2C+1` envelope boundary (share 9 generates, 8 refused). Before the fix this
  deadlocked at the first drain.

## Test results

| Check | Result |
|-------|--------|
| `test_batchnorm_execution` | PASS — 47 assertions, 3 cases |
| Full `timing` suite | PASS — 35/35, no regressions |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Werror` | clean |

## Note on residency

The design's all-channel preload makes the working set scale as `2C+1`, so each
test case sizes its envelope to `C` (`min(l3,l2)/4 ≥ 2C+1`); large-`C` with a
default envelope is refused a priori, as the T1 design documents.

## Coverage manifest (#93 contract)

`batchnorm` `generator` → **done**. `functional` (T4 #181) and `regression`
(T5 #182) remain.

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #180
Relates to #139

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BatchNorm inference schedules that could deadlock by ensuring each output tile receives the required computation before draining.
  * Improved inference handling for folded per-channel scale and shift parameters.
  * Reduced the required inference working-set size.

* **Tests**
  * Added regression coverage for execution completion, tile processing, non-aligned shapes, and working-set limits.
  * Updated BatchNorm schedule expectations and coverage status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->