### PR TITLE
feat(m2): ResNet head (global-avg-pool -> FC) on the CSP executor (M2-T3b, #203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **M2 ResNet classification head (GAP -> FC) on the CSP executor — M2-T3 part B
+  (#203).** Completes the ResNet-18 operator set: `run_global_avg_pool` (mean over
+  the H*W plane per channel, tiling the plane as one chunk so any spatial extent
+  works) and `run_matmul` (the FC GEMM with a bias + ReLU epilogue), plus
+  `GraphCspExecutor` **POOL2D** (global-average) and **MATMUL** dispatch. FC
+  weights/dims ride in `NodeData` (create_matmul exposes no config accessor).
+  `test_m2_resnet_head` builds a `GAP -> FC` `KernelGraph`, executes it through
+  the bridge, and validates the classification output vs a host oracle (with and
+  without FC ReLU), asserting both ops run on the CSP executor. With this and the
+  ResNet-18 tower (part A), every ResNet-18 operator executes as a DFG on the CSP
+  value path. Milestone M2 (#130).
+
 - **M2 ResNet-18 residual tower as a KernelGraph DFG — M2-T3 part A (#203).** The
   full ResNet-18 residual tower (stem 3x3 conv->BN->ReLU + four stages of stacked
   BasicBlocks, `[2,2,2,2]`, the first block of stages 2-4 stride-2 downsampling

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -26,8 +26,12 @@
 #include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
 #include <sw/kpu/timing/schedule/matmul_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/functional_elementwise_executor.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+#include <sw/kpu/timing/schedule/pooling_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
 
 #include <cstddef>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -227,6 +231,150 @@ run_elementwise(sw::kpu::isa::VEOp op, const std::vector<float>& a,
 run_relu(const std::vector<float>& x, RunStats& stats) {
     return run_elementwise(sw::kpu::isa::VEOp::MAX, x,
                            std::vector<float>(x.size(), 0.0f), stats);
+}
+
+/**
+ * @brief Run a matmul C = act(A @ W + bias) on the CSP executor (the FC layer).
+ *
+ * A is [M, K] row-major, W is [K, N] row-major. Reuses the value-producing GEMM
+ * path (schedule_matmul_compute) with the bias + activation epilogue.
+ *
+ * @param T tile size (must divide M, N, K)
+ */
+[[nodiscard]] inline std::vector<float>
+run_matmul(const std::vector<float>& a, const std::vector<float>& w,
+           Size M, Size N, Size K, const std::vector<float>& bias, bool relu,
+           Size T, RunStats& stats) {
+    using schedule::MatMulScheduleGenerator;
+    using MatrixID = sw::kpu::isa::MatrixID;
+    if (T == 0 || M % T || N % T || K % T)
+        throw std::invalid_argument("run_matmul: T must be > 0 and divide M, N, K");
+    if (a.size() != static_cast<std::size_t>(M) * K)
+        throw std::invalid_argument("run_matmul: A size does not match M*K");
+    if (w.size() != static_cast<std::size_t>(K) * N)
+        throw std::invalid_argument("run_matmul: W size does not match K*N");
+    if (!bias.empty() && bias.size() != static_cast<std::size_t>(N))
+        throw std::invalid_argument("run_matmul: bias size must be N or empty");
+
+    MatMulScheduleGenerator::Config cfg;
+    cfg.M = M; cfg.N = N; cfg.K = K; cfg.Ti = cfg.Tj = cfg.Tk = T;
+    cfg.a_base = 0x100000; cfg.b_base = 0x400000; cfg.c_base = 0x700000;
+    auto schedule = MatMulScheduleGenerator(cfg).generate();
+    if (!schedule.valid)
+        throw std::runtime_error("run_matmul: schedule refused: " + schedule.error_message);
+
+    ConcurrentTimingExecutor::Config ecfg; ecfg.max_cycles = 20'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+    for (const auto& op : schedule.operations) {
+        if (op.type != schedule::ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        if (id.matrix == MatrixID::A)
+            exec.set_tile_payload(id, TilePayload{T, T, detail::block(a, K, id.ti, id.tk, T)});
+        else
+            exec.set_tile_payload(id, TilePayload{T, T, detail::block(w, N, id.tk, id.tj, T)});
+    }
+    for (const auto& op : schedule.operations) {
+        using schedule::ScheduleOpType;
+        switch (op.type) {
+            case ScheduleOpType::LOAD:      exec.schedule_load(op.tile, op.engine_id); break;
+            case ScheduleOpType::MOVE:      exec.schedule_move(op.tile, op.transpose, op.mover_id); break;
+            case ScheduleOpType::FEED:      exec.schedule_feed(op.tile, op.streamer_id); break;
+            case ScheduleOpType::DRAIN:     exec.schedule_drain(op.tile, op.streamer_id); break;
+            case ScheduleOpType::WRITEBACK: exec.schedule_writeback(op.tile, op.mover_id); break;
+            case ScheduleOpType::STORE:     exec.schedule_store(op.tile, op.engine_id); break;
+            case ScheduleOpType::COMPUTE: {
+                ConcurrentTimingExecutor::MatMulComputeSpec spec;
+                for (const auto& dep : op.dependency_tiles) {
+                    if (dep.matrix == MatrixID::A) spec.a_tiles.push_back(dep);
+                    else                            spec.b_tiles.push_back(dep);
+                }
+                if (!bias.empty()) {
+                    const Size tj = op.tile.tile_id.tj;
+                    spec.bias.assign(bias.begin() + static_cast<std::ptrdiff_t>(tj * T),
+                                     bias.begin() + static_cast<std::ptrdiff_t>(tj * T + T));
+                }
+                if (relu) spec.activation = ConcurrentTimingExecutor::FunctionalActivation::RELU;
+                exec.schedule_matmul_compute(op.tile, spec);
+                break;
+            }
+        }
+    }
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles)
+        exec.step();
+    if (!exec.is_complete()) throw std::runtime_error("run_matmul: did not complete");
+    detail::accumulate(stats, exec);
+
+    std::vector<float> c(static_cast<std::size_t>(M) * N);
+    for (const auto& op : schedule.operations) {
+        if (op.type != schedule::ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        for (Size r = 0; r < T; ++r)
+            for (Size col = 0; col < T; ++col)
+                c[(id.ti * T + r) * N + (id.tj * T + col)] = p.values[r * T + col];
+    }
+    return c;
+}
+
+/**
+ * @brief Global average pool on the CSP executor: mean over the H*W plane per
+ *        (n, c). Input is NCHW; output is [N*C] row-major (the [N,C,1,1] tensor).
+ *
+ * Tiles the plane in Ti = H*W chunks so any spatial extent works (plane % Ti == 0).
+ */
+[[nodiscard]] inline std::vector<float>
+run_global_avg_pool(const std::vector<float>& input,
+                    const schedule::Pool2DGeometry& geom, RunStats& stats) {
+    using namespace sw::kpu::timing::schedule;
+    if (input.size() != geom.elems())
+        throw std::invalid_argument("run_global_avg_pool: input size does not match geometry");
+    const Size plane = geom.H * geom.W;
+    const Size Ti = plane;  // one chunk per channel: plane % Ti == 0 always
+
+    PoolingScheduleGenerator::Config cfg;
+    cfg.geom = geom; cfg.mode = PoolingScheduleGenerator::Mode::GLOBAL_AVG; cfg.Ti = Ti;
+    cfg.input_base = 0x100000; cfg.output_base = 0x400000;
+    auto schedule = PoolingScheduleGenerator(cfg).generate();
+    if (!schedule.valid)
+        throw std::runtime_error("run_global_avg_pool: schedule refused: " + schedule.error_message);
+
+    ConcurrentTimingExecutor::Config ecfg; ecfg.max_cycles = 20'000'000;
+    ConcurrentTimingExecutor exec(ecfg);
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        const std::size_t base = static_cast<std::size_t>(id.ti) * plane + id.tj * Ti;
+        exec.set_tile_payload(id, TilePayload{Ti, 1,
+            std::vector<float>(input.begin() + static_cast<std::ptrdiff_t>(base),
+                               input.begin() + static_cast<std::ptrdiff_t>(base + Ti))});
+    }
+
+    ScheduleExecutor sched_exec(exec);
+    sched_exec.set_functional_compute_binder(
+        [plane](const ScheduleOperation& op)
+            -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+            ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+            spec.input_tiles = op.dependency_tiles;
+            spec.operation = [plane](const std::vector<TilePayload>& in) {
+                float s = 0.0f;
+                for (const auto& t : in) for (float v : t.values) s += v;
+                return TilePayload{1, 1, {s / static_cast<float>(plane)}};
+            };
+            return spec;
+        });
+    auto result = sched_exec.execute(schedule);
+    if (!result.success)
+        throw std::runtime_error("run_global_avg_pool: execution failed: " + result.error_message);
+    stats.total_cycles += result.total_cycles;
+    ++stats.ops;
+
+    std::vector<float> out(static_cast<std::size_t>(geom.N) * geom.C);
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        out[id.ti] = exec.tile_payload_at(MemoryLevel::DRAM, id).values.at(0);
+    }
+    return out;
 }
 
 } // namespace sw::kpu::timing::graph

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -44,6 +44,11 @@ struct NodeData {
     // BATCHNORM raw inference params [C]:
     std::vector<float> gamma, beta, mean, var;
     float eps = 1e-5f;
+    // MATMUL (FC) params: weight [fc_K, fc_N] row-major, optional bias [fc_N].
+    // Dims are carried here because create_matmul exposes no config accessor.
+    std::vector<float> fc_weight, fc_bias;
+    Size fc_M = 0, fc_K = 0, fc_N = 0;
+    bool fc_relu = false;
 };
 
 /**
@@ -154,6 +159,27 @@ public:
                     } else {
                         throw std::runtime_error("GraphCspExecutor: unsupported elementwise op");
                     }
+                    last = id;
+                    break;
+                }
+                case KernelOpType::POOL2D: {
+                    const auto& pc = k.pool2d_config();
+                    if (pc.pool_type != sw::kpu::PoolType::GLOBAL_AVG)
+                        throw std::runtime_error("GraphCspExecutor: only GLOBAL_AVG pooling supported");
+                    schedule::Pool2DGeometry pg;
+                    pg.N = static_cast<Size>(pc.batch_size);
+                    pg.C = static_cast<Size>(pc.channels);
+                    pg.H = static_cast<Size>(pc.input_height);
+                    pg.W = static_cast<Size>(pc.input_width);
+                    out[id] = run_global_avg_pool(input_of(g, id, out, input), pg, result.stats);
+                    last = id;
+                    break;
+                }
+                case KernelOpType::MATMUL: {
+                    if (!nd) throw std::runtime_error("GraphCspExecutor: missing NodeData for matmul node");
+                    out[id] = run_matmul(input_of(g, id, out, input), nd->fc_weight,
+                                         nd->fc_M, nd->fc_N, nd->fc_K, nd->fc_bias,
+                                         nd->fc_relu, T, result.stats);
                     last = id;
                     break;
                 }

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -283,6 +283,16 @@ set_tests_properties(test_m2_resnet18_tower PROPERTIES
     LABELS "timing;m2;resnet;v0.9"
 )
 
+# M2 ResNet head: global-avg-pool -> FC as a KernelGraph DFG on the CSP executor
+# (issue #203, milestone M2) - completes the operator set (POOL2D + MATMUL)
+kpu_add_component_test(test_m2_resnet_head "timing"
+    test_m2_resnet_head.cpp
+)
+
+set_tests_properties(test_m2_resnet_head PROPERTIES
+    LABELS "timing;m2;resnet;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_m2_resnet_head.cpp
+++ b/tests/timing/test_m2_resnet_head.cpp
@@ -1,0 +1,121 @@
+// ============================================================================
+// tests/timing/test_m2_resnet_head.cpp
+// M2-T3 (#203) part B: the ResNet classification HEAD - global-average-pool ->
+// fully-connected - as a KernelGraph DFG executed on the CSP value path through
+// GraphCspExecutor (POOL2D + MATMUL dispatch), validated vs a host oracle.
+// Completes the operator set for the full ResNet-18 (tower from part A + this).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/kernel.hpp>
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/graph_csp_executor.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+using namespace sw::kpu;
+using namespace sw::kpu::timing::graph;
+using sw::kpu::timing::schedule::Pool2DGeometry;
+using sw::kpu::timing::schedule::global_avg_pool_reference;
+
+namespace {
+
+std::vector<float> synth(std::size_t n, uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    uint64_t s = seed * 2654435761ULL + 12345ULL;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<uint32_t>(s >> 33);
+        x = (static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+
+} // namespace
+
+TEST_CASE("M2 ResNet head (global-avg-pool -> FC) on the CSP executor",
+          "[timing][m2][resnet][head]") {
+    // Tower output shape: [N=16, C=32, H=2, W=2]; classify into 16 classes.
+    const Size N = 16, C = 32, H = 2, W = 2, CLASSES = 16;
+
+    Pool2DGeometry pg; pg.N = N; pg.C = C; pg.H = H; pg.W = W;
+    auto x  = synth(pg.elems(), 1, 1.0f);
+    auto wfc = synth(static_cast<std::size_t>(C) * CLASSES, 2, 0.1f);   // [C, CLASSES]
+    auto bfc = synth(CLASSES, 3, 0.2f);
+
+    // --- host oracle: GAP -> [N, C] then FC + bias ----------------------------
+    auto gap = global_avg_pool_reference(x, pg);   // [N*C]
+    std::vector<float> oref(static_cast<std::size_t>(N) * CLASSES, 0.0f);
+    for (Size m = 0; m < N; ++m)
+        for (Size n = 0; n < CLASSES; ++n) {
+            float acc = bfc[n];
+            for (Size k = 0; k < C; ++k)
+                acc += gap[m * C + k] * wfc[k * CLASSES + n];
+            oref[m * CLASSES + n] = acc;
+        }
+
+    // --- DFG: GAP node -> FC node ---------------------------------------------
+    KernelGraph g;
+    auto gp = g.add_kernel(Kernel::create_global_avg_pool2d(N, C, H, W), "gap");
+    auto fc = g.add_kernel(Kernel::create_matmul(N, CLASSES, C), "fc");  // M,N,K
+    g.add_edge(gp, fc);  // gap reads the external input tensor
+
+    std::unordered_map<std::size_t, NodeData> nd;
+    nd[fc].fc_weight = wfc; nd[fc].fc_bias = bfc;
+    nd[fc].fc_M = N; nd[fc].fc_K = C; nd[fc].fc_N = CLASSES;
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, x, nd, /*T*/16);
+
+    REQUIRE(result.output.size() == oref.size());
+    REQUIRE(result.stats.ops == 2);   // GAP + FC, both on the CSP executor
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < oref.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - oref[i]));
+    INFO("head max_err=" << max_err << " cycles=" << result.stats.total_cycles);
+    REQUIRE(max_err < 1e-3f);
+}
+
+TEST_CASE("M2 ResNet head: FC ReLU activation on the CSP executor",
+          "[timing][m2][resnet][head]") {
+    const Size N = 16, C = 16, H = 4, W = 4, CLASSES = 16;
+    Pool2DGeometry pg; pg.N = N; pg.C = C; pg.H = H; pg.W = W;
+    auto x  = synth(pg.elems(), 11, 1.0f);
+    auto wfc = synth(static_cast<std::size_t>(C) * CLASSES, 12, 0.1f);
+    auto bfc = synth(CLASSES, 13, -2.0f);   // negative bias -> exercises the ReLU clamp
+
+    auto gap = global_avg_pool_reference(x, pg);
+    std::vector<float> oref(static_cast<std::size_t>(N) * CLASSES, 0.0f);
+    for (Size m = 0; m < N; ++m)
+        for (Size n = 0; n < CLASSES; ++n) {
+            float acc = bfc[n];
+            for (Size k = 0; k < C; ++k) acc += gap[m * C + k] * wfc[k * CLASSES + n];
+            oref[m * CLASSES + n] = std::max(0.0f, acc);
+        }
+
+    KernelGraph g;
+    auto gp = g.add_kernel(Kernel::create_global_avg_pool2d(N, C, H, W), "gap");
+    auto fc = g.add_kernel(Kernel::create_matmul(N, CLASSES, C), "fc");
+    g.add_edge(gp, fc);
+    std::unordered_map<std::size_t, NodeData> nd;
+    nd[fc].fc_weight = wfc; nd[fc].fc_bias = bfc;
+    nd[fc].fc_M = N; nd[fc].fc_K = C; nd[fc].fc_N = CLASSES; nd[fc].fc_relu = true;
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, x, nd, 16);
+
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < oref.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - oref[i]));
+    INFO("head+relu max_err=" << max_err);
+    REQUIRE(max_err < 1e-3f);
+}


### PR DESCRIPTION
## Summary

M2-T3 **part B** (#203), completing the ResNet-18 operator set for the graph→CSP
bridge (part A delivered the residual tower). The **classification head** —
global-average-pool → fully-connected — now executes as a DFG on the CSP value path.

## What landed

- **`run_global_avg_pool`** — mean over the `H*W` plane per channel, tiling the
  plane as a single `Ti = H*W` chunk so any spatial extent works (reuses the E7
  GLOBAL_AVG pooling value path).
- **`run_matmul`** — the FC GEMM with a bias + ReLU epilogue (reuses the matmul
  value path).
- **`GraphCspExecutor`** POOL2D (`GLOBAL_AVG`) + MATMUL dispatch. FC weights/dims
  ride in `NodeData` (`create_matmul` exposes no config accessor); the
  `Pool2DConfig → Pool2DGeometry` mapping is cast to avoid MSVC C4267.
- **`test_m2_resnet_head`** — a `GAP → FC` `KernelGraph` executed through the
  bridge, validated vs a host oracle **with and without FC ReLU**, asserting both
  ops run on the CSP executor (`ops == 2`).

## Test results

| Check | Result |
|-------|--------|
| `test_m2_resnet_head` | PASS — GAP+FC, ±ReLU, oracle-matched |
| Full `timing` suite | PASS — 47/47 |
| clang `-Wshorten-64-to-32` (MSVC C4267 guard) | clean |
| clang `-Wall -Wextra -Werror` | clean |

## Milestone

**Every ResNet-18 operator now executes as a DFG on the CSP value path** — conv
(im2col→GEMM), BatchNorm (folded), ReLU (fused epilogue + standalone), residual
add, global-average-pool, and FC — with the conv+BN and conv+ReLU fusions. The
**full tower+head assembly + whole-network oracle + benchmark table + Chrome trace
+ writeup** is **T4** (the reproducible `m2_resnet` demo).

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #130
Relates to #203

Generated with [Claude Code](https://claude.com/claude-code)