### PR TITLE
feat(pooling): envelope-aware schedule generator (E7-T3, #193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pooling schedule generator — E7-T3 (#193).** `PoolingScheduleGenerator` emits
+  an **executable reduce COMPUTE per output tile** before each drain, so — unlike
+  the pre-existing norm/conv generators — pooling never has the #139
+  DRAIN-without-COMPUTE defect. Two modes: `WINDOWED` (per channel, per Ti-block
+  of output positions, the `[Ti, Kh*Kw]` window block is reduced per row — MAX or
+  MEAN) and `GLOBAL_AVG` (per channel, the whole `H*W` plane streamed and reduced
+  to one value). The pool op rides in Config/metadata; the reduce is the existing
+  `VE_REDUCE` bound at execution, so movement is pool-op-agnostic. New
+  `test_pooling_execution` runs the generated schedules through the executor
+  (timing-only) across windowed max/avg, batch, non-tile-aligned, and global-avg
+  cases, asserting a COMPUTE per output tile, livelock-free completion, and the
+  envelope-refusal boundary. Coverage: `pooling` generator → done.
+
 - **Pooling window-patchify helper — E7-T2 ISA/executor closure (#192).** Pooling
   reduces each channel over a spatial window; the M2 realization is a per-channel
   im2col window unfold reduced by the existing `VE_REDUCE` (MAX/MEAN), so **no new

--- a/include/sw/kpu/timing/schedule/pooling_schedule_generator.hpp
+++ b/include/sw/kpu/timing/schedule/pooling_schedule_generator.hpp
@@ -1,0 +1,196 @@
+// ============================================================================
+// include/sw/kpu/timing/schedule/pooling_schedule_generator.hpp
+// Pooling schedule generator for CSP-style timing model (E7-T3, #193)
+//
+// Pooling reduces each channel over a spatial window (see
+// docs/plans/e7_pooling_pattern.md). The generator emits an EXECUTABLE schedule
+// from the start (no #139): per output tile it streams the window rows and emits
+// a reduce COMPUTE before the drain.
+//
+//   WINDOWED  (max/avg): per channel, per Ti-block of output positions, the
+//             input is the [Ti, Kh*Kw] window block; the COMPUTE reduces each
+//             row along the window axis (MAX / MEAN) to one output per position.
+//   GLOBAL_AVG:          per channel, the whole H*W plane is streamed and a
+//             single COMPUTE reduces it to one value (mean).
+//
+// The pool op (MAX/MEAN) rides in Config/metadata; the reduce itself is the
+// existing VE_REDUCE bound at execution (no new executor kernel). Movement is
+// pool-op-agnostic.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/schedule/schedule_generator_interface.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>  // Pool2DGeometry, PoolType
+
+#include <sstream>
+#include <vector>
+
+namespace sw::kpu::timing::schedule {
+
+class PoolingScheduleGenerator : public IScheduleGenerator {
+public:
+    enum class Mode { WINDOWED, GLOBAL_AVG };
+
+    struct Config {
+        Pool2DGeometry geom;             ///< N/C/H/W/Kh/Kw/stride/pad
+        PoolType pool_type = PoolType::MAX;
+        Mode mode = Mode::WINDOWED;
+        Size Ti = 16;                    ///< output positions per tile
+        Size element_size = 4;
+
+        // Resource envelope (issue #90).
+        Size l3_buffer_count = 32;
+        Size l2_bank_count = 64;
+
+        Address input_base = 0;
+        Address output_base = 0;
+
+        /// Output positions per channel (N*Hout*Wout for windowed; N for gap).
+        [[nodiscard]] Size out_positions() const {
+            return mode == Mode::GLOBAL_AVG ? geom.N : geom.N * geom.out_spatial();
+        }
+        [[nodiscard]] Size out_tiles() const {
+            return (out_positions() + Ti - 1) / Ti;
+        }
+        /// Plane tiles per channel for GLOBAL_AVG (H*W streamed in Ti-chunks).
+        [[nodiscard]] Size plane_tiles() const {
+            const Size plane = geom.H * geom.W;
+            return (plane + Ti - 1) / Ti;
+        }
+        [[nodiscard]] Size max_burst_tiles() const {
+            return per_matrix_burst_share(l3_buffer_count, l2_bank_count);
+        }
+        /// Windowed streams one window tile + one output; gap streams one plane
+        /// tile + the running output.
+        [[nodiscard]] Size required_working_set() const { return 3; }
+    };
+
+    explicit PoolingScheduleGenerator(const Config& config) : config_(config) {}
+
+    ScheduleResult generate() override {
+        ScheduleResult result;
+
+        if (config_.required_working_set() > config_.max_burst_tiles()) {
+            result.valid = false;
+            result.error_message =
+                "pooling schedule requires a working set of " +
+                std::to_string(config_.required_working_set()) +
+                " tiles but the resource envelope share is " +
+                std::to_string(config_.max_burst_tiles()) +
+                "; enlarge l3_buffer_count/l2_bank_count";
+            return result;
+        }
+        if (!config_.geom.valid()) {
+            result.valid = false;
+            result.error_message = "pooling geometry invalid (check sizes/padding)";
+            return result;
+        }
+
+        if (config_.mode == Mode::GLOBAL_AVG) generate_global_avg(result);
+        else                                  generate_windowed(result);
+
+        result.metadata.name = generate_name();
+        result.metadata.generator = name();
+        result.metadata.M = config_.out_positions();
+        result.metadata.N = config_.geom.C;
+        result.metadata.K = (config_.mode == Mode::GLOBAL_AVG)
+                                ? config_.geom.H * config_.geom.W : config_.geom.window();
+        result.metadata.Ti = config_.Ti;
+        result.metadata.strategy = strategy_name();
+        result.metadata.l3_buffer_count = config_.l3_buffer_count;
+        result.metadata.l2_bank_count = config_.l2_bank_count;
+        result.valid = true;
+        return result;
+    }
+
+    [[nodiscard]] std::string name() const override { return "PoolingScheduleGenerator"; }
+    [[nodiscard]] std::string description() const override {
+        std::ostringstream ss;
+        ss << strategy_name() << " [" << config_.geom.N << "x" << config_.geom.C
+           << "x" << config_.geom.H << "x" << config_.geom.W << "]";
+        return ss.str();
+    }
+    [[nodiscard]] const Config& config() const { return config_; }
+
+private:
+    Config config_;
+
+    // Windowed pooling: per channel, per output-position tile, reduce the
+    // [Ti, Kh*Kw] window block along the window axis.
+    void generate_windowed(ScheduleResult& result) {
+        const Size out_tiles = config_.out_tiles();
+        for (Size c = 0; c < config_.geom.C; ++c) {
+            for (Size ti = 0; ti < out_tiles; ++ti) {
+                auto in = make_tile(isa::MatrixID::A, c, ti, config_.geom.window());
+                result.operations.push_back(ScheduleOperation::load(in));
+                result.operations.push_back(ScheduleOperation::move(in));
+                result.operations.push_back(ScheduleOperation::feed(in));
+
+                auto out = make_tile(isa::MatrixID::C, c, ti, 1);
+                result.operations.push_back(ScheduleOperation::compute(out, {in.tile_id}));
+                result.operations.push_back(ScheduleOperation::drain(out));
+                result.operations.push_back(ScheduleOperation::writeback(out));
+                result.operations.push_back(ScheduleOperation::store(out));
+            }
+        }
+    }
+
+    // Global average pool: per channel, stream the whole H*W plane and reduce
+    // it to one value. The COMPUTE depends on every plane tile.
+    void generate_global_avg(ScheduleResult& result) {
+        const Size plane_tiles = config_.plane_tiles();
+        for (Size n = 0; n < config_.geom.N; ++n) {
+            for (Size c = 0; c < config_.geom.C; ++c) {
+                std::vector<TileID> deps;
+                deps.reserve(plane_tiles);
+                for (Size pt = 0; pt < plane_tiles; ++pt) {
+                    auto in = make_tile(isa::MatrixID::A, n * config_.geom.C + c, pt,
+                                        config_.Ti);
+                    result.operations.push_back(ScheduleOperation::load(in));
+                    result.operations.push_back(ScheduleOperation::move(in));
+                    result.operations.push_back(ScheduleOperation::feed(in));
+                    deps.push_back(in.tile_id);
+                }
+                auto out = make_tile(isa::MatrixID::C, n * config_.geom.C + c, 0, 1);
+                result.operations.push_back(ScheduleOperation::compute(out, std::move(deps)));
+                result.operations.push_back(ScheduleOperation::drain(out));
+                result.operations.push_back(ScheduleOperation::writeback(out));
+                result.operations.push_back(ScheduleOperation::store(out));
+            }
+        }
+    }
+
+    TileDescriptor make_tile(isa::MatrixID matrix, Size ti, Size tj, Size width) const {
+        TileDescriptor tile;
+        tile.tile_id.matrix = matrix;
+        tile.tile_id.ti = ti;
+        tile.tile_id.tj = tj;
+        tile.tile_id.tk = 0;
+        tile.height = config_.Ti;
+        tile.width = width;
+        tile.element_size = config_.element_size;
+        tile.size_bytes = config_.Ti * width * config_.element_size;
+        tile.dram_address = (matrix == isa::MatrixID::A ? config_.input_base
+                                                        : config_.output_base) +
+                            (ti * 0x10000 + tj * 0x100) * config_.element_size;
+        return tile;
+    }
+
+    std::string generate_name() const {
+        std::ostringstream ss;
+        ss << "pooling_" << strategy_name() << "_" << config_.geom.N << "x"
+           << config_.geom.C << "x" << config_.geom.H << "x" << config_.geom.W;
+        return ss.str();
+    }
+
+    const char* strategy_name() const {
+        if (config_.mode == Mode::GLOBAL_AVG) return "global_avg_pool";
+        return config_.pool_type == PoolType::MAX ? "max_pool" : "avg_pool";
+    }
+};
+
+} // namespace sw::kpu::timing::schedule

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -97,11 +97,11 @@
       "stages": {
         "design": "done",
         "isa_closure": "done",
-        "generator": "partial",
+        "generator": "done",
         "functional": "missing",
         "regression": "missing"
       },
-      "notes": "Design (T1 #190): max/avg pooling = per-channel im2col window unfold [Hout*Wout, Kh*Kw] reduced by existing VE_REDUCE (MAX/MEAN); global avg pool = E3 full-spatial per-channel reduce; reuses E6 patchify + E3 reduce, no new kernel; docs/plans/e7_pooling_pattern.md. ISA/executor closure (T2 #192): host-side pooling_window.hpp (Pool2DGeometry, pool_window_channel with -inf fill for MAX / 0+valid-count for AVG, reduce_window_row, pool2d_reference + global_avg_pool_reference oracles matching ref_pool2d count-excludes-padding); confirmed VE_REDUCE {MAX,MEAN} + functional/reduction value path cover pooling, no new executor kernel. Remaining: generator (T3 #193), functional (T4 #194), regression (T5 #195). Direct/halo P2 is an E7 follow-on off the M2 path."
+      "notes": "Design (T1 #190): max/avg pooling = per-channel im2col window unfold [Hout*Wout, Kh*Kw] reduced by existing VE_REDUCE (MAX/MEAN); global avg pool = E3 full-spatial per-channel reduce; reuses E6 patchify + E3 reduce, no new kernel; docs/plans/e7_pooling_pattern.md. ISA/executor closure (T2 #192): host-side pooling_window.hpp (Pool2DGeometry, pool_window_channel -inf/0+count fill, reduce_window_row, pool2d_reference + global_avg_pool_reference oracles). Generator (T3 #193): PoolingScheduleGenerator emits an executable reduce COMPUTE per output tile before each drain (WINDOWED: [Ti, Kh*Kw] window block reduced per row; GLOBAL_AVG: whole H*W plane reduced per channel) - executable from the start, no #139; envelope stamping. Remaining: functional (T4 #194), regression (T5 #195). Direct/halo P2 is an E7 follow-on off the M2 path."
     },
     {
       "name": "softmax",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -232,6 +232,17 @@ set_tests_properties(test_pooling_window PROPERTIES
     LABELS "timing;functional;pooling;v0.9"
 )
 
+# Pooling schedule execution regression (issue #193, epic E7): the generator is
+# executable from the start (reduce COMPUTE per output tile), so generated
+# schedules execute livelock-free through the executor
+kpu_add_component_test(test_pooling_execution "timing"
+    test_pooling_execution.cpp
+)
+
+set_tests_properties(test_pooling_execution PROPERTIES
+    LABELS "timing;pooling;executor;regression;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_pooling_execution.cpp
+++ b/tests/timing/test_pooling_execution.cpp
@@ -1,0 +1,104 @@
+// ============================================================================
+// tests/timing/test_pooling_execution.cpp
+// End-to-end execution regression for PoolingScheduleGenerator (E7-T3, #193).
+//
+// The pooling generator is executable from the start: every output tile has a
+// reduce COMPUTE before its drain (so no DRAIN lacks a producer - it never has
+// the #139 defect). This EXECUTES the generated schedules (timing-only) and
+// asserts a COMPUTE per output tile and livelock-free completion, for windowed
+// max/avg pooling and global average pooling. Value correctness is T4 (#194).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/pooling_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+namespace {
+
+ConcurrentTimingExecutor::Config exec_config() {
+    ConcurrentTimingExecutor::Config config;
+    config.l3_buffer_count = 32;
+    config.l2_bank_count = 64;
+    config.max_cycles = 1'000'000;
+    config.enable_livelock_detection = true;
+    config.livelock_threshold = 20000;
+    return config;
+}
+
+PoolingScheduleGenerator::Config windowed(Size N, Size C, Size H, Size W,
+                                          Size Kh, Size Kw, Size stride, Size pad,
+                                          PoolType type) {
+    PoolingScheduleGenerator::Config cfg;
+    cfg.geom.N = N; cfg.geom.C = C; cfg.geom.H = H; cfg.geom.W = W;
+    cfg.geom.Kh = Kh; cfg.geom.Kw = Kw;
+    cfg.geom.stride_h = cfg.geom.stride_w = stride;
+    cfg.geom.pad_h = cfg.geom.pad_w = pad;
+    cfg.pool_type = type;
+    cfg.mode = PoolingScheduleGenerator::Mode::WINDOWED;
+    cfg.Ti = 16;
+    cfg.input_base = 0x100000; cfg.output_base = 0x400000;
+    return cfg;
+}
+
+void run_and_check(const PoolingScheduleGenerator::Config& cfg, const char* label) {
+    DYNAMIC_SECTION(label) {
+        auto schedule = PoolingScheduleGenerator(cfg).generate();
+        REQUIRE(schedule.valid);
+
+        // Executable-from-the-start: a COMPUTE per output tile.
+        const auto n_compute = schedule.count_ops(ScheduleOpType::COMPUTE);
+        const auto n_drain   = schedule.count_ops(ScheduleOpType::DRAIN);
+        const auto n_store   = schedule.count_ops(ScheduleOpType::STORE);
+        REQUIRE(n_compute > 0);
+        REQUIRE(n_compute == n_drain);
+        REQUIRE(n_compute == n_store);
+
+        ConcurrentTimingExecutor executor(exec_config());
+        ScheduleExecutor sched_exec(executor);
+        auto result = sched_exec.execute(schedule);
+        INFO("cycles=" << result.total_cycles << " error=" << result.error_message);
+        REQUIRE(result.success);
+        REQUIRE_FALSE(result.livelock_detected);
+        REQUIRE(result.total_cycles > 0);
+
+        auto stats = executor.get_statistics();
+        REQUIRE(stats.tiles_drained == n_drain);
+        REQUIRE(stats.tiles_fed == schedule.count_ops(ScheduleOpType::FEED));
+    }
+}
+
+} // namespace
+
+TEST_CASE("Pooling generator emits an executable COMPUTE per output tile "
+          "and executes livelock-free", "[timing][pooling][generator][executor]") {
+    run_and_check(windowed(1, 8, 8, 8, 2, 2, 2, 0, PoolType::MAX), "max_2x2_s2");
+    run_and_check(windowed(1, 8, 8, 8, 2, 2, 2, 0, PoolType::AVG), "avg_2x2_s2");
+    run_and_check(windowed(1, 16, 16, 16, 3, 3, 2, 1, PoolType::MAX), "max_3x3_s2_p1");
+    run_and_check(windowed(2, 8, 8, 8, 2, 2, 2, 0, PoolType::MAX), "max_batch2");
+    run_and_check(windowed(1, 8, 7, 7, 3, 3, 2, 1, PoolType::MAX), "max_nonaligned");
+
+    PoolingScheduleGenerator::Config gap;
+    gap.geom.N = 1; gap.geom.C = 16; gap.geom.H = 8; gap.geom.W = 8;
+    gap.mode = PoolingScheduleGenerator::Mode::GLOBAL_AVG;
+    gap.Ti = 16; gap.input_base = 0x100000; gap.output_base = 0x400000;
+    run_and_check(gap, "global_avg_pool");
+}
+
+TEST_CASE("Pooling envelope refusal boundary", "[timing][pooling][envelope]") {
+    // working set 3; share = min(l3,l2)/4: 12 -> 3 generates, 11 -> 2 refused.
+    auto cfg = windowed(1, 8, 8, 8, 2, 2, 2, 0, PoolType::MAX);
+    cfg.l3_buffer_count = 12; cfg.l2_bank_count = 12;
+    REQUIRE(PoolingScheduleGenerator(cfg).generate().valid);
+    cfg.l3_buffer_count = 11; cfg.l2_bank_count = 11;
+    auto refused = PoolingScheduleGenerator(cfg).generate();
+    REQUIRE_FALSE(refused.valid);
+    REQUIRE(refused.error_message.find("working set") != std::string::npos);
+}


### PR DESCRIPTION
## Summary

E7-T3 (pooling schedule generator, #193), following merged T1/T2 (#190/#196).
`PoolingScheduleGenerator` emits an **executable reduce COMPUTE per output tile**,
so — unlike the pre-existing norm/conv generators — pooling **never has the #139**
DRAIN-without-COMPUTE defect.

## What changed

- **`PoolingScheduleGenerator`** with two modes:
  - **`WINDOWED`** (max/avg): per channel, per `Ti`-block of output positions, the
    input is the `[Ti, Kh*Kw]` window block; the COMPUTE reduces each row along the
    window axis (MAX / MEAN) to one output per position.
  - **`GLOBAL_AVG`**: per channel, the whole `H*W` plane is streamed and a single
    COMPUTE reduces it to one value.
  - The pool op rides in Config/metadata; the reduce is the existing `VE_REDUCE`
    bound at execution, so **movement is pool-op-agnostic**. Envelope stamping +
    working-set (3) validation.

- **`test_pooling_execution`** executes the generated schedules (timing-only)
  across windowed max/avg, batch, non-tile-aligned, and global-average cases,
  asserting a COMPUTE per output tile, livelock-free completion, and the
  envelope-refusal boundary.

## Test results

| Check | Result |
|-------|--------|
| `test_pooling_execution` | PASS — 57 assertions, 2 cases |
| Full `timing` suite | PASS — 41/41 |
| `test_pattern_coverage` gate | PASS |
| clang `-Wall -Wextra -Werror` | clean |

## Coverage manifest (#93 contract)

`pooling` `generator` → **done**. Remaining: `functional` (T4 #194),
`regression` (T5 #195).

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #193

Generated with [Claude Code](https://claude.com/claude-code)