### PR TITLE
feat(pooling): window-patchify helper + oracle (E7-T2, #192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pooling window-patchify helper — E7-T2 ISA/executor closure (#192).** Pooling
+  reduces each channel over a spatial window; the M2 realization is a per-channel
+  im2col window unfold reduced by the existing `VE_REDUCE` (MAX/MEAN), so **no new
+  executor kernel**. New `include/sw/kpu/timing/schedule/pooling_window.hpp`:
+  `Pool2DGeometry` (floored `Hout/Wout`), `pool_window_channel` (materializes a
+  channel's `[Hout*Wout, Kh*Kw]` windows with the pooling-specific fill: `-inf`
+  for MAX so padding never wins, `0` + a per-row valid-count for AVG so the mean
+  excludes padding), `reduce_window_row` (the MAX/MEAN reduce), and
+  `pool2d_reference` / `global_avg_pool_reference` oracles (matching `ref_pool2d`
+  count-excludes-padding). `test_pooling_window` verifies window+reduce vs the
+  direct reference (max/avg × window/stride/pad/non-square), hand cases, the
+  padding semantics, global avg pool, and guards. Coverage: `pooling` design
+  (T1 #190) + isa_closure → done.
+
 - **Fused-epilogue regression — E10-T5 (#188); satisfies the
   `epilogue_fused.regression` M2 gate cell.** The fused epilogue (per-output-column
   bias + activation applied in the compute, so the pre-bias accumulator never

--- a/include/sw/kpu/timing/schedule/pooling_window.hpp
+++ b/include/sw/kpu/timing/schedule/pooling_window.hpp
@@ -1,0 +1,215 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/pooling_window.hpp
+// Host-side pooling window-patchify + reduce + oracle (E7-T2, #192)
+//
+// Pooling reduces each channel over a spatial window (see
+// docs/plans/e7_pooling_pattern.md) - no cross-channel mixing:
+//
+//   max-pool: y[n,c,ho,wo] = max_{kh,kw} x[n,c, ho*s+kh-p, wo*s+kw-p]
+//   avg-pool: y[n,c,ho,wo] = mean over the VALID (non-padded) taps
+//   gap:      y[n,c]       = mean_{h,w} x[n,c,h,w]   (global average)
+//
+// The M2 realization is a per-channel im2col window unfold [Hout*Wout, Kh*Kw]
+// reduced along the window axis by the existing VE_REDUCE (MAX / MEAN). This
+// header provides the window patchify (with the pooling-specific fill: -inf for
+// MAX so padding never wins, 0 + a valid-count for AVG so the mean excludes
+// padding, matching ref_pool2d) and direct pooling reference oracles. Pooling is
+// a Vector-Engine reduce, not a matmul - no new executor kernel.
+//
+// Tensors are row-major NCHW fp32: x[((n*C + c)*H + h)*W + w].
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/tile_descriptor.hpp>  // Size, TilePayload
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+enum class PoolType { MAX, AVG };
+
+/**
+ * @brief Pooling geometry (NCHW), with the conv floor for the output extents.
+ */
+struct Pool2DGeometry {
+    Size N = 1, C = 1, H = 1, W = 1;
+    Size Kh = 1, Kw = 1;
+    Size stride_h = 1, stride_w = 1;
+    Size pad_h = 0, pad_w = 0;
+
+    [[nodiscard]] Size H_out() const {
+        if (H + 2 * pad_h < Kh) return 0;
+        return (H + 2 * pad_h - Kh) / stride_h + 1;  // floor
+    }
+    [[nodiscard]] Size W_out() const {
+        if (W + 2 * pad_w < Kw) return 0;
+        return (W + 2 * pad_w - Kw) / stride_w + 1;  // floor
+    }
+    [[nodiscard]] Size out_spatial() const { return H_out() * W_out(); }
+    [[nodiscard]] Size window() const { return Kh * Kw; }
+    [[nodiscard]] std::size_t elems() const {
+        return static_cast<std::size_t>(N) * C * H * W;
+    }
+    [[nodiscard]] std::size_t out_elems() const {
+        return static_cast<std::size_t>(N) * C * H_out() * W_out();
+    }
+    [[nodiscard]] bool valid() const {
+        return N && C && H && W && Kh && Kw && stride_h && stride_w &&
+               H_out() && W_out();
+    }
+};
+
+/**
+ * @brief One channel's im2col window matrix plus per-row valid-tap counts.
+ *
+ * `rows` is [N*H_out*W_out, Kh*Kw] row-major; each row is one output position's
+ * window. Padded taps are filled with -inf (MAX) or 0 (AVG). `counts[m]` is the
+ * number of non-padded taps in row m (used by AVG to divide, so the mean
+ * excludes padding).
+ */
+struct PoolWindow {
+    std::vector<float> rows;
+    std::vector<Size> counts;
+};
+
+/**
+ * @brief Materialize channel `c`'s pooling windows from an NCHW input.
+ */
+[[nodiscard]] inline PoolWindow
+pool_window_channel(const std::vector<float>& input, const Pool2DGeometry& geom,
+                    Size n, Size c, PoolType type) {
+    if (!geom.valid()) throw std::invalid_argument("pool_window_channel: invalid geometry");
+    if (input.size() != geom.elems())
+        throw std::invalid_argument("pool_window_channel: input size does not match geometry");
+    if (n >= geom.N || c >= geom.C)
+        throw std::invalid_argument("pool_window_channel: n/c out of range");
+
+    const Size Hout = geom.H_out(), Wout = geom.W_out(), K = geom.window();
+    const Size M = Hout * Wout;
+    const float pad_fill = (type == PoolType::MAX)
+        ? -std::numeric_limits<float>::infinity() : 0.0f;
+
+    PoolWindow out;
+    out.rows.assign(static_cast<std::size_t>(M) * K, pad_fill);
+    out.counts.assign(M, 0);
+
+    const std::size_t plane = (static_cast<std::size_t>(n) * geom.C + c) *
+                              geom.H * geom.W;
+    for (Size ho = 0; ho < Hout; ++ho)
+        for (Size wo = 0; wo < Wout; ++wo) {
+            const Size m = ho * Wout + wo;
+            Size valid = 0;
+            for (Size kh = 0; kh < geom.Kh; ++kh) {
+                const long ih = static_cast<long>(ho * geom.stride_h + kh) -
+                                static_cast<long>(geom.pad_h);
+                const bool h_in = ih >= 0 && ih < static_cast<long>(geom.H);
+                for (Size kw = 0; kw < geom.Kw; ++kw) {
+                    const long iw = static_cast<long>(wo * geom.stride_w + kw) -
+                                    static_cast<long>(geom.pad_w);
+                    const bool w_in = iw >= 0 && iw < static_cast<long>(geom.W);
+                    const Size k = kh * geom.Kw + kw;
+                    if (h_in && w_in) {
+                        out.rows[static_cast<std::size_t>(m) * K + k] =
+                            input[plane + static_cast<std::size_t>(ih) * geom.W +
+                                  static_cast<std::size_t>(iw)];
+                        ++valid;
+                    }
+                }
+            }
+            out.counts[m] = valid;
+        }
+    return out;
+}
+
+/**
+ * @brief Reduce one window row to its pooled value (the VE_REDUCE the executor
+ *        applies): MAX -> max element, AVG -> sum / valid-count.
+ */
+[[nodiscard]] inline float
+reduce_window_row(const float* row, Size window, Size valid_count, PoolType type) {
+    if (type == PoolType::MAX) {
+        float m = -std::numeric_limits<float>::infinity();
+        for (Size k = 0; k < window; ++k) m = std::max(m, row[k]);
+        return m;
+    }
+    float sum = 0.0f;
+    for (Size k = 0; k < window; ++k) sum += row[k];  // padded taps are 0
+    return valid_count > 0 ? sum / static_cast<float>(valid_count) : 0.0f;
+}
+
+/**
+ * @brief Direct pooling reference (the functional oracle), NCHW output
+ *        [N, C, H_out, W_out]. AVG excludes padding (matches ref_pool2d).
+ */
+[[nodiscard]] inline std::vector<float>
+pool2d_reference(const std::vector<float>& input, const Pool2DGeometry& geom,
+                 PoolType type) {
+    if (!geom.valid()) throw std::invalid_argument("pool2d_reference: invalid geometry");
+    if (input.size() != geom.elems())
+        throw std::invalid_argument("pool2d_reference: input size does not match geometry");
+
+    const Size Hout = geom.H_out(), Wout = geom.W_out();
+    std::vector<float> y(geom.out_elems());
+    for (Size n = 0; n < geom.N; ++n)
+        for (Size c = 0; c < geom.C; ++c) {
+            const std::size_t plane = (static_cast<std::size_t>(n) * geom.C + c) *
+                                      geom.H * geom.W;
+            for (Size ho = 0; ho < Hout; ++ho)
+                for (Size wo = 0; wo < Wout; ++wo) {
+                    float acc = (type == PoolType::MAX)
+                        ? -std::numeric_limits<float>::infinity() : 0.0f;
+                    Size cnt = 0;
+                    for (Size kh = 0; kh < geom.Kh; ++kh) {
+                        const long ih = static_cast<long>(ho * geom.stride_h + kh) -
+                                        static_cast<long>(geom.pad_h);
+                        if (ih < 0 || ih >= static_cast<long>(geom.H)) continue;
+                        for (Size kw = 0; kw < geom.Kw; ++kw) {
+                            const long iw = static_cast<long>(wo * geom.stride_w + kw) -
+                                            static_cast<long>(geom.pad_w);
+                            if (iw < 0 || iw >= static_cast<long>(geom.W)) continue;
+                            const float v = input[plane + static_cast<std::size_t>(ih) * geom.W +
+                                                  static_cast<std::size_t>(iw)];
+                            if (type == PoolType::MAX) acc = std::max(acc, v);
+                            else                        acc += v;
+                            ++cnt;
+                        }
+                    }
+                    if (type == PoolType::AVG && cnt > 0) acc /= static_cast<float>(cnt);
+                    y[((static_cast<std::size_t>(n) * geom.C + c) * Hout + ho) * Wout + wo] = acc;
+                }
+        }
+    return y;
+}
+
+/**
+ * @brief Global average pool: mean over the whole H*W plane per channel.
+ *        Output is [N, C] row-major (the [N,C,1,1] tensor flattened).
+ */
+[[nodiscard]] inline std::vector<float>
+global_avg_pool_reference(const std::vector<float>& input, const Pool2DGeometry& geom) {
+    if (!geom.valid()) throw std::invalid_argument("global_avg_pool_reference: invalid geometry");
+    if (input.size() != geom.elems())
+        throw std::invalid_argument("global_avg_pool_reference: input size does not match geometry");
+
+    const std::size_t plane_sz = static_cast<std::size_t>(geom.H) * geom.W;
+    std::vector<float> y(static_cast<std::size_t>(geom.N) * geom.C);
+    for (Size n = 0; n < geom.N; ++n)
+        for (Size c = 0; c < geom.C; ++c) {
+            const std::size_t base = (static_cast<std::size_t>(n) * geom.C + c) * plane_sz;
+            float sum = 0.0f;
+            for (std::size_t i = 0; i < plane_sz; ++i) sum += input[base + i];
+            y[static_cast<std::size_t>(n) * geom.C + c] =
+                sum / static_cast<float>(plane_sz);
+        }
+    return y;
+}
+
+} // namespace sw::kpu::timing::schedule

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -95,13 +95,13 @@
         "cv"
       ],
       "stages": {
-        "design": "missing",
-        "isa_closure": "partial",
+        "design": "done",
+        "isa_closure": "done",
         "generator": "partial",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "Kernel-level streaming program with VE_REDUCE markers (#142); VE semantics and CSP schedule missing."
+      "notes": "Design (T1 #190): max/avg pooling = per-channel im2col window unfold [Hout*Wout, Kh*Kw] reduced by existing VE_REDUCE (MAX/MEAN); global avg pool = E3 full-spatial per-channel reduce; reuses E6 patchify + E3 reduce, no new kernel; docs/plans/e7_pooling_pattern.md. ISA/executor closure (T2 #192): host-side pooling_window.hpp (Pool2DGeometry, pool_window_channel with -inf fill for MAX / 0+valid-count for AVG, reduce_window_row, pool2d_reference + global_avg_pool_reference oracles matching ref_pool2d count-excludes-padding); confirmed VE_REDUCE {MAX,MEAN} + functional/reduction value path cover pooling, no new executor kernel. Remaining: generator (T3 #193), functional (T4 #194), regression (T5 #195). Direct/halo P2 is an E7 follow-on off the M2 path."
     },
     {
       "name": "softmax",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -222,6 +222,16 @@ set_tests_properties(test_epilogue_fused_regression PROPERTIES
     LABELS "timing;regression;epilogue;v0.9"
 )
 
+# Pooling window-patchify helper unit tests (issue #192, epic E7): geometry,
+# window unfold + reduce vs a direct reference, padding semantics, global avg
+kpu_add_component_test(test_pooling_window "timing"
+    test_pooling_window.cpp
+)
+
+set_tests_properties(test_pooling_window PROPERTIES
+    LABELS "timing;functional;pooling;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_pooling_window.cpp
+++ b/tests/timing/test_pooling_window.cpp
@@ -1,0 +1,174 @@
+// ============================================================================
+// tests/timing/test_pooling_window.cpp
+// Unit tests for the pooling window-patchify helper (E7-T2, #192).
+//
+// Verifies (1) geometry, (2) that the per-channel window unfold + reduce
+// reproduces the direct pooling reference for MAX and AVG, (3) hand-computed
+// tiny cases, (4) padding semantics (-inf fill for MAX, count-excludes-padding
+// for AVG), (5) global average pool, and (6) the public guards.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+std::vector<float> fill(std::size_t n, int period, float base, float step) {
+    std::vector<float> v(n);
+    for (std::size_t i = 0; i < n; ++i)
+        v[i] = base + step * static_cast<float>(i % static_cast<std::size_t>(period));
+    return v;
+}
+
+// Reconstruct the pooled output via window unfold + reduce, compare to the
+// direct reference; return the max abs error.
+double check_via_window(const Pool2DGeometry& g, PoolType type) {
+    auto input = fill(g.elems(), 7, -1.5f, 0.5f);
+    const auto ref = pool2d_reference(input, g, type);
+    const Size Hout = g.H_out(), Wout = g.W_out(), K = g.window(), M = Hout * Wout;
+
+    double max_err = 0.0;
+    for (Size n = 0; n < g.N; ++n)
+        for (Size c = 0; c < g.C; ++c) {
+            const auto win = pool_window_channel(input, g, n, c, type);
+            REQUIRE(win.rows.size() == static_cast<std::size_t>(M) * K);
+            REQUIRE(win.counts.size() == M);
+            for (Size m = 0; m < M; ++m) {
+                const float got = reduce_window_row(
+                    &win.rows[static_cast<std::size_t>(m) * K], K, win.counts[m], type);
+                const float want =
+                    ref[((static_cast<std::size_t>(n) * g.C + c) * Hout) * Wout + m];
+                max_err = std::max(max_err, static_cast<double>(std::abs(got - want)));
+            }
+        }
+    return max_err;
+}
+
+Pool2DGeometry base() {
+    Pool2DGeometry g;
+    g.N = 2; g.C = 3; g.H = 8; g.W = 8; g.Kh = 2; g.Kw = 2; g.stride_h = g.stride_w = 2;
+    return g;
+}
+
+} // namespace
+
+TEST_CASE("pooling geometry: floored output extents", "[pooling][window]") {
+    Pool2DGeometry g; g.H = 7; g.W = 7; g.Kh = 3; g.Kw = 3; g.stride_h = g.stride_w = 2;
+    REQUIRE(g.H_out() == 3);  // floor((7-3)/2)+1
+    REQUIRE(g.W_out() == 3);
+    g.pad_h = g.pad_w = 1;
+    REQUIRE(g.H_out() == 4);  // floor((7+2-3)/2)+1
+    REQUIRE(g.window() == 9);
+    REQUIRE(g.valid());
+    g.Kh = 20; g.pad_h = 0;
+    REQUIRE(g.H_out() == 0);
+    REQUIRE_FALSE(g.valid());
+}
+
+TEST_CASE("pooling window+reduce matches direct reference", "[pooling][window]") {
+    SECTION("2x2 max, stride 2") { REQUIRE(check_via_window(base(), PoolType::MAX) < 1e-6); }
+    SECTION("2x2 avg, stride 2") { REQUIRE(check_via_window(base(), PoolType::AVG) < 1e-6); }
+    SECTION("3x3 max, stride 2, pad 1") {
+        auto g = base(); g.Kh = g.Kw = 3; g.pad_h = g.pad_w = 1;
+        REQUIRE(check_via_window(g, PoolType::MAX) < 1e-6);
+    }
+    SECTION("3x3 avg, stride 2, pad 1 (count excludes padding)") {
+        auto g = base(); g.Kh = g.Kw = 3; g.pad_h = g.pad_w = 1;
+        REQUIRE(check_via_window(g, PoolType::AVG) < 1e-6);
+    }
+    SECTION("non-square window 2x3, stride 1") {
+        auto g = base(); g.Kh = 2; g.Kw = 3; g.stride_h = g.stride_w = 1;
+        REQUIRE(check_via_window(g, PoolType::MAX) < 1e-6);
+    }
+}
+
+TEST_CASE("pooling hand-computed tiny cases", "[pooling][window]") {
+    // 1x1x2x2 input [[1,2],[3,4]], 2x2 window stride 2 -> single output.
+    Pool2DGeometry g; g.N = 1; g.C = 1; g.H = 2; g.W = 2; g.Kh = 2; g.Kw = 2;
+    g.stride_h = g.stride_w = 2;
+    std::vector<float> x = {1, 2, 3, 4};
+
+    REQUIRE(pool2d_reference(x, g, PoolType::MAX) == std::vector<float>{4.0f});
+    REQUIRE(pool2d_reference(x, g, PoolType::AVG) == std::vector<float>{2.5f});
+
+    auto win = pool_window_channel(x, g, 0, 0, PoolType::MAX);
+    REQUIRE(win.counts == std::vector<Size>{4});
+    REQUIRE(reduce_window_row(win.rows.data(), 4, win.counts[0], PoolType::MAX) == 4.0f);
+}
+
+TEST_CASE("pooling padding: -inf for max, excluded count for avg", "[pooling][window]") {
+    // 1x1x3x3 input [1..9], 2x2 window, pad 1, stride 1. The top-left output
+    // (ho=0,wo=0) sees ih,iw in {-1,0} -> only x[0,0]=1 is valid; the other 3
+    // taps are padding.
+    Pool2DGeometry g; g.N = 1; g.C = 1; g.H = 3; g.W = 3; g.Kh = 2; g.Kw = 2;
+    g.pad_h = g.pad_w = 1; g.stride_h = g.stride_w = 1;
+    std::vector<float> x = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    auto win = pool_window_channel(x, g, 0, 0, PoolType::MAX);
+    REQUIRE(win.counts[0] == 1);  // corner sees a single valid tap
+    Size neg_inf_taps = 0;
+    for (Size k = 0; k < g.window(); ++k)
+        if (win.rows[k] == -std::numeric_limits<float>::infinity()) ++neg_inf_taps;
+    REQUIRE(neg_inf_taps == g.window() - win.counts[0]);  // 3 padded taps are -inf
+    REQUIRE(reduce_window_row(win.rows.data(), g.window(), win.counts[0], PoolType::MAX)
+            == 1.0f);  // max over {1, -inf, -inf, -inf} = 1
+
+    // AVG at the corner: mean over the valid taps only (count excludes padding).
+    auto wavg = pool_window_channel(x, g, 0, 0, PoolType::AVG);
+    const float avg0 = reduce_window_row(wavg.rows.data(), g.window(), wavg.counts[0],
+                                         PoolType::AVG);
+    REQUIRE_THAT(avg0, Catch::Matchers::WithinAbs(1.0f, 1e-6));  // only x[0,0]=1 valid
+    // count-includes-padding would give 1/4; excludes-padding gives 1/1.
+}
+
+TEST_CASE("global average pool matches reference", "[pooling][window]") {
+    Pool2DGeometry g; g.N = 2; g.C = 4; g.H = 4; g.W = 4;
+    auto input = fill(g.elems(), 5, 0.0f, 1.0f);
+    auto gap = global_avg_pool_reference(input, g);
+    REQUIRE(gap.size() == static_cast<std::size_t>(g.N) * g.C);
+    // Independently compute channel means.
+    const std::size_t plane = static_cast<std::size_t>(g.H) * g.W;
+    for (Size n = 0; n < g.N; ++n)
+        for (Size c = 0; c < g.C; ++c) {
+            const std::size_t b = (static_cast<std::size_t>(n) * g.C + c) * plane;
+            float s = 0.0f;
+            for (std::size_t i = 0; i < plane; ++i) s += input[b + i];
+            REQUIRE_THAT(gap[static_cast<std::size_t>(n) * g.C + c],
+                Catch::Matchers::WithinAbs(s / static_cast<float>(plane), 1e-5));
+        }
+}
+
+TEST_CASE("pooling public guards reject malformed input", "[pooling][window]") {
+    Pool2DGeometry g = base();
+    auto input = fill(g.elems(), 5, 0.0f, 1.0f);
+    SECTION("invalid geometry") {
+        Pool2DGeometry bad = g; bad.Kh = 99; bad.pad_h = 0;
+        REQUIRE_FALSE(bad.valid());
+        REQUIRE_THROWS_AS(pool2d_reference(std::vector<float>(bad.elems()), bad, PoolType::MAX),
+                          std::invalid_argument);
+    }
+    SECTION("input size mismatch") {
+        REQUIRE_THROWS_AS(pool2d_reference(std::vector<float>(input.size() + 1), g, PoolType::AVG),
+                          std::invalid_argument);
+        REQUIRE_THROWS_AS(pool_window_channel(std::vector<float>(input.size() - 1), g, 0, 0, PoolType::MAX),
+                          std::invalid_argument);
+    }
+    SECTION("channel/batch out of range") {
+        REQUIRE_THROWS_AS(pool_window_channel(input, g, g.N, 0, PoolType::MAX),
+                          std::invalid_argument);
+        REQUIRE_THROWS_AS(pool_window_channel(input, g, 0, g.C, PoolType::MAX),
+                          std::invalid_argument);
+    }
+}


### PR DESCRIPTION
## Summary

E7-T2 (pooling ISA/executor capability closure, #192), following the merged T1
design (#190). It adds the host-side capability pooling needs and confirms the
value path requires **no new executor kernel** (pooling is a Vector-Engine
reduce, reusing the existing `VE_REDUCE`).

## What landed

- **`include/sw/kpu/timing/schedule/pooling_window.hpp`** (new)
  - `Pool2DGeometry` — floored `Hout/Wout`, `window() = Kh*Kw`.
  - `pool_window_channel` — materializes a channel's `[Hout*Wout, Kh*Kw]` im2col
    windows, with the **pooling-specific fill**: `-inf` for MAX (so padding never
    wins the max) or `0` + a per-row **valid-count** for AVG (so the mean excludes
    padding — matching `ref_pool2d`).
  - `reduce_window_row` — the MAX (`max`) / MEAN (`sum / valid-count`) reduce the
    executor applies via `VE_REDUCE`.
  - `pool2d_reference` / `global_avg_pool_reference` — direct host oracles.

- **`test_pooling_window.cpp`** — geometry, window+reduce vs the direct reference
  (max/avg × window/stride/pad/non-square), hand-computed cases, the padding
  semantics (`-inf` fill; corner-sees-one-tap count-excludes-padding), global
  average pool, and guards.

## Test results

| Check | Result |
|-------|--------|
| `test_pooling_window` | PASS — 95 assertions, 6 cases |
| Full `timing` suite | PASS — 40/40 |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Wconversion -Wshadow -Werror` | clean |

## Coverage manifest (#93 contract)

`pooling` `design` (T1 #190) + `isa_closure` → **done**. Remaining: `generator`
(T3 #193), `functional` (T4 #194), `regression` (T5 #195).

## Note

Two `Size` types coexist in the tree (`sw::kpu::Size` = uint64_t vs the timing
`Size` = uint32); the header and test use the **timing** `Size` consistently.

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #192

Generated with [Claude Code](https://claude.com/claude-code)