### PR TITLE
feat(m2): graph->CSP bridge + ResNet BasicBlock DFG (M2-T2, #201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **M2 ResNet BasicBlock as a KernelGraph DFG on the CSP executor — M2-T2 (#201).**
+  The graph->CSP bridge: `GraphCspExecutor` walks a `KernelGraph` in topological
+  order and runs each operator node on the schedule-generator value path
+  (`csp_op_runners.hpp`: `run_conv2d_fused` = im2col->GEMM with an optional folded
+  BatchNorm + bias/activation epilogue, `run_elementwise`/`run_relu`), threading
+  activations between nodes and applying the operator fusions as it lowers —
+  **conv+BN fold** (a CONV2D's sole-consumer BATCHNORM folds into its
+  weights+bias) and **conv+ReLU fused epilogue** (a CONV2D/folded-conv's
+  sole-consumer ReLU applies in-compute), so a `conv->BN->ReLU` chain collapses to
+  one GEMM. `test_m2_resnet_block` builds a ResNet BasicBlock (identity skip and
+  1x1-projection skip) as a `KernelGraph` (conv/BN/ReLU/residual-add nodes),
+  executes it through the bridge, and validates elementwise against a composed
+  host oracle (conv2d_reference + batchnorm_reference + add/ReLU) at 1e-3 — while
+  asserting the fusion fired (7 graph nodes -> 4 CSP ops for the identity block,
+  9 -> 5 for the projection). Nodes execute sequentially in topological order
+  (the design's honest scope). Milestone M2 (#130), design docs/plans/m2_resnet_dfg.md.
+
 - **Pooling regression matrix + characterization — E7-T5 (#195); completes the
   pooling coverage row.** `test_pooling_regression` executes a pool-type × shape ×
   envelope matrix (max/avg × shapes × {default, minimum, partitioned}) with, per

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -1,0 +1,228 @@
+// ============================================================================
+// include/sw/kpu/timing/graph/csp_op_runners.hpp
+// Value-producing single-op runners on the CSP executor (M2-T2, #201)
+//
+// The workhorses the graph->CSP bridge (graph_csp_executor.hpp) dispatches to.
+// Each runs one operator through the credit-based ConcurrentTimingExecutor and
+// returns the output tensor (real fp32 values), reusing the schedule-generator
+// value path proven by the E6/E9/E10 functional tests.
+//
+//   run_conv2d_fused: conv (im2col -> GEMM) with an OPTIONAL folded BatchNorm and
+//     an OPTIONAL bias + activation applied in-compute (the fused epilogue) - so
+//     conv+BN+ReLU is one GEMM, no DRAM round-trip for the intermediate.
+//   run_elementwise: a binary VE op (ADD for the residual join, MAX for ReLU).
+//
+// Tensors are row-major NCHW fp32. Tile size T divides M / Cout / K; the M2 demo
+// picks aligned shapes (documented in docs/plans/m2_resnet_dfg.md).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/functional_elementwise_executor.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace sw::kpu::timing::graph {
+
+using schedule::Conv2DGeometry;
+using schedule::BatchNormAffine;
+
+/// Accumulated CSP-execution stats across the ops of a graph run.
+struct RunStats {
+    Cycle total_cycles = 0;
+    Cycle dma_stalls = 0;
+    Cycle bm_stalls = 0;
+    Cycle str_stalls = 0;
+    std::size_t ops = 0;
+};
+
+namespace detail {
+
+// [T x T] block (br, bc) of a row-major [rows x cols] matrix.
+inline std::vector<float> block(const std::vector<float>& mat, Size cols,
+                                Size br, Size bc, Size T) {
+    std::vector<float> b(static_cast<std::size_t>(T) * T);
+    for (Size r = 0; r < T; ++r)
+        for (Size c = 0; c < T; ++c)
+            b[r * T + c] = mat[(br * T + r) * cols + (bc * T + c)];
+    return b;
+}
+
+inline void accumulate(RunStats& s, const ConcurrentTimingExecutor& exec) {
+    const auto st = exec.get_statistics();
+    s.total_cycles += exec.current_cycle();
+    s.dma_stalls += st.dma_credit_stalls;
+    s.bm_stalls += st.bm_tag_stalls + st.bm_credit_stalls;
+    s.str_stalls += st.str_tag_stalls + st.str_credit_stalls;
+    ++s.ops;
+}
+
+} // namespace detail
+
+/**
+ * @brief Run conv2d (im2col -> GEMM) with a fused epilogue, on the CSP executor.
+ *
+ * y = act( conv(x, filter) * bn.scale + bn.shift )     (if bn != nullptr)
+ * y = act( conv(x, filter) + bias )                    (otherwise)
+ *
+ * The BatchNorm fold (E9) scales the weight columns and moves the shift into the
+ * per-output-channel bias, so conv+BN is a single GEMM; bias + activation apply
+ * in-compute (E10). Input/output are NCHW.
+ *
+ * @param bn  optional folded BatchNorm affine (size C_out each), or nullptr
+ * @param bias optional per-output-channel conv bias (size C_out), or empty
+ * @param relu apply ReLU as the in-compute activation
+ * @param T   tile size (must divide M = N*Hout*Wout, C_out, and K = Cin*Kh*Kw)
+ */
+[[nodiscard]] inline std::vector<float>
+run_conv2d_fused(const std::vector<float>& input, const std::vector<float>& filter,
+                 const Conv2DGeometry& geom, const BatchNormAffine* bn,
+                 const std::vector<float>& bias, bool relu, Size T, RunStats& stats) {
+    using schedule::MatMulScheduleGenerator;
+    using MatrixID = sw::kpu::isa::MatrixID;
+
+    const Size M = geom.M(), N = geom.C_out, K = geom.K();
+    if (M % T || N % T || K % T)
+        throw std::invalid_argument("run_conv2d_fused: T must divide M, C_out, K");
+    if (bn && (bn->scale.size() != static_cast<std::size_t>(N) ||
+               bn->shift.size() != static_cast<std::size_t>(N)))
+        throw std::invalid_argument("run_conv2d_fused: bn scale/shift size must be C_out");
+    if (!bias.empty() && bias.size() != static_cast<std::size_t>(N))
+        throw std::invalid_argument("run_conv2d_fused: bias size must be C_out");
+
+    // im2col A_col [M, K] and reshaped weights B_w [K, N].
+    auto a_col = schedule::im2col_nchw(input, geom);
+    auto b_w = schedule::filter_to_bw_nchw(filter, geom);
+
+    // Fold: scale the weight columns; fused bias = bias*scale + shift.
+    std::vector<float> fused_bias(bias.empty() ? std::vector<float>(N, 0.0f) : bias);
+    bool has_bias = !bias.empty();
+    if (bn) {
+        for (Size k = 0; k < K; ++k)
+            for (Size co = 0; co < N; ++co)
+                b_w[static_cast<std::size_t>(k) * N + co] *= bn->scale[co];
+        for (Size co = 0; co < N; ++co)
+            fused_bias[co] = fused_bias[co] * bn->scale[co] + bn->shift[co];
+        has_bias = true;
+    }
+
+    MatMulScheduleGenerator::Config cfg;
+    cfg.M = M; cfg.N = N; cfg.K = K; cfg.Ti = cfg.Tj = cfg.Tk = T;
+    cfg.a_base = 0x100000; cfg.b_base = 0x400000; cfg.c_base = 0x700000;
+    auto schedule = MatMulScheduleGenerator(cfg).generate();
+    if (!schedule.valid)
+        throw std::runtime_error("run_conv2d_fused: schedule refused: " + schedule.error_message);
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.max_cycles = 20'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+
+    for (const auto& op : schedule.operations) {
+        if (op.type != schedule::ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        if (id.matrix == MatrixID::A)
+            exec.set_tile_payload(id, TilePayload{T, T, detail::block(a_col, K, id.ti, id.tk, T)});
+        else
+            exec.set_tile_payload(id, TilePayload{T, T, detail::block(b_w, N, id.tk, id.tj, T)});
+    }
+    for (const auto& op : schedule.operations) {
+        using schedule::ScheduleOpType;
+        switch (op.type) {
+            case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+            case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+            case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+            case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+            case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+            case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+            case ScheduleOpType::COMPUTE: {
+                ConcurrentTimingExecutor::MatMulComputeSpec spec;
+                for (const auto& dep : op.dependency_tiles) {
+                    if (dep.matrix == MatrixID::A) spec.a_tiles.push_back(dep);
+                    else                            spec.b_tiles.push_back(dep);
+                }
+                if (has_bias) {
+                    const Size tj = op.tile.tile_id.tj;
+                    spec.bias.assign(fused_bias.begin() + static_cast<std::ptrdiff_t>(tj * T),
+                                     fused_bias.begin() + static_cast<std::ptrdiff_t>(tj * T + T));
+                }
+                if (relu) spec.activation = ConcurrentTimingExecutor::FunctionalActivation::RELU;
+                exec.schedule_matmul_compute(op.tile, spec);
+                break;
+            }
+        }
+    }
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles)
+        exec.step();
+    if (!exec.is_complete())
+        throw std::runtime_error("run_conv2d_fused: schedule did not complete");
+    detail::accumulate(stats, exec);
+
+    // Read C [M, N] from DRAM stores; reshape to NCHW y[n, co, ho, wo].
+    const Size Hout = geom.H_out(), Wout = geom.W_out();
+    std::vector<float> y(static_cast<std::size_t>(geom.N) * N * Hout * Wout);
+    for (const auto& op : schedule.operations) {
+        if (op.type != schedule::ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        for (Size r = 0; r < T; ++r)
+            for (Size c = 0; c < T; ++c) {
+                const Size m = id.ti * T + r, co = id.tj * T + c;
+                const Size n = m / (Hout * Wout), rem = m % (Hout * Wout);
+                const Size ho = rem / Wout, wo = rem % Wout;
+                y[((static_cast<std::size_t>(n) * N + co) * Hout + ho) * Wout + wo] =
+                    p.values[r * T + c];
+            }
+    }
+    return y;
+}
+
+/**
+ * @brief Run a binary elementwise op (ADD residual join / MAX for ReLU) on the
+ *        CSP executor via the value-producing functional path.
+ *
+ * For ReLU pass op = MAX and b = zeros. Both operands must be the same length.
+ */
+[[nodiscard]] inline std::vector<float>
+run_elementwise(sw::kpu::isa::VEOp op, const std::vector<float>& a,
+                const std::vector<float>& b, RunStats& stats) {
+    using schedule::ElementwiseScheduleGenerator;
+    using schedule::FunctionalElementwiseExecutor;
+    if (a.size() != b.size())
+        throw std::invalid_argument("run_elementwise: operand size mismatch");
+
+    ElementwiseScheduleGenerator::Config gcfg;
+    gcfg.num_elements = a.size();
+    gcfg.tile_elems = 256;
+    gcfg.form = ElementwiseScheduleGenerator::Form::BINARY;
+    gcfg.a_base = 0x100000; gcfg.b_base = 0x400000; gcfg.c_base = 0x700000;
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.max_cycles = 20'000'000;
+
+    FunctionalElementwiseExecutor exec(gcfg, ecfg);
+    auto result = exec.run(op, a, b);
+    if (!result.execution.success)
+        throw std::runtime_error("run_elementwise: execution failed: " +
+                                 result.execution.error_message);
+    stats.total_cycles += result.execution.total_cycles;
+    ++stats.ops;
+    return result.values;
+}
+
+/// ReLU as MAX(x, 0) on the CSP executor.
+[[nodiscard]] inline std::vector<float>
+run_relu(const std::vector<float>& x, RunStats& stats) {
+    return run_elementwise(sw::kpu::isa::VEOp::MAX, x,
+                           std::vector<float>(x.size(), 0.0f), stats);
+}
+
+} // namespace sw::kpu::timing::graph

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -91,8 +91,12 @@ run_conv2d_fused(const std::vector<float>& input, const std::vector<float>& filt
     using MatrixID = sw::kpu::isa::MatrixID;
 
     const Size M = geom.M(), N = geom.C_out, K = geom.K();
-    if (M % T || N % T || K % T)
-        throw std::invalid_argument("run_conv2d_fused: T must divide M, C_out, K");
+    if (T == 0 || M % T || N % T || K % T)
+        throw std::invalid_argument("run_conv2d_fused: T must be > 0 and divide M, C_out, K");
+    if (input.size() != static_cast<std::size_t>(geom.N) * geom.C_in * geom.H_in * geom.W_in)
+        throw std::invalid_argument("run_conv2d_fused: input size does not match geometry");
+    if (filter.size() != static_cast<std::size_t>(N) * geom.C_in * geom.Kh * geom.Kw)
+        throw std::invalid_argument("run_conv2d_fused: filter size does not match geometry");
     if (bn && (bn->scale.size() != static_cast<std::size_t>(N) ||
                bn->shift.size() != static_cast<std::size_t>(N)))
         throw std::invalid_argument("run_conv2d_fused: bn scale/shift size must be C_out");
@@ -200,7 +204,7 @@ run_elementwise(sw::kpu::isa::VEOp op, const std::vector<float>& a,
         throw std::invalid_argument("run_elementwise: operand size mismatch");
 
     ElementwiseScheduleGenerator::Config gcfg;
-    gcfg.num_elements = a.size();
+    gcfg.num_elements = static_cast<Size>(a.size());
     gcfg.tile_elems = 256;
     gcfg.form = ElementwiseScheduleGenerator::Form::BINARY;
     gcfg.a_base = 0x100000; gcfg.b_base = 0x400000; gcfg.c_base = 0x700000;

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -219,12 +219,20 @@ private:
     }
 
     static Conv2DGeometry conv_geom(const sw::kpu::Conv2DConfig& c) {
+        // Conv2DConfig uses sw::kpu::Size (64-bit); Conv2DGeometry uses the
+        // timing Size (32-bit) - cast to avoid MSVC C4267.
         Conv2DGeometry g;
-        g.N = c.batch_size; g.C_in = c.in_channels; g.H_in = c.input_height;
-        g.W_in = c.input_width; g.C_out = c.out_channels;
-        g.Kh = c.kernel_height; g.Kw = c.kernel_width;
-        g.stride_h = c.stride_h; g.stride_w = c.stride_w;
-        g.pad_h = c.padding_h; g.pad_w = c.padding_w;
+        g.N = static_cast<Size>(c.batch_size);
+        g.C_in = static_cast<Size>(c.in_channels);
+        g.H_in = static_cast<Size>(c.input_height);
+        g.W_in = static_cast<Size>(c.input_width);
+        g.C_out = static_cast<Size>(c.out_channels);
+        g.Kh = static_cast<Size>(c.kernel_height);
+        g.Kw = static_cast<Size>(c.kernel_width);
+        g.stride_h = static_cast<Size>(c.stride_h);
+        g.stride_w = static_cast<Size>(c.stride_w);
+        g.pad_h = static_cast<Size>(c.padding_h);
+        g.pad_w = static_cast<Size>(c.padding_w);
         return g;
     }
 };

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -1,0 +1,232 @@
+// ============================================================================
+// include/sw/kpu/timing/graph/graph_csp_executor.hpp
+// Graph->CSP bridge: execute a KernelGraph on the credit-based value path
+// (M2-T2, #201). See docs/plans/m2_resnet_dfg.md.
+//
+// Walks a KernelGraph in topological order and runs each operator node on the
+// schedule-generator value path (csp_op_runners.hpp), threading activations
+// between nodes and applying the operator fusions as it lowers:
+//   * conv+BN fold  - a CONV2D followed (as sole consumer) by a BATCHNORM folds
+//     BN's scale/shift into the conv's weights+bias; the BN node is not executed.
+//   * conv+ReLU fused epilogue - a CONV2D/folded-conv followed (as sole consumer)
+//     by an ELEMENTWISE RELU applies ReLU in-compute; the ReLU node is not run.
+// A standalone ELEMENTWISE (the residual ADD, and the block's final ReLU whose
+// producer is the ADD) runs as its own CSP op.
+//
+// Nodes execute SEQUENTIALLY in topological order (the design's honest scope):
+// the measured concurrency is the tile-level pipeline overlap within each op,
+// not operator-branch overlap. get_execution_levels / find_fusible_pairs remain
+// available for analysis/viz.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/csp_op_runners.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+namespace sw::kpu::timing::graph {
+
+/// Per-node data the bridge needs beyond the KernelGraph Kernel config (the
+/// graph carries shapes, not weights). Keyed by node id.
+struct NodeData {
+    std::vector<float> filter;   ///< CONV2D weights [Cout,Cin,Kh,Kw]
+    std::vector<float> bias;     ///< optional CONV2D bias [Cout]
+    // BATCHNORM raw inference params [C]:
+    std::vector<float> gamma, beta, mean, var;
+    float eps = 1e-5f;
+};
+
+/**
+ * @brief Execute a KernelGraph (a ResNet block / network) on the CSP value path.
+ *
+ * The graph is a single-source, single-sink operator DAG. `input` is the source
+ * tensor (NCHW); `node_data` supplies per-node weights/params. Returns the sink
+ * node's output tensor plus accumulated CSP stats.
+ *
+ * @param T tile size (must divide the GEMM M/N/K of every conv node)
+ */
+class GraphCspExecutor {
+public:
+    struct Result {
+        std::vector<float> output;
+        RunStats stats;
+    };
+
+    Result run(const KernelGraph& g, const std::vector<float>& input,
+               const std::unordered_map<std::size_t, NodeData>& node_data, Size T) {
+        using sw::kpu::KernelOpType;
+        using sw::kpu::ElementwiseOp;
+
+        Result result;
+        std::unordered_map<std::size_t, std::vector<float>> out;  // node id -> tensor
+
+        // --- fusion pre-pass ---------------------------------------------------
+        // fold_bn[conv] = bn node folded into conv; consumed[node] = not run.
+        std::unordered_map<std::size_t, std::size_t> fold_bn;
+        std::unordered_map<std::size_t, std::size_t> bn_to_conv;  // bn -> conv it folds into
+        std::unordered_map<std::size_t, std::size_t> fuse_relu;   // conv -> relu
+        std::unordered_map<std::size_t, bool> consumed;
+
+        // Pass 1: fold each BATCHNORM whose sole producer is a CONV2D (and which
+        // is that conv's sole consumer) into the conv.
+        for (auto id : g.get_execution_order()) {
+            if (g.get_kernel(id).op_type() != KernelOpType::BATCHNORM) continue;
+            std::optional<std::size_t> prod = sole_producer(g, id);
+            if (prod && g.get_kernel(*prod).op_type() == KernelOpType::CONV2D &&
+                sole_consumer(g, *prod) == id) {
+                fold_bn[*prod] = id;
+                bn_to_conv[id] = *prod;
+                consumed[id] = true;
+            }
+        }
+        // Pass 2: fuse a ReLU epilogue onto the conv it follows - directly
+        // (conv->relu) or through a folded BN (conv->bn->relu). Never onto the ADD.
+        for (auto id : g.get_execution_order()) {
+            const auto& k = g.get_kernel(id);
+            if (k.op_type() != KernelOpType::ELEMENTWISE ||
+                k.elementwise_config().op != ElementwiseOp::RELU) continue;
+            std::optional<std::size_t> prod = sole_producer(g, id);
+            if (!prod || sole_consumer(g, *prod) != id) continue;
+            std::size_t conv = static_cast<std::size_t>(-1);
+            if (g.get_kernel(*prod).op_type() == KernelOpType::CONV2D) conv = *prod;
+            else if (auto it = bn_to_conv.find(*prod); it != bn_to_conv.end()) conv = it->second;
+            if (conv != static_cast<std::size_t>(-1)) {
+                fuse_relu[conv] = id;
+                consumed[id] = true;
+            }
+        }
+
+        // --- topological execution --------------------------------------------
+        std::size_t last = 0;
+        for (auto id : g.get_execution_order()) {
+            if (consumed.count(id)) continue;
+            const auto& k = g.get_kernel(id);
+            const NodeData* nd = data_or_null(node_data, id);
+
+            switch (k.op_type()) {
+                case KernelOpType::CONV2D: {
+                    const auto& cc = k.conv2d_config();
+                    if (!nd) throw std::runtime_error("GraphCspExecutor: missing NodeData for conv node");
+                    Conv2DGeometry geom = conv_geom(cc);
+                    // input: this conv's graph predecessor output, else external input.
+                    const std::vector<float>& x = input_of(g, id, out, input);
+
+                    // Optional folded BN.
+                    schedule::BatchNormAffine affine;
+                    const schedule::BatchNormAffine* bn = nullptr;
+                    if (auto it = fold_bn.find(id); it != fold_bn.end()) {
+                        const auto* bd = data_or_null(node_data, it->second);
+                        if (!bd) throw std::runtime_error("GraphCspExecutor: missing NodeData for folded BN");
+                        affine = schedule::bn_fold(bd->gamma, bd->beta, bd->mean, bd->var, bd->eps);
+                        bn = &affine;
+                    }
+                    const bool relu = fuse_relu.count(id) > 0;
+                    auto y = run_conv2d_fused(x, nd->filter, geom, bn, nd->bias, relu, T, result.stats);
+                    out[id] = y;
+                    // Fused BN / ReLU nodes alias this output for their consumers.
+                    if (auto it = fold_bn.find(id); it != fold_bn.end()) out[it->second] = y;
+                    if (auto it = fuse_relu.find(id); it != fuse_relu.end()) out[it->second] = y;
+                    last = alias_last(id, fold_bn, fuse_relu);
+                    break;
+                }
+                case KernelOpType::ELEMENTWISE: {
+                    const auto op = k.elementwise_config().op;
+                    if (op == ElementwiseOp::ADD) {
+                        // Residual join: gather the ADD's input-edge producers.
+                        // Two edges = both branches (projection skip); one edge =
+                        // main branch + the external input (identity skip).
+                        auto ins = edge_inputs(g, id, out);
+                        const std::vector<float>& a = ins.empty() ? input : *ins[0];
+                        const std::vector<float>& b = ins.size() > 1 ? *ins[1] : input;
+                        out[id] = run_elementwise(sw::kpu::isa::VEOp::ADD, a, b, result.stats);
+                    } else if (op == ElementwiseOp::RELU) {
+                        out[id] = run_relu(input_of(g, id, out, input), result.stats);
+                    } else {
+                        throw std::runtime_error("GraphCspExecutor: unsupported elementwise op");
+                    }
+                    last = id;
+                    break;
+                }
+                default:
+                    throw std::runtime_error("GraphCspExecutor: unsupported kernel op type");
+            }
+        }
+        result.output = out.at(last);
+        return result;
+    }
+
+private:
+    static const NodeData* data_or_null(
+        const std::unordered_map<std::size_t, NodeData>& m, std::size_t id) {
+        auto it = m.find(id);
+        return it == m.end() ? nullptr : &it->second;
+    }
+
+    // The output of this node's single internal producer, or the external input
+    // if it has no incoming edge (a graph source).
+    static const std::vector<float>& input_of(
+        const KernelGraph& g, std::size_t id,
+        const std::unordered_map<std::size_t, std::vector<float>>& out,
+        const std::vector<float>& external) {
+        const auto& node = g.get_node(id);
+        for (std::size_t e : node.input_edges) {
+            const auto& edge = g.get_edge(e);
+            auto it = out.find(edge.from_node);
+            if (it != out.end()) return it->second;
+        }
+        return external;
+    }
+
+    // All input-edge producer outputs, in edge order (only those already run).
+    static std::vector<const std::vector<float>*> edge_inputs(
+        const KernelGraph& g, std::size_t id,
+        const std::unordered_map<std::size_t, std::vector<float>>& out) {
+        std::vector<const std::vector<float>*> res;
+        for (std::size_t e : g.get_node(id).input_edges) {
+            auto it = out.find(g.get_edge(e).from_node);
+            if (it != out.end()) res.push_back(&it->second);
+        }
+        return res;
+    }
+
+    static std::optional<std::size_t> sole_producer(const KernelGraph& g, std::size_t id) {
+        const auto& node = g.get_node(id);
+        if (node.input_edges.size() != 1) return std::nullopt;
+        return g.get_edge(node.input_edges[0]).from_node;
+    }
+    static std::size_t sole_consumer(const KernelGraph& g, std::size_t id) {
+        const auto& node = g.get_node(id);
+        if (node.output_edges.size() != 1) return static_cast<std::size_t>(-1);
+        return g.get_edge(node.output_edges[0]).to_node;
+    }
+    static std::size_t alias_last(std::size_t conv,
+        const std::unordered_map<std::size_t, std::size_t>& fold_bn,
+        const std::unordered_map<std::size_t, std::size_t>& fuse_relu) {
+        std::size_t l = conv;
+        if (auto it = fold_bn.find(conv); it != fold_bn.end()) l = it->second;
+        if (auto it = fuse_relu.find(conv); it != fuse_relu.end()) l = it->second;
+        return l;
+    }
+
+    static Conv2DGeometry conv_geom(const sw::kpu::Conv2DConfig& c) {
+        Conv2DGeometry g;
+        g.N = c.batch_size; g.C_in = c.in_channels; g.H_in = c.input_height;
+        g.W_in = c.input_width; g.C_out = c.out_channels;
+        g.Kh = c.kernel_height; g.Kw = c.kernel_width;
+        g.stride_h = c.stride_h; g.stride_w = c.stride_w;
+        g.pad_h = c.padding_h; g.pad_w = c.padding_w;
+        return g;
+    }
+};
+
+} // namespace sw::kpu::timing::graph

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -263,6 +263,16 @@ set_tests_properties(test_pooling_regression PROPERTIES
     LABELS "timing;regression;pooling;v0.9"
 )
 
+# M2 ResNet BasicBlock DFG on the CSP executor (issue #201, milestone M2):
+# a KernelGraph residual block executed through GraphCspExecutor vs a host oracle
+kpu_add_component_test(test_m2_resnet_block "timing"
+    test_m2_resnet_block.cpp
+)
+
+set_tests_properties(test_m2_resnet_block PROPERTIES
+    LABELS "timing;m2;resnet;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_m2_resnet_block.cpp
+++ b/tests/timing/test_m2_resnet_block.cpp
@@ -1,0 +1,206 @@
+// ============================================================================
+// tests/timing/test_m2_resnet_block.cpp
+// M2-T2 (#201): a ResNet BasicBlock expressed as a KernelGraph DFG, executed on
+// the CSP value path through GraphCspExecutor, validated vs a composed host
+// oracle. Exercises the operators (conv/BN/ReLU/residual-add) and the fusions
+// (conv+BN fold, conv+ReLU epilogue) in composition. See docs/plans/m2_resnet_dfg.md.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/kernel.hpp>
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/graph_csp_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+using namespace sw::kpu;
+using namespace sw::kpu::timing::graph;
+using sw::kpu::timing::schedule::Conv2DGeometry;
+using sw::kpu::timing::schedule::BatchNormGeometry;
+
+namespace {
+
+// Small deterministic weights (fixed-seed LCG), as M1 - keeps activations O(1)
+// so fp32 stays comfortable through the block.
+std::vector<float> synth(std::size_t n, uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    uint64_t s = seed;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<uint32_t>(s >> 33);
+        x = (static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+
+void relu_ip(std::vector<float>& v) { for (auto& x : v) x = std::max(0.0f, x); }
+std::vector<float> add(const std::vector<float>& a, const std::vector<float>& b) {
+    std::vector<float> r(a.size());
+    for (std::size_t i = 0; i < a.size(); ++i) r[i] = a[i] + b[i];
+    return r;
+}
+
+Conv2DConfig conv_cfg(Size N, Size Cin, Size Cout, Size H, Size W, Size stride) {
+    Conv2DConfig c;
+    c.batch_size = N; c.in_channels = Cin; c.out_channels = Cout;
+    c.input_height = H; c.input_width = W;
+    c.kernel_height = 3; c.kernel_width = 3;
+    c.stride_h = c.stride_w = stride; c.padding_h = c.padding_w = 1;
+    return c;
+}
+Conv2DGeometry geom_of(const Conv2DConfig& c) {
+    Conv2DGeometry g;
+    g.N = c.batch_size; g.C_in = c.in_channels; g.H_in = c.input_height;
+    g.W_in = c.input_width; g.C_out = c.out_channels; g.Kh = c.kernel_height;
+    g.Kw = c.kernel_width; g.stride_h = c.stride_h; g.stride_w = c.stride_w;
+    g.pad_h = c.padding_h; g.pad_w = c.padding_w;
+    return g;
+}
+
+// BatchNorm raw params for C channels.
+struct BN { std::vector<float> gamma, beta, mean, var; float eps = 1e-3f; };
+BN synth_bn(Size C, uint64_t seed) {
+    BN b;
+    b.gamma = synth(C, seed + 1, 0.5f);      for (auto& g : b.gamma) g += 1.0f;   // ~1
+    b.beta  = synth(C, seed + 2, 0.2f);
+    b.mean  = synth(C, seed + 3, 0.3f);
+    b.var   = synth(C, seed + 4, 0.2f);      for (auto& v : b.var) v = std::abs(v) + 0.5f;  // >0
+    return b;
+}
+
+// Host oracle: conv (no bias) -> BN inference -> optional ReLU. Returns NCHW.
+std::vector<float> conv_bn(const std::vector<float>& x, const std::vector<float>& w,
+                           const Conv2DConfig& cc, const BN& bn, bool relu) {
+    const auto g = geom_of(cc);
+    auto z = sw::kpu::timing::schedule::conv2d_reference(x, w, {}, g, false);
+    BatchNormGeometry bg; bg.N = g.N; bg.C = g.C_out; bg.H = g.H_out(); bg.W = g.W_out();
+    auto y = sw::kpu::timing::schedule::batchnorm_reference(z, bn.gamma, bn.beta,
+                                                            bn.mean, bn.var, bn.eps, bg);
+    if (relu) relu_ip(y);
+    return y;
+}
+
+void set_bn(NodeData& nd, const BN& bn) {
+    nd.gamma = bn.gamma; nd.beta = bn.beta; nd.mean = bn.mean; nd.var = bn.var; nd.eps = bn.eps;
+}
+
+} // namespace
+
+TEST_CASE("M2 ResNet BasicBlock (identity skip) on the CSP executor",
+          "[timing][m2][resnet]") {
+    const Size N = 1, C = 16, H = 8, W = 8;  // aligned: M=64, K=144, Cout=16 (T=16)
+    auto cc = conv_cfg(N, C, C, H, W, 1);
+    auto x  = synth(static_cast<std::size_t>(N) * C * H * W, 1, 1.0f);
+    auto w1 = synth(static_cast<std::size_t>(C) * C * 9, 2, 0.1f);
+    auto w2 = synth(static_cast<std::size_t>(C) * C * 9, 3, 0.1f);
+    BN bn1 = synth_bn(C, 100), bn2 = synth_bn(C, 200);
+
+    // --- host oracle: conv1->BN1->ReLU -> conv2->BN2 -> +x -> ReLU ------------
+    auto o1 = conv_bn(x, w1, cc, bn1, /*relu*/true);
+    auto o2 = conv_bn(o1, w2, cc, bn2, /*relu*/false);
+    auto oref = add(o2, x);
+    relu_ip(oref);
+
+    // --- DFG: build the BasicBlock KernelGraph -------------------------------
+    KernelGraph g;
+    auto c1 = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "conv1");
+    auto b1 = g.add_kernel(Kernel::create_batchnorm(N, C, H, W, bn1.eps), "bn1");
+    auto r1 = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU, {C * H * W}), "relu1");
+    auto c2 = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "conv2");
+    auto b2 = g.add_kernel(Kernel::create_batchnorm(N, C, H, W, bn2.eps), "bn2");
+    auto ad = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::ADD, {C * H * W}), "add");
+    auto r2 = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU, {C * H * W}), "relu2");
+    g.add_edge(c1, b1); g.add_edge(b1, r1); g.add_edge(r1, c2);
+    g.add_edge(c2, b2); g.add_edge(b2, ad); g.add_edge(ad, r2);
+    // identity skip: the ADD has one edge (bn2->add); its 2nd operand is x.
+
+    // DFG structural checks: the fusion pass will find conv->BN pairs.
+    REQUIRE(g.num_nodes() == 7);
+    REQUIRE(g.get_execution_order().size() == 7);
+
+    std::unordered_map<std::size_t, NodeData> nd;
+    nd[c1].filter = w1; set_bn(nd[b1], bn1);
+    nd[c2].filter = w2; set_bn(nd[b2], bn2);
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, x, nd, /*T*/16);
+
+    REQUIRE(result.output.size() == oref.size());
+    // Fusion fired: 7 graph nodes collapse to 4 CSP ops - bn1/bn2 folded into
+    // their convs, relu1 fused as conv1's epilogue; only conv1, conv2, add, and
+    // the final relu2 execute.
+    REQUIRE(result.stats.ops == 4);
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < oref.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - oref[i]));
+    INFO("max_err=" << max_err << " ops=" << result.stats.ops
+         << " cycles=" << result.stats.total_cycles);
+    REQUIRE(max_err < 1e-3f);
+}
+
+TEST_CASE("M2 ResNet BasicBlock (1x1 projection skip) on the CSP executor",
+          "[timing][m2][resnet]") {
+    // Channel-changing block: Cin=16 -> Cout=32; skip = 1x1 conv projection + BN.
+    const Size N = 1, Cin = 16, Cout = 32, H = 8, W = 8;
+    auto cc1 = conv_cfg(N, Cin, Cout, H, W, 1);   // 3x3
+    auto cc2 = conv_cfg(N, Cout, Cout, H, W, 1);  // 3x3
+    Conv2DConfig ccp = conv_cfg(N, Cin, Cout, H, W, 1);  // 1x1 projection
+    ccp.kernel_height = ccp.kernel_width = 1; ccp.padding_h = ccp.padding_w = 0;
+
+    auto x   = synth(static_cast<std::size_t>(N) * Cin * H * W, 11, 1.0f);
+    auto w1  = synth(static_cast<std::size_t>(Cout) * Cin * 9, 12, 0.1f);
+    auto w2  = synth(static_cast<std::size_t>(Cout) * Cout * 9, 13, 0.1f);
+    auto wp  = synth(static_cast<std::size_t>(Cout) * Cin * 1, 14, 0.1f);
+    BN bn1 = synth_bn(Cout, 300), bn2 = synth_bn(Cout, 400), bnp = synth_bn(Cout, 500);
+
+    // oracle
+    auto o1   = conv_bn(x, w1, cc1, bn1, true);
+    auto o2   = conv_bn(o1, w2, cc2, bn2, false);
+    auto skip = conv_bn(x, wp, ccp, bnp, false);   // projection branch
+    auto oref = add(o2, skip);
+    relu_ip(oref);
+
+    // DFG with a real skip branch (conv_proj -> bn_proj -> add)
+    KernelGraph g;
+    auto c1 = g.add_kernel(Kernel::create_conv2d(cc1, false, ActivationType::NONE), "conv1");
+    auto b1 = g.add_kernel(Kernel::create_batchnorm(N, Cout, H, W, bn1.eps), "bn1");
+    auto r1 = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU, {Cout * H * W}), "relu1");
+    auto c2 = g.add_kernel(Kernel::create_conv2d(cc2, false, ActivationType::NONE), "conv2");
+    auto b2 = g.add_kernel(Kernel::create_batchnorm(N, Cout, H, W, bn2.eps), "bn2");
+    auto cp = g.add_kernel(Kernel::create_conv2d(ccp, false, ActivationType::NONE), "conv_proj");
+    auto bp = g.add_kernel(Kernel::create_batchnorm(N, Cout, H, W, bnp.eps), "bn_proj");
+    auto ad = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::ADD, {Cout * H * W}), "add");
+    auto r2 = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU, {Cout * H * W}), "relu2");
+    g.add_edge(c1, b1); g.add_edge(b1, r1); g.add_edge(r1, c2); g.add_edge(c2, b2);
+    g.add_edge(cp, bp);
+    g.add_edge(b2, ad); g.add_edge(bp, ad, "C", "B");  // main + projection skip
+    g.add_edge(ad, r2);
+
+    std::unordered_map<std::size_t, NodeData> nd;
+    nd[c1].filter = w1; set_bn(nd[b1], bn1);
+    nd[c2].filter = w2; set_bn(nd[b2], bn2);
+    nd[cp].filter = wp; set_bn(nd[bp], bnp);
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, x, nd, 16);
+
+    REQUIRE(result.output.size() == oref.size());
+    // 9 graph nodes -> 5 CSP ops: conv1, conv2, conv_proj (each with folded BN),
+    // add, relu2; bn1/bn2/bn_proj folded and relu1 fused.
+    REQUIRE(result.stats.ops == 5);
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < oref.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - oref[i]));
+    INFO("projection max_err=" << max_err);
+    REQUIRE(max_err < 1e-3f);
+}

--- a/tests/timing/test_m2_resnet_block.cpp
+++ b/tests/timing/test_m2_resnet_block.cpp
@@ -59,11 +59,16 @@ Conv2DConfig conv_cfg(Size N, Size Cin, Size Cout, Size H, Size W, Size stride) 
     return c;
 }
 Conv2DGeometry geom_of(const Conv2DConfig& c) {
+    // Conv2DConfig fields are sw::kpu::Size (64-bit); Conv2DGeometry uses the
+    // timing Size (32-bit) - cast to avoid MSVC C4267.
+    using G = sw::kpu::timing::Size;
     Conv2DGeometry g;
-    g.N = c.batch_size; g.C_in = c.in_channels; g.H_in = c.input_height;
-    g.W_in = c.input_width; g.C_out = c.out_channels; g.Kh = c.kernel_height;
-    g.Kw = c.kernel_width; g.stride_h = c.stride_h; g.stride_w = c.stride_w;
-    g.pad_h = c.padding_h; g.pad_w = c.padding_w;
+    g.N = static_cast<G>(c.batch_size); g.C_in = static_cast<G>(c.in_channels);
+    g.H_in = static_cast<G>(c.input_height); g.W_in = static_cast<G>(c.input_width);
+    g.C_out = static_cast<G>(c.out_channels); g.Kh = static_cast<G>(c.kernel_height);
+    g.Kw = static_cast<G>(c.kernel_width); g.stride_h = static_cast<G>(c.stride_h);
+    g.stride_w = static_cast<G>(c.stride_w); g.pad_h = static_cast<G>(c.padding_h);
+    g.pad_w = static_cast<G>(c.padding_w);
     return g;
 }
 


### PR DESCRIPTION
## Summary

M2-T2 (#201), following the merged M2 design (#200). The **graph→CSP bridge** that
executes a `KernelGraph` (the operator DFG) on the credit-based CSP value path,
demonstrated + validated on a **ResNet BasicBlock**.

## What landed

- **`csp_op_runners.hpp`** — single-op CSP runners:
  - `run_conv2d_fused` = conv (im2col → GEMM) with an **optional folded BatchNorm**
    and an **optional bias + ReLU applied in-compute** (the fused epilogue),
    reusing the E6/E9/E10 value path — so `conv+BN+ReLU` is one GEMM.
  - `run_elementwise` / `run_relu` for the residual ADD and ReLU.

- **`graph_csp_executor.hpp`** — `GraphCspExecutor` walks `get_execution_order()`
  and dispatches each node to the runners, threading activations via edges. A
  **fusion pre-pass** folds a CONV2D's sole-consumer BATCHNORM into its
  weights/bias, and fuses a sole-consumer ReLU (directly or *through* the folded
  BN) as the conv's in-compute activation. The residual ADD gathers its operands
  from its input edges (projection skip) or the external input (identity skip).
  Nodes execute **sequentially in topological order** (the design's honest scope).

- **`test_m2_resnet_block.cpp`** — a ResNet BasicBlock (identity skip *and*
  1×1-projection skip) built as a `KernelGraph` (conv/BN/ReLU/residual-add nodes),
  executed through the bridge, validated elementwise vs a composed host oracle
  (`conv2d_reference` + `batchnorm_reference` + add/ReLU) at 1e-3 — **and asserts
  the fusion fired**: 7 graph nodes → 4 CSP ops (identity), 9 → 5 (projection).

## Test results

| Check | Result |
|-------|--------|
| `test_m2_resnet_block` | PASS — identity + projection blocks, fusion verified |
| Full `timing` suite | PASS — 45/45 |
| clang `-Wall -Wextra -Werror` | clean |

## Milestone

This is the M2 **demonstrate + validate** tiers for the residual block: the DFG
runs end-to-end on the CSP executor and matches the oracle, exercising the
operators (conv/BN/ReLU/residual-add) *and* the fusions (conv+BN fold,
conv+ReLU epilogue) in composition. Next: **T3** stacks blocks into full
ResNet-18 (stem + 4 stages + GAP + FC); **T4** is the benchmark + writeup.

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #130
Relates to #201

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GraphCSP execution support for single-source/single-sink KernelGraphs, including Conv2D with optional BatchNorm folding, fused ReLU epilogues, and residual ADD handling for ResNet BasicBlocks.
  * Introduced value-producing operator execution with collected per-run performance stats (total cycles, DMA/BM/STR stalls, and op counts).
* **Bug Fixes**
  * Added stronger validation for tensor/parameter sizes, tile divisibility, and supported elementwise cases.
* **Tests**
  * Added timing/accuracy coverage for identity and projection skip variants, including fusion-related op-count checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->