### PR TITLE
test(batchnorm): regression matrix + characterization (E9-T5, #182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BatchNorm regression matrix + characterization — E9-T5 (#182); completes the
+  batchnorm coverage row.** `test_batchnorm_regression` executes a shape ×
+  envelope matrix (4 shapes incl. batch, large-C, non-tile-aligned spatial ×
+  {ample, minimum, partitioned}, each envelope sized to the case's `2C+1`) with,
+  per cell: exact per-stage tile accounting, L3/L2 credit conservation, a
+  COMPUTE-per-drain check (#139 lock-in), and a stall-sanity bound. Adds an exact
+  `2C+1` envelope-refusal boundary (share 9 generates, 8 refused), a
+  functional-under-credit-pressure oracle cell (values survive the minimum
+  partitioned envelope), and a printed characterization report. With this, the
+  `batchnorm` row is **done across all five stages** (E9 T1–T5).
+
 - **BatchNorm functional integration + host oracle — E9-T4 (#181); satisfies the
   `batchnorm.functional` M2 gate cell.** Value-producing BN inference on the CSP
   executor: the streamed input tiles and the folded per-channel `scale/shift`

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -178,9 +178,9 @@
         "isa_closure": "done",
         "generator": "done",
         "functional": "done",
-        "regression": "missing"
+        "regression": "done"
       },
-      "notes": "Design (T1 #178): BN inference folds to a per-channel affine y=x*scale+shift (scale=gamma/sqrt(var+eps), shift=beta-mean*scale) on the FunctionalComputeSpec broadcast path, no new kernel; docs/plans/e9_batchnorm_pattern.md. ISA/executor closure (T2 #179): host-side fold helper batchnorm_affine.hpp (bn_fold, batchnorm_apply, batchnorm_reference oracle); no new executor kernel. Generator (T3 #180): BatchNormScheduleGenerator inference loads folded scale/shift as per-channel broadcast operands (emit_broadcast_tile) and emits executable per-channel affine COMPUTE (resolves the batchnorm half of #139); working set folded 4C+1->2C+1. Functional (T4 #181): value-producing BN inference on the CSP executor (FunctionalComputeSpec binder applying y=x*scale+shift) verified elementwise vs the direct 4-param oracle across spatial-tile/single-tile/batch/large-C (test_functional_batchnorm) + batchnorm_simulator tile-log showing scale/shift residency. batchnorm.functional (M2 gate cell) satisfied. Remaining: regression T5 #182. Training (P3 reduction) is an E9 follow-on."
+      "notes": "BatchNorm inference complete across all five stages (E9 batchnorm T1-T5, #178-#182). T1 #178: design - BN inference folds to a per-channel affine y=x*scale+shift (scale=gamma/sqrt(var+eps), shift=beta-mean*scale) on the FunctionalComputeSpec broadcast path, no new kernel; docs/plans/e9_batchnorm_pattern.md. T2 #179: host-side fold helper batchnorm_affine.hpp (bn_fold, batchnorm_apply, batchnorm_reference oracle). T3 #180: generator loads folded scale/shift as per-channel broadcast operands (emit_broadcast_tile) and emits executable affine COMPUTE (resolves the batchnorm half of #139); working set 4C+1->2C+1. T4 #181: value-producing BN vs the direct 4-param oracle (test_functional_batchnorm) + batchnorm_simulator. T5 #182: shape x envelope regression matrix with per-stage tile accounting, credit conservation, stall invariants, exact 2C+1 refusal boundary, functional-under-credit-pressure oracle, and characterization (test_batchnorm_regression). batchnorm.functional (M2 gate cell) satisfied. Training (P3 reduction) is an E9 follow-on."
     },
     {
       "name": "elementwise",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -201,6 +201,16 @@ set_tests_properties(test_functional_batchnorm PROPERTIES
     LABELS "timing;functional;batchnorm;v0.9"
 )
 
+# BatchNorm execution regression matrix (issue #182, epic E9): shape x envelope
+# with credit/stall invariants, the 2C+1 boundary, and characterization
+kpu_add_component_test(test_batchnorm_regression "timing"
+    test_batchnorm_regression.cpp
+)
+
+set_tests_properties(test_batchnorm_regression PROPERTIES
+    LABELS "timing;regression;batchnorm;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_batchnorm_regression.cpp
+++ b/tests/timing/test_batchnorm_regression.cpp
@@ -1,0 +1,278 @@
+// ============================================================================
+// tests/timing/test_batchnorm_regression.cpp
+// BatchNorm inference execution regression: shape x envelope matrix with
+// per-stage tile accounting, credit conservation, stall invariants, an exact
+// 2C+1 refusal boundary, a functional-under-credit-pressure oracle cell, and
+// performance characterization (issue #182, epic E9).
+//
+// The fold makes the all-channel-preload working set 2C+1, so each envelope is
+// sized to the case's C (min(l3,l2)/4 >= 2C+1).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+using sw::kpu::isa::MatrixID;
+
+namespace {
+
+struct BNCase {
+    const char* name;
+    Size N, C, H, W, Ti;
+};
+
+// Spread of shapes; the last has a non-tile-aligned spatial extent (49).
+constexpr BNCase kCases[] = {
+    {"1x4x8x8",    1, 4,  8,  8, 16},
+    {"2x8x4x4",    2, 8,  4,  4, 16},
+    {"1x16x8x8",   1, 16, 8,  8, 16},
+    {"1x8x7x7",    1, 8,  7,  7, 16},  // spatial 49, partial trailing tile
+};
+
+// share = min(l3,l2)/4 must be >= 2C+1.
+struct EnvelopeMode { const char* name; bool minimum; bool partitioned; };
+constexpr EnvelopeMode kEnvelopes[] = {
+    {"ample",       false, false},
+    {"minimum",     true,  false},
+    {"partitioned", false, true},
+};
+
+Size credits_for(Size C, bool minimum) {
+    const Size need = 4 * (2 * C + 1);            // share == 2C+1
+    return minimum ? need : need + 4 * (2 * C + 1);  // ample = 2x share
+}
+
+BatchNormScheduleGenerator::Config gen_config(const BNCase& c, const EnvelopeMode& e) {
+    BatchNormScheduleGenerator::Config config;
+    config.N = c.N; config.C = c.C; config.H = c.H; config.W = c.W;
+    config.Ti = c.Ti; config.Tj = c.Ti; config.training = false;
+    const Size credits = credits_for(c.C, e.minimum);
+    config.l3_buffer_count = credits;
+    config.l2_bank_count = credits;
+    config.input_base  = 0x00100000;
+    config.output_base = 0x00400000;
+    config.scale_base  = 0x00010000;
+    config.shift_base  = 0x00020000;
+    return config;
+}
+
+ConcurrentTimingExecutor::Config exec_config(const BNCase& c, const EnvelopeMode& e) {
+    ConcurrentTimingExecutor::Config config;
+    const Size credits = credits_for(c.C, e.minimum);
+    config.l3_buffer_count = credits;
+    config.l2_bank_count = credits;
+    config.partition_l3_credits = e.partitioned;
+    config.partition_l2_credits = e.partitioned;
+    config.max_cycles = 5'000'000;
+    return config;
+}
+
+struct CellResult {
+    std::string shape, envelope;
+    std::size_t out_tiles = 0;  // count_ops is size_t (MSVC C4267)
+    Cycle cycles = 0;
+    double cycles_per_tile = 0.0;
+    Cycle stalls = 0;
+    double dma_util = 0.0, str_util = 0.0;
+};
+
+std::vector<CellResult>& characterization() {
+    static std::vector<CellResult> rows;
+    return rows;
+}
+
+void run_cell(const BNCase& c, const EnvelopeMode& e) {
+    auto schedule = BatchNormScheduleGenerator(gen_config(c, e)).generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor executor(exec_config(c, e));
+    ScheduleExecutor sched_exec(executor);
+    auto result = sched_exec.execute(schedule);
+
+    INFO("shape=" << c.name << " envelope=" << e.name
+         << " cycles=" << result.total_cycles << " error=" << result.error_message);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+    REQUIRE(result.warnings.empty());  // generation envelope == execution envelope
+
+    const auto stats = executor.get_statistics();
+
+    // Per-stage tile accounting (a tile reaches L3 from LOAD and from WRITEBACK).
+    REQUIRE(stats.tiles_loaded == schedule.count_ops(ScheduleOpType::LOAD) +
+                                  schedule.count_ops(ScheduleOpType::WRITEBACK));
+    REQUIRE(stats.tiles_moved == schedule.count_ops(ScheduleOpType::MOVE));
+    REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+    REQUIRE(stats.tiles_drained == schedule.count_ops(ScheduleOpType::DRAIN));
+    REQUIRE(stats.tiles_writeback == schedule.count_ops(ScheduleOpType::WRITEBACK));
+    REQUIRE(stats.tiles_stored == schedule.count_ops(ScheduleOpType::STORE));
+
+    // A COMPUTE per output tile (the #139 fix): no DRAIN without a producer.
+    REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) ==
+            schedule.count_ops(ScheduleOpType::DRAIN));
+
+    // Credit conservation: every L3/L2 credit returned (broadcast params too).
+    REQUIRE(executor.l3_credits().available() == exec_config(c, e).l3_buffer_count);
+    REQUIRE(executor.l2_credits().available() == exec_config(c, e).l2_bank_count);
+
+    // Stall sanity.
+    const Cycle stalls = stats.dma_credit_stalls + stats.bm_tag_stalls +
+                         stats.bm_credit_stalls + stats.str_tag_stalls +
+                         stats.str_credit_stalls;
+    const auto& ec = executor.config();
+    const Cycle stall_capable =
+        static_cast<Cycle>(ec.num_dma_engines + ec.num_block_movers +
+                           ec.num_row_streamers + ec.num_col_streamers);
+    REQUIRE(result.total_cycles > 0);
+    REQUIRE(stalls < result.total_cycles * stall_capable);
+
+    const std::size_t out_tiles = schedule.count_ops(ScheduleOpType::STORE);
+    characterization().push_back(
+        {c.name, e.name, out_tiles, result.total_cycles,
+         static_cast<double>(result.total_cycles) / static_cast<double>(out_tiles),
+         stalls, stats.dma_utilization(), stats.str_utilization()});
+}
+
+} // namespace
+
+TEST_CASE("BatchNorm execution matrix: shape x envelope",
+          "[timing][regression][batchnorm][matrix]") {
+    for (const auto& c : kCases)
+        for (const auto& e : kEnvelopes)
+            DYNAMIC_SECTION(c.name << "/" << e.name) {
+                run_cell(c, e);
+            }
+}
+
+TEST_CASE("BatchNorm envelope refusal boundary is exact (2C+1)",
+          "[timing][regression][batchnorm][envelope]") {
+    BNCase c{"1x4x8x8", 1, 4, 8, 8, 16};  // 2C+1 = 9
+    auto cfg = gen_config(c, {"", true, false});
+
+    cfg.l3_buffer_count = 36; cfg.l2_bank_count = 36;  // share 9 == working set
+    REQUIRE(BatchNormScheduleGenerator(cfg).generate().valid);
+
+    cfg.l3_buffer_count = 35; cfg.l2_bank_count = 35;  // share 8 < 9
+    auto refused = BatchNormScheduleGenerator(cfg).generate();
+    REQUIRE_FALSE(refused.valid);
+    REQUIRE(refused.error_message.find("working set") != std::string::npos);
+}
+
+TEST_CASE("BatchNorm functional correctness under credit pressure",
+          "[timing][regression][batchnorm][functional]") {
+    // Values must survive the minimum partitioned envelope: every tile contends
+    // for its partition. A credit bug that reorders/drops a tile shows up as a
+    // value error against the direct 4-param oracle.
+    BatchNormGeometry g; g.N = 1; g.C = 4; g.H = 8; g.W = 8;  // spatial 64
+    const Size Ti = 16;
+    BNCase c{"1x4x8x8", 1, 4, 8, 8, 16};
+    EnvelopeMode e{"minimum-partitioned", true, true};
+
+    std::vector<float> input(g.elems()), gamma(g.C), beta(g.C), mean(g.C), var(g.C);
+    for (std::size_t i = 0; i < input.size(); ++i)
+        input[i] = -1.0f + 0.5f * static_cast<float>(i % 7);
+    for (Size ch = 0; ch < g.C; ++ch) {
+        gamma[ch] = 0.5f + 0.5f * static_cast<float>(ch % 4);
+        beta[ch]  = -1.0f + 0.75f * static_cast<float>(ch % 3);
+        mean[ch]  = 0.25f + 0.5f * static_cast<float>(ch % 5);
+        var[ch]   = 0.5f + 0.25f * static_cast<float>(ch % 4);
+    }
+    const float eps = 1e-3f;
+    const auto affine = bn_fold(gamma, beta, mean, var, eps);
+    const auto ref = batchnorm_reference(input, gamma, beta, mean, var, eps, g);
+
+    auto schedule = BatchNormScheduleGenerator(gen_config(c, e)).generate();
+    REQUIRE(schedule.valid);
+
+    ConcurrentTimingExecutor exec(exec_config(c, e));
+    const Size spatial = g.spatial();
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        if (id.matrix == MatrixID::A) {
+            const Size n = id.ti / g.C, ch = id.ti % g.C, si = id.tj;
+            const std::size_t base =
+                (static_cast<std::size_t>(n) * g.C + ch) * spatial + si * Ti;
+            exec.set_tile_payload(id, TilePayload{Ti, 1,
+                std::vector<float>(input.begin() + static_cast<std::ptrdiff_t>(base),
+                                   input.begin() + static_cast<std::ptrdiff_t>(base + Ti))});
+        } else {
+            const Size ch = id.ti;
+            const bool is_scale = (id.tj == 4);  // ParamType::SCALE
+            exec.set_tile_payload(id, TilePayload{1, 1,
+                {is_scale ? affine.scale[ch] : affine.shift[ch]}});
+        }
+    }
+
+    ScheduleExecutor sched_exec(exec);
+    sched_exec.set_functional_compute_binder(
+        [](const ScheduleOperation& compute_op)
+            -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+            ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+            spec.input_tiles = compute_op.dependency_tiles;
+            spec.operation = [](const std::vector<TilePayload>& in) {
+                const auto& x = in.at(0);
+                const float scale = in.at(1).values.at(0);
+                const float shift = in.at(2).values.at(0);
+                TilePayload out{x.rows, x.cols, std::vector<float>(x.values.size())};
+                for (std::size_t i = 0; i < x.values.size(); ++i)
+                    out.values[i] = x.values[i] * scale + shift;
+                return out;
+            };
+            return spec;
+        });
+
+    auto result = sched_exec.execute(schedule);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+
+    double max_err = 0.0;
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        const Size n = id.ti / g.C, ch = id.ti % g.C, si = id.tj;
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        const std::size_t base =
+            (static_cast<std::size_t>(n) * g.C + ch) * spatial + si * Ti;
+        for (Size i = 0; i < Ti; ++i) {
+            const double got = p.values[i];
+            REQUIRE(std::isfinite(got));
+            max_err = std::max(max_err, std::abs(got - ref[base + i]));
+        }
+    }
+    REQUIRE(max_err < 1e-3);
+}
+
+// Runs last: prints the characterization table gathered by the matrix test.
+TEST_CASE("BatchNorm characterization report",
+          "[timing][regression][batchnorm][report]") {
+    const auto& rows = characterization();
+    if (rows.empty()) { SUCCEED("matrix test did not run in this invocation"); return; }
+    std::printf("\n%-12s %-16s %8s %9s %10s %8s %6s %6s\n",
+                "shape", "envelope", "outtiles", "cycles", "cyc/tile",
+                "stalls", "dma%", "str%");
+    for (const auto& r : rows) {
+        std::printf("%-12s %-16s %8zu %9llu %10.1f %8llu %6.1f %6.1f\n",
+                    r.shape.c_str(), r.envelope.c_str(),
+                    static_cast<size_t>(r.out_tiles),
+                    static_cast<unsigned long long>(r.cycles),
+                    r.cycles_per_tile,
+                    static_cast<unsigned long long>(r.stalls),
+                    100.0 * r.dma_util, 100.0 * r.str_util);
+    }
+    SUCCEED("characterization recorded");
+}

--- a/tests/timing/test_batchnorm_regression.cpp
+++ b/tests/timing/test_batchnorm_regression.cpp
@@ -125,15 +125,16 @@ void run_cell(const BNCase& c, const EnvelopeMode& e) {
     REQUIRE(schedule.count_ops(ScheduleOpType::COMPUTE) ==
             schedule.count_ops(ScheduleOpType::DRAIN));
 
+    const auto& ec = executor.config();
+
     // Credit conservation: every L3/L2 credit returned (broadcast params too).
-    REQUIRE(executor.l3_credits().available() == exec_config(c, e).l3_buffer_count);
-    REQUIRE(executor.l2_credits().available() == exec_config(c, e).l2_bank_count);
+    REQUIRE(executor.l3_credits().available() == ec.l3_buffer_count);
+    REQUIRE(executor.l2_credits().available() == ec.l2_bank_count);
 
     // Stall sanity.
     const Cycle stalls = stats.dma_credit_stalls + stats.bm_tag_stalls +
                          stats.bm_credit_stalls + stats.str_tag_stalls +
                          stats.str_credit_stalls;
-    const auto& ec = executor.config();
     const Cycle stall_capable =
         static_cast<Cycle>(ec.num_dma_engines + ec.num_block_movers +
                            ec.num_row_streamers + ec.num_col_streamers);


### PR DESCRIPTION
## Summary

E9-T5 (BatchNorm regression & characterization, #182), the final BatchNorm task
following the merged T1–T4 (#178/#183/#184/#185). It **completes the `batchnorm`
coverage row across all five stages**.

## What landed

- **`tests/timing/test_batchnorm_regression.cpp`** — a shape × envelope execution
  matrix (4 shapes: `1x4x8x8`, `2x8x4x4`, `1x16x8x8`, and a non-tile-aligned
  `1x8x7x7` (spatial 49) × `{ample, minimum, partitioned}`, each envelope sized to
  the case's `2C+1` all-channel-preload residency). Per cell it enforces:
  - success + no livelock, generation envelope == execution envelope;
  - exact per-stage tile accounting (`loaded = LOAD + WRITEBACK`, and
    `moved/fed/drained/writeback/stored` match the schedule);
  - a **COMPUTE-per-drain** check (locks in the #139 fix);
  - L3/L2 **credit conservation** (including the broadcast scale/shift params);
  - a **stall-sanity** bound.

- **Exact `2C+1` refusal boundary** — share `min(l3,l2)/4`: 9 credits generate, 8
  refused a priori.

- **Functional-under-credit-pressure** — values survive the minimum *partitioned*
  envelope, checked elementwise against the direct 4-param oracle.

- **Characterization report** — cycles, cyc/tile, stalls, DMA/streamer utilization
  (BN inference is DMA-bound at 100%).

## Test results

| Check | Result |
|-------|--------|
| `test_batchnorm_regression` | PASS — 444 assertions, 12-cell matrix + boundary + functional + report |
| Full `timing` suite | PASS — 38/38 |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Werror` | clean |

MSVC-safe: `count_ops` results kept in `std::size_t` (the C4267 class that broke
#184's predecessor); `std::isfinite` guard on the oracle.

## Coverage manifest (#93 contract)

`batchnorm` `regression` → **done**. The **batchnorm row is now complete** across
all five stages (E9 T1–T5). `batchnorm.functional` — an M2 gate cell — is
satisfied.

Remaining M2 gate cells: `pooling.functional` (E7 #76) and
`epilogue_fused.regression` (E10-T5 #79).

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #182

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive BatchNorm regression coverage across tensor shapes and execution envelope modes.
  * Added validation for tile accounting, credit conservation, compute/drain behavior, stall limits, and envelope boundaries.
  * Added functional correctness checks under constrained execution credits.
  * Added characterization reporting for cycles, stalls, tile counts, and utilization.

* **Documentation**
  * Updated coverage tracking and changelog entries to mark BatchNorm regression work complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->