### PR TITLE
feat(batchnorm): functional integration + host oracle (E9-T4, #181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BatchNorm functional integration + host oracle — E9-T4 (#181); satisfies the
+  `batchnorm.functional` M2 gate cell.** Value-producing BN inference on the CSP
+  executor: the streamed input tiles and the folded per-channel `scale/shift`
+  (E9-T2 `bn_fold`) are seeded as tile payloads, and the schedule runs through the
+  `ScheduleExecutor` functional-compute binder applying `y = x·scale + shift`
+  (per-channel), checked elementwise against `batchnorm_reference` (the direct
+  4-param formula). `test_functional_batchnorm` covers spatial-tile / single-tile
+  / batch / large-C shapes. New `examples/schedule/batchnorm_simulator` drives the
+  schedule cycle-by-cycle through the `TileTracker`, showing the per-channel
+  `scale/shift` broadcast params arriving and staying **resident** (with their
+  values) while input tiles stream and the affine computes drain — ending on the
+  oracle check (geometry flags). Coverage: `batchnorm.functional` → done;
+  regression T5 #182 remains.
+
 ### Fixed
 
 - **BatchNorm inference generator emitted DRAIN without COMPUTE (batchnorm half

--- a/examples/schedule/CMakeLists.txt
+++ b/examples/schedule/CMakeLists.txt
@@ -98,3 +98,14 @@ if(KPU_BUILD_TESTS)
         LABELS "timing;conv2d;tracker;example;v0.9"
     )
 endif()
+
+# BatchNorm simulator with tile-state tracker (folded affine; issue #181, epic E9)
+add_executable(batchnorm_simulator batchnorm_simulator.cpp)
+target_link_libraries(batchnorm_simulator PRIVATE kpu_simulator)
+set_target_properties(batchnorm_simulator PROPERTIES FOLDER "Examples/Schedule")
+if(KPU_BUILD_TESTS)
+    add_test(NAME batchnorm_simulator COMMAND batchnorm_simulator)
+    set_tests_properties(batchnorm_simulator PROPERTIES
+        LABELS "timing;batchnorm;tracker;example;v0.9"
+    )
+endif()

--- a/examples/schedule/batchnorm_simulator.cpp
+++ b/examples/schedule/batchnorm_simulator.cpp
@@ -1,0 +1,191 @@
+// ============================================================================
+// examples/schedule/batchnorm_simulator.cpp
+// Standalone BatchNorm-inference simulator with a horizontal tile-state debug
+// log (companion to conv2d_simulator; see docs/tile-state-tracking.md).
+//
+// BatchNorm inference folds to a per-channel affine y = x*scale[c] + shift[c]
+// (see docs/plans/e9_batchnorm_pattern.md). This driver seeds the streamed
+// input tiles and the folded per-channel scale/shift params (the E9-T2 fold),
+// runs the generated BN schedule one executor cycle at a time, and after each
+// cycle records any change in what tiles occupy L3 / L2 / L1 / array via the
+// TileTracker. Watch the per-channel scale/shift broadcast params arrive and
+// stay RESIDENT while the input tiles stream DRAM->L3->L2->L1/array, a
+// per-channel affine compute in the array, and the output drain back out. Ends
+// on a direct-conv-style host oracle check.
+//
+// Usage: batchnorm_simulator [--n N] [--c C] [--h H] [--w W] [--tile T]
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/tile_tracker.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+long arg(int argc, char** argv, const char* flag, long def) {
+    for (int i = 1; i + 1 < argc; ++i)
+        if (std::strcmp(argv[i], flag) == 0) return std::atol(argv[i + 1]);
+    return def;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        BatchNormGeometry g;
+        g.N = static_cast<Size>(arg(argc, argv, "--n", 1));
+        g.C = static_cast<Size>(arg(argc, argv, "--c", 2));
+        g.H = static_cast<Size>(arg(argc, argv, "--h", 4));
+        g.W = static_cast<Size>(arg(argc, argv, "--w", 4));
+        const Size T = static_cast<Size>(arg(argc, argv, "--tile", 16));
+        if (T == 0) { std::cerr << "error: --tile must be > 0\n"; return 2; }
+        if (!g.valid()) { std::cerr << "error: invalid geometry\n"; return 2; }
+        if (g.spatial() % T) {
+            std::cerr << "error: --tile " << T << " must divide H*W=" << g.spatial() << "\n";
+            return 2;
+        }
+
+        // Host operands (bounded) and the folded scale/shift.
+        std::vector<float> input(g.elems());
+        for (std::size_t i = 0; i < input.size(); ++i)
+            input[i] = -1.0f + 0.5f * static_cast<float>(i % 7);
+        std::vector<float> gamma(g.C), beta(g.C), mean(g.C), var(g.C);
+        for (Size c = 0; c < g.C; ++c) {
+            gamma[c] = 0.5f + 0.5f * static_cast<float>(c % 4);
+            beta[c]  = -1.0f + 0.75f * static_cast<float>(c % 3);
+            mean[c]  = 0.25f + 0.5f * static_cast<float>(c % 5);
+            var[c]   = 0.5f + 0.25f * static_cast<float>(c % 4);
+        }
+        const float eps = 1e-3f;
+        const auto affine = bn_fold(gamma, beta, mean, var, eps);
+        const auto ref = batchnorm_reference(input, gamma, beta, mean, var, eps, g);
+
+        BatchNormScheduleGenerator::Config cfg;
+        cfg.N = g.N; cfg.C = g.C; cfg.H = g.H; cfg.W = g.W;
+        cfg.Ti = T; cfg.Tj = T; cfg.training = false;
+        const Size credits = 4 * (2 * g.C + 1) + 4;
+        cfg.l3_buffer_count = cfg.l2_bank_count = credits < 32 ? 32 : credits;
+        auto schedule = BatchNormScheduleGenerator(cfg).generate();
+        if (!schedule.valid) {
+            std::cerr << "schedule refused: " << schedule.error_message << "\n";
+            return 1;
+        }
+
+        std::cout << "BatchNorm simulator  -  inference (folded affine)  (N" << g.N
+                  << " C" << g.C << " " << g.H << "x" << g.W << ", tile " << T
+                  << ")\n  y = x*scale[c] + shift[c]  (scale/shift resident per channel)\n\n";
+
+        ConcurrentTimingExecutor::Config ecfg;
+        ecfg.l3_buffer_count = ecfg.l2_bank_count = cfg.l3_buffer_count;
+        ecfg.max_cycles = 2'000'000;
+        ConcurrentTimingExecutor exec(ecfg);
+
+        const Size spatial = g.spatial();
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::LOAD) continue;
+            const auto id = op.tile.tile_id;
+            if (id.matrix == MatrixID::A) {
+                const Size n = id.ti / g.C, c = id.ti % g.C, si = id.tj;
+                const std::size_t base =
+                    (static_cast<std::size_t>(n) * g.C + c) * spatial + si * T;
+                exec.set_tile_payload(id, TilePayload{T, 1,
+                    std::vector<float>(input.begin() + static_cast<std::ptrdiff_t>(base),
+                                       input.begin() + static_cast<std::ptrdiff_t>(base + T))});
+            } else {  // param: ti = channel, tj = SCALE(4)/SHIFT(5) ordinal
+                const Size c = id.ti;
+                const bool is_scale = (id.tj == 4);
+                exec.set_tile_payload(id, TilePayload{1, 1,
+                    {is_scale ? affine.scale[c] : affine.shift[c]}});
+            }
+        }
+
+        // Enqueue; a COMPUTE becomes a value-producing FunctionalComputeSpec
+        // applying the per-channel affine to the streamed input tile.
+        for (const auto& op : schedule.operations) {
+            switch (op.type) {
+                case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+                case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+                case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+                case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+                case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+                case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+                case ScheduleOpType::COMPUTE: {
+                    ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+                    spec.input_tiles = op.dependency_tiles;  // {input, scale, shift}
+                    spec.operation = [](const std::vector<TilePayload>& in) {
+                        const auto& x = in.at(0);
+                        const float scale = in.at(1).values.at(0);
+                        const float shift = in.at(2).values.at(0);
+                        TilePayload out{x.rows, x.cols, std::vector<float>(x.values.size())};
+                        for (std::size_t i = 0; i < x.values.size(); ++i)
+                            out.values[i] = x.values[i] * scale + shift;
+                        return out;
+                    };
+                    exec.schedule_functional_compute(op.tile, spec);
+                    break;
+                }
+            }
+        }
+
+        // Label input as X[c,si], params as scale[c]/shift[c], output as Y[c,si].
+        TileTracker::Config tcfg;
+        tcfg.label = [C = g.C](const TileID& id) -> std::string {
+            auto ij = [](Size a, Size b) {
+                return "[" + std::to_string(a) + "," + std::to_string(b) + "]";
+            };
+            if (id.matrix == MatrixID::A) return "X" + ij(id.ti % C, id.tj);
+            if (id.matrix == MatrixID::C) return "Y" + ij(id.ti % C, id.tj);
+            return (id.tj == 4 ? "scale[" : "shift[") + std::to_string(id.ti) + "]";
+        };
+        TileTracker tracker(tcfg);
+        tracker.observe(exec);
+        while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
+            exec.step();
+            tracker.observe(exec);
+        }
+        std::cout << tracker.log() << "\n";
+
+        if (!exec.is_complete()) {
+            std::cerr << "schedule did not complete (deadlock or max_cycles)\n";
+            return 1;
+        }
+
+        std::cout << "Result: y = batchnorm_inference(x)\n";
+        double max_err = 0.0;
+        for (const auto& op : schedule.operations) {
+            if (op.type != ScheduleOpType::STORE) continue;
+            const auto id = op.tile.tile_id;
+            const Size n = id.ti / g.C, c = id.ti % g.C, si = id.tj;
+            const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+            const std::size_t base =
+                (static_cast<std::size_t>(n) * g.C + c) * spatial + si * T;
+            for (Size i = 0; i < T; ++i)
+                max_err = std::max(max_err,
+                    static_cast<double>(std::abs(p.values[i] - ref[base + i])));
+        }
+        const bool ok = max_err < 1e-3;
+        std::cout << "  max abs error vs host oracle: " << max_err
+                  << (ok ? "  [OK]" : "  [FAIL]") << "\n\n"
+                  << (ok ? "BATCHNORM OK" : "BATCHNORM MISMATCH") << "\n";
+        return ok ? 0 : 1;
+    } catch (const std::exception& e) {
+        std::cerr << "error: " << e.what() << "\n";
+        return 1;
+    }
+}

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -177,10 +177,10 @@
         "design": "done",
         "isa_closure": "done",
         "generator": "done",
-        "functional": "missing",
+        "functional": "done",
         "regression": "missing"
       },
-      "notes": "Design (T1 #178): BN inference folds to a per-channel affine y=x*scale+shift (scale=gamma/sqrt(var+eps), shift=beta-mean*scale) on the FunctionalComputeSpec broadcast path, no new kernel; docs/plans/e9_batchnorm_pattern.md. ISA/executor closure (T2 #179): host-side fold helper batchnorm_affine.hpp (bn_fold, batchnorm_apply, batchnorm_reference oracle); no new executor kernel. Generator (T3 #180): BatchNormScheduleGenerator inference loads folded scale/shift as per-channel broadcast operands (emit_broadcast_tile, consumer_count) and emits an executable per-channel affine COMPUTE (input + resident scale/shift) before each drain (resolves the batchnorm half of #139); working set folded 4C+1->2C+1. Remaining: functional T4 #181, regression T5 #182. Training (P3 reduction) is an E9 follow-on."
+      "notes": "Design (T1 #178): BN inference folds to a per-channel affine y=x*scale+shift (scale=gamma/sqrt(var+eps), shift=beta-mean*scale) on the FunctionalComputeSpec broadcast path, no new kernel; docs/plans/e9_batchnorm_pattern.md. ISA/executor closure (T2 #179): host-side fold helper batchnorm_affine.hpp (bn_fold, batchnorm_apply, batchnorm_reference oracle); no new executor kernel. Generator (T3 #180): BatchNormScheduleGenerator inference loads folded scale/shift as per-channel broadcast operands (emit_broadcast_tile) and emits executable per-channel affine COMPUTE (resolves the batchnorm half of #139); working set folded 4C+1->2C+1. Functional (T4 #181): value-producing BN inference on the CSP executor (FunctionalComputeSpec binder applying y=x*scale+shift) verified elementwise vs the direct 4-param oracle across spatial-tile/single-tile/batch/large-C (test_functional_batchnorm) + batchnorm_simulator tile-log showing scale/shift residency. batchnorm.functional (M2 gate cell) satisfied. Remaining: regression T5 #182. Training (P3 reduction) is an E9 follow-on."
     },
     {
       "name": "elementwise",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -191,6 +191,16 @@ set_tests_properties(test_batchnorm_execution PROPERTIES
     LABELS "timing;batchnorm;executor;regression;v0.9"
 )
 
+# BatchNorm functional integration + host oracle (issue #181, epic E9):
+# value-producing BN inference on the CSP executor vs a direct 4-param oracle
+kpu_add_component_test(test_functional_batchnorm "timing"
+    test_functional_batchnorm.cpp
+)
+
+set_tests_properties(test_functional_batchnorm PROPERTIES
+    LABELS "timing;functional;batchnorm;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_functional_batchnorm.cpp
+++ b/tests/timing/test_functional_batchnorm.cpp
@@ -1,0 +1,158 @@
+// ============================================================================
+// tests/timing/test_functional_batchnorm.cpp
+// Value-producing BatchNorm inference on the CSP executor vs a host oracle
+// (E9-T4, #181).
+//
+// Seeds the streamed input tiles and the folded per-channel scale/shift params
+// (E9-T2 bn_fold) as tile payloads, executes the BatchNormScheduleGenerator
+// inference schedule through the value-producing functional path (the
+// ScheduleExecutor functional-compute binder applying y = x*scale + shift), and
+// checks every drained output tile elementwise against batchnorm_reference (the
+// independent direct 4-param formula). This is the batchnorm.functional gate.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+#include <cmath>
+#include <optional>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+std::vector<float> fill(std::size_t n, int period, float base, float step) {
+    std::vector<float> v(n);
+    for (std::size_t i = 0; i < n; ++i)
+        v[i] = base + step * static_cast<float>(i % static_cast<std::size_t>(period));
+    return v;
+}
+
+// Size l3/l2 so min/4 >= 2C+1 (all-channel preload residency).
+Size envelope_for(Size C) {
+    const Size credits = 4 * (2 * C + 1) + 4;
+    return credits < 32 ? 32 : credits;
+}
+
+// Execute BN inference and return the max abs error vs the host oracle.
+double run_and_compare(const BatchNormGeometry& g, Size Ti) {
+    REQUIRE(g.spatial() % Ti == 0);  // full tiles only
+
+    // Host operands (bounded) and the folded scale/shift.
+    auto input = fill(g.elems(), 7, -1.0f, 0.5f);
+    auto gamma = fill(g.C, 4, 0.5f, 0.5f);
+    auto beta  = fill(g.C, 3, -1.0f, 0.75f);
+    auto mean  = fill(g.C, 5, 0.25f, 0.5f);
+    auto var   = fill(g.C, 4, 0.5f, 0.25f);  // all > 0
+    const float eps = 1e-3f;
+    const auto affine = bn_fold(gamma, beta, mean, var, eps);
+    const auto ref = batchnorm_reference(input, gamma, beta, mean, var, eps, g);
+
+    BatchNormScheduleGenerator::Config cfg;
+    cfg.N = g.N; cfg.C = g.C; cfg.H = g.H; cfg.W = g.W;
+    cfg.Ti = Ti; cfg.Tj = Ti; cfg.training = false;
+    const Size credits = envelope_for(g.C);
+    cfg.l3_buffer_count = credits; cfg.l2_bank_count = credits;
+    auto schedule = BatchNormScheduleGenerator(cfg).generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.l3_buffer_count = credits; ecfg.l2_bank_count = credits;
+    ecfg.max_cycles = 2'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+
+    const Size spatial = g.spatial();
+    // Seed input tiles (A: [Ti x 1] spatial slices) and scale/shift params
+    // (B: [1 x 1] per channel, distinguished by tj = SCALE/SHIFT ordinal).
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        if (id.matrix == MatrixID::A) {
+            const Size n = id.ti / g.C, c = id.ti % g.C, si = id.tj;
+            const std::size_t base =
+                (static_cast<std::size_t>(n) * g.C + c) * spatial + si * Ti;
+            exec.set_tile_payload(id, TilePayload{Ti, 1,
+                std::vector<float>(input.begin() + static_cast<std::ptrdiff_t>(base),
+                                   input.begin() + static_cast<std::ptrdiff_t>(base + Ti))});
+        } else {  // param tile: ti = channel, tj = ParamType ordinal
+            // Inference emits only SCALE (ordinal 4) and SHIFT (ordinal 5); see
+            // BatchNormScheduleGenerator::ParamType.
+            const Size c = id.ti;
+            const bool is_scale = (id.tj == 4);
+            exec.set_tile_payload(id, TilePayload{1, 1,
+                {is_scale ? affine.scale[c] : affine.shift[c]}});
+        }
+    }
+
+    ScheduleExecutor sched_exec(exec);
+    sched_exec.set_functional_compute_binder(
+        [](const ScheduleOperation& compute_op)
+            -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+            ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+            spec.input_tiles = compute_op.dependency_tiles;  // {input, scale, shift}
+            spec.operation = [](const std::vector<TilePayload>& in) {
+                const auto& x = in.at(0);
+                const float scale = in.at(1).values.at(0);
+                const float shift = in.at(2).values.at(0);
+                TilePayload out{x.rows, x.cols, std::vector<float>(x.values.size())};
+                for (std::size_t i = 0; i < x.values.size(); ++i)
+                    out.values[i] = x.values[i] * scale + shift;
+                return out;
+            };
+            return spec;
+        });
+
+    auto result = sched_exec.execute(schedule);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+
+    // Gather output tiles and compare to the oracle.
+    double max_err = 0.0;
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        const Size n = id.ti / g.C, c = id.ti % g.C, si = id.tj;
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        const std::size_t base =
+            (static_cast<std::size_t>(n) * g.C + c) * spatial + si * Ti;
+        for (Size i = 0; i < Ti; ++i) {
+            const double got = p.values[i];
+            REQUIRE(std::isfinite(got));
+            max_err = std::max(max_err, std::abs(got - ref[base + i]));
+        }
+    }
+    return max_err;
+}
+
+} // namespace
+
+TEST_CASE("BatchNorm functional: inference on CSP executor matches host oracle",
+          "[timing][batchnorm][functional]") {
+    SECTION("1x4x8x8 (4 spatial tiles/channel)") {
+        BatchNormGeometry g; g.N = 1; g.C = 4; g.H = 8; g.W = 8;
+        REQUIRE(run_and_compare(g, 16) < 1e-3);
+    }
+    SECTION("single spatial tile per channel") {
+        BatchNormGeometry g; g.N = 1; g.C = 6; g.H = 4; g.W = 4;  // spatial 16 = Ti
+        REQUIRE(run_and_compare(g, 16) < 1e-3);
+    }
+    SECTION("batch N=2") {
+        BatchNormGeometry g; g.N = 2; g.C = 4; g.H = 4; g.W = 8;  // spatial 32
+        REQUIRE(run_and_compare(g, 16) < 1e-3);
+    }
+    SECTION("larger channel count") {
+        BatchNormGeometry g; g.N = 1; g.C = 16; g.H = 4; g.W = 4;
+        REQUIRE(run_and_compare(g, 16) < 1e-3);
+    }
+}


### PR DESCRIPTION
## Summary

E9-T4 (BatchNorm functional integration & oracle, #181), following merged
T1/T2/T3 (#178/#183/#184). It delivers **value-producing BN inference on the CSP
executor, verified elementwise against a host oracle** — satisfying
**`batchnorm.functional`, an M2 ResNet gate cell**.

## What landed

- **`tests/timing/test_functional_batchnorm.cpp`** (the coverage gate) — seeds the
  streamed input tiles and the folded per-channel `scale/shift` (E9-T2 `bn_fold`)
  as tile payloads, runs the `BatchNormScheduleGenerator` inference schedule
  through the **`ScheduleExecutor` functional-compute binder** applying
  `y = x·scale + shift` (per channel), and checks every drained output tile against
  `batchnorm_reference` (the independent direct 4-param formula). Covers
  spatial-tile / single-tile / batch / large-C. Envelope sized to `C` (the `2C+1`
  all-channel preload).

- **`examples/schedule/batchnorm_simulator.cpp`** (tile-log artifact, companion to
  the matmul/conv2d simulators) — drives the schedule cycle-by-cycle through the
  `TileTracker`, showing the per-channel `scale/shift` **broadcast params arriving
  and staying resident** (with their values, e.g. `scale[0]=(0.706)*`) while input
  tiles stream and the affine computes drain — ending on the oracle check.
  Geometry flags. CI smoke test asserts exit 0.

## Test results

| Check | Result |
|-------|--------|
| `test_functional_batchnorm` | PASS — 884 assertions, 4 shapes |
| `batchnorm_simulator` smoke | PASS — oracle match (max err ~1e-7) |
| Full `timing` suite | PASS — 37/37 |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Werror` | clean |

## Coverage manifest (#93 contract)

`batchnorm` `functional` → **done** — `batchnorm.functional`, an M2 gate cell, is
satisfied. Only `regression` (T5 #182) remains for the batchnorm row.

Remaining M2 gate cells after E9-batchnorm: `pooling.functional` (E7 #76) and
`epilogue_fused.regression` (E10-T5 #79).

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #181

Generated with [Claude Code](https://claude.com/claude-code)