### PR TITLE
feat(m2): full ResNet-18 demo + benchmark + writeup (M2-T4, #206; closes #130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DNN Milestone M2: ResNet-18 as a DFG on the CSP executor — M2-T4 (#206);
+  milestone #130 achieved.** The full ResNet-18 (stem + four stages of
+  BasicBlocks with stride-2 downsampling + 1x1 projections + global-average-pool +
+  FC) is built via a reusable `include/sw/kpu/timing/graph/resnet18.hpp` builder
+  and executed end-to-end on the credit-based CSP value path through
+  `GraphCspExecutor`, with the conv+BN and conv+ReLU fusions applied. Delivers the
+  three-tier DoD: **demonstrate** (`examples/milestones/m2_resnet` runs the network
+  and emits the `KernelGraph` via `--dot`), **validate** (`test_m2_resnet18` checks
+  the classification output elementwise vs a composed whole-network host oracle,
+  max error ~3e-8, plus the block/tower/head tests), and **benchmark** (a cycles /
+  ops / cyc-per-op / DMA-BM-STR stall table across a spec sweep). Fusion payoff:
+  the `[2,2,2,2]` network's 67 graph nodes execute as 38 CSP ops (every BN folded,
+  every block ReLU fused). Writeup `docs/milestones/M2_resnet.md`; coverage
+  manifest M2 marked achieved. Demo dims are scaled for a fast CSP simulation
+  (batch 16 for FC/conv tile alignment; uniform channels keep the GAP's N*C
+  reductions small); the `[2,2,2,2]` residual depth with channel growth is
+  validated by `test_m2_resnet18_tower`.
+
 - **M2 ResNet classification head (GAP -> FC) on the CSP executor — M2-T3 part B
   (#203).** Completes the ResNet-18 operator set: `run_global_avg_pool` (mean over
   the H*W plane per channel, tiling the plane as one chunk so any spatial extent

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -1,0 +1,100 @@
+# DNN Milestone M2: ResNet-18 on the CSP Executor
+
+**Status:** achieved (capability + demo). Issue #130.
+**Demo:** `examples/milestones/m2_resnet.cpp` (`ctest -R m2_resnet`).
+**Design:** `docs/plans/m2_resnet_dfg.md`.
+
+---
+
+## What M2 delivers
+
+The first recognizable CNN — **ResNet-18** — expressed as a **dataflow graph
+(DFG)** and executed end-to-end on the credit-based CSP concurrent executor, with
+real fp32 values flowing DRAM → L3 → L2 → compute → … The whole network runs
+through one `KernelGraph`, and its classification output is validated elementwise
+against a composed host oracle.
+
+In one artifact this exercises: the operators (conv, folded BatchNorm, ReLU,
+residual add, global-average-pool, FC), the **fusions** (conv+BN fold,
+conv+bias+ReLU epilogue), and the **layout/graph transformations** (im2col,
+topological scheduling, residual-branch structure + fusible-pair analysis).
+
+## Architecture: a KernelGraph DFG + a graph→CSP bridge
+
+ResNet-18 is built as a **`KernelGraph`** (the operator DAG — `add_kernel(
+Kernel::create_conv2d/batchnorm/elementwise/global_avg_pool2d/matmul)`, tensor
+edges, topological order, `find_fusible_pairs`, `to_dot`). It is executed by
+**`GraphCspExecutor`** (`include/sw/kpu/timing/graph/`), which walks the graph in
+topological order and runs each node on the schedule-generator value path
+(`csp_op_runners.hpp`), threading activations between nodes and applying the
+operator fusions as it lowers:
+
+- **conv+BN fold** — a conv's sole-consumer BatchNorm folds its scale/shift into
+  the conv's weights+bias (E9); the BN node does not execute.
+- **conv+ReLU fused epilogue** — a sole-consumer ReLU (directly or through the
+  folded BN) applies in-compute (E10), so `conv→BN→ReLU` is a single GEMM.
+- **im2col layout** — conv lowers to a GEMM over the unfolded `A_col` (E6).
+- **residual add / GAP / FC** — the elementwise ADD joins the (identity or 1×1
+  projected) skip; global-average-pool and FC run on the pooling/matmul value paths.
+
+The graph gives structure, fusion detection, and visualization; the CSP path
+gives oracle-validated numbers and credit/stall benchmarks. Nodes execute
+**sequentially in topological order** — the measured concurrency is the tile-level
+pipeline overlap *within* each op, not operator-branch overlap (a named follow-on).
+
+## Three-tier definition of done
+
+- **Demonstrate.** The full network runs end-to-end on the CSP executor;
+  `m2_resnet --dot FILE` emits the `KernelGraph` (Graphviz).
+- **Validate.** The classification output is compared elementwise against a
+  composed whole-network host oracle (`conv2d_reference` + `batchnorm_reference` +
+  ReLU + add + `global_avg_pool_reference` + matmul). Max error is ~3e-8 —
+  fp-exact at this scale. Per-block and per-network checks:
+  `test_m2_resnet_block`, `test_m2_resnet18_tower` (the `[2,2,2,2]` residual
+  tower), `test_m2_resnet_head` (GAP→FC), `test_m2_resnet18` (full network).
+- **Benchmark.** Cycles, CSP ops (post-fusion), cyc/op, and DMA/BlockMover/
+  Streamer stall breakdown across a small spec sweep (`m2_resnet`).
+
+### Example benchmark output (scaled demo)
+
+```
+configuration           nodes   ops     cycles    cyc/op   dmaStl    bmStl   strStl
+resnet18 (base)            39    22      39881      1813     4322     7696     2939
+resnet18 [2,2,2,2]         67    38      51469      1354     7290    13548     5043
+resnet18 (batch 32)        39    22      72169      3280    10226     8061     2171
+```
+
+**Fusion payoff:** the `[2,2,2,2]` network's 67 graph nodes execute as **38 CSP
+ops** — every BatchNorm folded into its conv, every block-internal ReLU fused as
+an epilogue. The base `[1,1,1,1]` scale runs 39 nodes as 22 ops.
+
+## Scope & scaling notes
+
+- **Dims are scaled for a fast CSP simulation.** The CSP executor models every
+  tile movement cycle-by-cycle, so the demo uses small spatial extents and
+  tile-aligned channels. **batch N=16** is required because the FC's GEMM `M` axis
+  is the batch, and it must be a multiple of the tile size; the same batch keeps
+  every conv GEMM's `M = N·Hout·Wout` aligned. The default demo uses uniform
+  16-channel stages (the global-average-pool does `N·C` per-channel reductions, so
+  its cost scales with the final channel count) at `[1,1,1,1]` depth; the full
+  `[2,2,2,2]` residual depth with channel growth is validated by
+  `test_m2_resnet18_tower`.
+- **Weights are deterministic synthetic** (fixed-seed LCG), and the oracle is
+  computed from the same weights, so validation is exact-to-fp32. Loading trained
+  ResNet weights (ONNX/PyTorch) is an E15 runtime follow-on.
+- **What M2 tests vs. the DFX compiler.** M2 exercises the *operator-level*
+  fusions (conv+BN, conv+ReLU) + im2col + the `KernelGraph` structural passes.
+  The full DFX tiling/dataflow-strategy compiler is matmul-only today (conv2d is a
+  `TODO`); extending it to a whole CNN is a named follow-on, off M2's critical path.
+- **Follow-ons:** ResNet-50 (bottleneck block), trained-weight loading, concurrent
+  multi-node scheduling of execution-level-independent branches, a unified Chrome
+  trace across the network, and the DFX conv compiler.
+
+## Running it
+
+```bash
+cmake --build --preset release --target m2_resnet
+./build/examples/milestones/m2_resnet            # benchmark table + validation
+./build/examples/milestones/m2_resnet --dot resnet18.dot   # + KernelGraph
+ctest -R m2_resnet                               # CI smoke test
+```

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -57,7 +57,7 @@ pipeline overlap *within* each op, not operator-branch overlap (a named follow-o
 
 ### Example benchmark output (scaled demo)
 
-```
+```text
 configuration           nodes   ops     cycles    cyc/op   dmaStl    bmStl   strStl
 resnet18 (base)            39    22      39881      1813     4322     7696     2939
 resnet18 [2,2,2,2]         67    38      51469      1354     7290    13548     5043

--- a/examples/milestones/CMakeLists.txt
+++ b/examples/milestones/CMakeLists.txt
@@ -18,3 +18,15 @@ if(KPU_BUILD_TESTS)
         LABELS "timing;mlp;milestone;v0.9"
     )
 endif()
+
+add_executable(m2_resnet m2_resnet.cpp)
+target_link_libraries(m2_resnet PRIVATE kpu_simulator)
+set_target_properties(m2_resnet PROPERTIES
+    FOLDER "Examples/Milestones"
+)
+if(KPU_BUILD_TESTS)
+    add_test(NAME m2_resnet COMMAND m2_resnet)
+    set_tests_properties(m2_resnet PROPERTIES
+        LABELS "timing;resnet;milestone;v0.9"
+    )
+endif()

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -1,0 +1,138 @@
+/**
+ * @file m2_resnet.cpp
+ * @brief DNN Milestone M2: ResNet-18 as a dataflow graph on the CSP executor.
+ *
+ * The second rung of the DNN milestone ladder (issue #130). The full ResNet-18
+ * (stem + four stages of BasicBlocks + global-average-pool + FC) is expressed as
+ * a KernelGraph DFG and executed end-to-end on the credit-based CSP value path
+ * through GraphCspExecutor, which folds BatchNorm into its conv, fuses the ReLU
+ * epilogue, lowers conv via im2col, and joins the residual branches.
+ *
+ * Three-tier definition of done:
+ *  - Demonstrate: the whole network runs end-to-end on the CSP executor;
+ *    `--dot FILE` emits the KernelGraph for visualization.
+ *  - Validate: the classification output is compared elementwise against a
+ *    composed whole-network host oracle (conv/BN/ReLU/add/GAP/FC references).
+ *  - Benchmark: cycles, CSP ops (post-fusion), cyc/op, and DMA/BM/STR stall
+ *    breakdown across a small spec sweep.
+ *
+ * Usage: m2_resnet [--dot FILE]
+ * Writeup: docs/milestones/M2_resnet.md
+ */
+
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/resnet18.hpp>
+
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing::graph;
+
+namespace {
+
+struct Row {
+    std::string name;
+    std::size_t nodes = 0, ops = 0;
+    bool pass = false;
+    float max_err = 0.0f;
+    RunStats stats;
+};
+
+Row run_spec(const std::string& name, const ResNet18Spec& spec,
+             const std::string& dot_path) {
+    sw::kpu::KernelGraph g;
+    auto net = build_resnet18(g, spec);
+    if (!dot_path.empty()) {
+        std::ofstream f(dot_path);
+        if (f) f << g.to_dot(true);
+    }
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, net.input, net.node_data, /*T*/16);
+
+    Row r;
+    r.name = name;
+    r.nodes = net.num_nodes;
+    r.ops = result.stats.ops;
+    r.stats = result.stats;
+    r.pass = result.output.size() == net.oracle.size();
+    for (std::size_t i = 0; i < result.output.size() && i < net.oracle.size(); ++i)
+        r.max_err = std::max(r.max_err, std::abs(result.output[i] - net.oracle[i]));
+    r.pass = r.pass && r.max_err < 5e-3f;
+    return r;
+}
+
+void print_row(const Row& r) {
+    double cyc_per_op = r.ops ? static_cast<double>(r.stats.total_cycles) / static_cast<double>(r.ops) : 0.0;
+    std::cout << "  " << std::left << std::setw(22) << r.name << std::right
+              << std::setw(7) << r.nodes
+              << std::setw(6) << r.ops
+              << std::setw(11) << r.stats.total_cycles
+              << std::setw(10) << std::fixed << std::setprecision(0) << cyc_per_op
+              << std::setw(9) << r.stats.dma_stalls
+              << std::setw(9) << r.stats.bm_stalls
+              << std::setw(9) << r.stats.str_stalls
+              << std::setw(11) << std::scientific << std::setprecision(1) << r.max_err
+              << std::setw(7) << (r.pass ? "PASS" : "FAIL") << "\n"
+              << std::defaultfloat;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    std::string dot_path;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--dot") == 0 && i + 1 < argc) {
+            dot_path = argv[++i];
+        } else {
+            std::cout << "Usage: " << argv[0] << " [--dot FILE]\n";
+            return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
+        }
+    }
+
+    std::cout << "\n"
+        "======================================================================\n"
+        "DNN Milestone M2: ResNet-18 as a DFG on the CSP concurrent executor\n"
+        "The whole network runs through the credit-based dataflow (conv im2col->\n"
+        "GEMM, folded BN, fused ReLU epilogue, residual adds, global-avg-pool,\n"
+        "FC); outputs are validated elementwise against a host oracle.\n"
+        "======================================================================\n\n";
+
+    std::vector<Row> rows;
+
+    // Default scaled demo, plus two sweeps: wider batch, and deeper channels.
+    ResNet18Spec base;                                   // batch 16, 16ch 8x8
+    rows.push_back(run_spec("resnet18 (base)", base, dot_path));
+
+    ResNet18Spec deeper = base; deeper.blocks_per_stage = 2;   // [2,2,2,2]
+    rows.push_back(run_spec("resnet18 [2,2,2,2]", deeper, {}));
+
+    ResNet18Spec batch32 = base; batch32.batch = 32;
+    rows.push_back(run_spec("resnet18 (batch 32)", batch32, {}));
+
+    std::cout << "  " << std::left << std::setw(22) << "configuration" << std::right
+              << std::setw(7) << "nodes" << std::setw(6) << "ops"
+              << std::setw(11) << "cycles" << std::setw(10) << "cyc/op"
+              << std::setw(9) << "dmaStl" << std::setw(9) << "bmStl"
+              << std::setw(9) << "strStl" << std::setw(11) << "maxErr"
+              << std::setw(7) << "check" << "\n";
+    std::cout << "  " << std::string(97, '-') << "\n";
+
+    bool all_pass = true;
+    for (const auto& r : rows) { print_row(r); all_pass = all_pass && r.pass; }
+
+    std::cout << "\n  Fusion: BatchNorm folded into conv, ReLU fused as the conv"
+                 " epilogue -\n  the base network's " << rows.front().nodes
+              << " graph nodes execute as " << rows.front().ops << " CSP ops.\n";
+    std::cout << "  Validation: " << (all_pass ? "ALL PASS" : "FAILURES PRESENT")
+              << " (oracle: composed whole-network host reference, tol 5e-3)\n";
+    if (!dot_path.empty())
+        std::cout << "  KernelGraph written to " << dot_path << " (Graphviz dot)\n";
+    std::cout << "\n";
+    return all_pass ? 0 : 1;
+}

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -39,6 +39,7 @@ struct Row {
     std::string name;
     std::size_t nodes = 0, ops = 0;
     bool pass = false;
+    bool dot_ok = true;   // false if a requested --dot write failed
     float max_err = 0.0f;
     RunStats stats;
 };
@@ -47,9 +48,11 @@ Row run_spec(const std::string& name, const ResNet18Spec& spec,
              const std::string& dot_path) {
     sw::kpu::KernelGraph g;
     auto net = build_resnet18(g, spec);
+    bool dot_ok = true;
     if (!dot_path.empty()) {
         std::ofstream f(dot_path);
-        if (f) f << g.to_dot(true);
+        f << g.to_dot(true);
+        dot_ok = static_cast<bool>(f);   // open + write succeeded
     }
 
     GraphCspExecutor exec;
@@ -60,6 +63,7 @@ Row run_spec(const std::string& name, const ResNet18Spec& spec,
     r.nodes = net.num_nodes;
     r.ops = result.stats.ops;
     r.stats = result.stats;
+    r.dot_ok = dot_ok;
     r.pass = result.output.size() == net.oracle.size();
     for (std::size_t i = 0; i < result.output.size() && i < net.oracle.size(); ++i)
         r.max_err = std::max(r.max_err, std::abs(result.output[i] - net.oracle[i]));
@@ -131,8 +135,14 @@ int main(int argc, char* argv[]) {
               << " graph nodes execute as " << rows.front().ops << " CSP ops.\n";
     std::cout << "  Validation: " << (all_pass ? "ALL PASS" : "FAILURES PRESENT")
               << " (oracle: composed whole-network host reference, tol 5e-3)\n";
-    if (!dot_path.empty())
-        std::cout << "  KernelGraph written to " << dot_path << " (Graphviz dot)\n";
+    if (!dot_path.empty()) {
+        if (rows.front().dot_ok) {
+            std::cout << "  KernelGraph written to " << dot_path << " (Graphviz dot)\n";
+        } else {
+            std::cerr << "  error: could not write KernelGraph to " << dot_path << "\n";
+            all_pass = false;
+        }
+    }
     std::cout << "\n";
     return all_pass ? 0 : 1;
 }

--- a/include/sw/kpu/timing/graph/resnet18.hpp
+++ b/include/sw/kpu/timing/graph/resnet18.hpp
@@ -50,6 +50,7 @@ struct ResNet18Spec {
     std::vector<Size> stage_channels = {16, 16, 16, 16};
     Size blocks_per_stage = 1;                          // fast default; [2,2,2,2] in the tower test
     Size num_classes = 16;
+    Size tile = 16;   ///< GEMM tile size; batch/channels/num_classes must be multiples
     float eps = 1e-3f;
     std::uint64_t seed = 1000;
 };
@@ -72,8 +73,9 @@ inline std::vector<float> rn_synth(std::size_t n, std::uint64_t seed, float scal
     std::uint64_t s = seed * 2654435761ULL + 12345ULL;
     for (auto& x : v) {
         s = s * 6364136223846793005ULL + 1442695040888963407ULL;
-        auto bits = static_cast<std::uint32_t>(s >> 33);
-        x = (static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+        auto bits = static_cast<std::uint32_t>(s >> 33);   // [0, 0x7FFFFFFF]
+        // Map to [-scale, +scale] (both signs, so ReLU/fusion are exercised).
+        x = (2.0f * static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
     }
     return v;
 }
@@ -136,6 +138,22 @@ inline std::vector<float> rn_conv_bn(const std::vector<float>& x, const std::vec
     using sw::kpu::Kernel;
     using sw::kpu::ElementwiseOp;
     using sw::kpu::ActivationType;
+
+    // Every conv/FC GEMM is tiled at sp.tile; batch (the FC/conv M axis),
+    // channels (K/N), and num_classes (FC N) must be nonzero multiples so the
+    // dimensions are tile-aligned. Fail fast with a clear message here rather
+    // than deep inside a runner.
+    if (sp.tile == 0 || sp.batch == 0 || sp.batch % sp.tile != 0)
+        throw std::invalid_argument("build_resnet18: batch must be a nonzero multiple of tile");
+    if (sp.in_channels == 0 || sp.in_channels % sp.tile != 0)
+        throw std::invalid_argument("build_resnet18: in_channels must be a nonzero multiple of tile");
+    if (sp.num_classes == 0 || sp.num_classes % sp.tile != 0)
+        throw std::invalid_argument("build_resnet18: num_classes must be a nonzero multiple of tile");
+    for (Size ch : sp.stage_channels)
+        if (ch == 0 || ch % sp.tile != 0)
+            throw std::invalid_argument("build_resnet18: stage channels must be nonzero multiples of tile");
+    if (sp.height == 0 || sp.width == 0 || sp.stage_channels.empty() || sp.blocks_per_stage == 0)
+        throw std::invalid_argument("build_resnet18: invalid geometry");
 
     ResNet18 net;
     auto& nd = net.node_data;

--- a/include/sw/kpu/timing/graph/resnet18.hpp
+++ b/include/sw/kpu/timing/graph/resnet18.hpp
@@ -1,0 +1,250 @@
+// ============================================================================
+// include/sw/kpu/timing/graph/resnet18.hpp
+// Reusable ResNet-18 builder: constructs the full network (stem + 4 stages of
+// BasicBlocks + global-average-pool + FC) as a KernelGraph DFG, with matching
+// per-node weights and a composed host oracle (M2-T4, #206). See
+// docs/plans/m2_resnet_dfg.md and docs/milestones/M2_resnet.md.
+//
+// The graph is executed through GraphCspExecutor on the CSP value path; the
+// oracle is the elementwise reference the CSP output is validated against. Both
+// use the same deterministic synthetic weights. Dims are scaled down for a fast
+// CSP demo; batch N keeps every conv GEMM's M = N*Hout*Wout tile-aligned.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/kernel.hpp>
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/graph_csp_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace sw::kpu::timing::graph {
+
+/// ResNet-18 topology (scaled for the CSP demo). Channels are tile-aligned; the
+/// batch keeps every conv GEMM's M = batch*Hout*Wout a multiple of the tile size
+/// (the FC requires batch itself to be a multiple, so batch >= 16).
+///
+/// The default is a fast, CI-friendly scale that exercises the FULL structure
+/// (stem, four stages with stride-2 downsampling + 1x1 projection, GAP, FC). The
+/// [2,2,2,2] block depth of the real ResNet-18 is validated separately by
+/// test_m2_resnet18_tower; here blocks_per_stage defaults to 1 to keep the
+/// tile-by-tile CSP simulation fast. Bump height/width/blocks_per_stage for a
+/// larger run.
+struct ResNet18Spec {
+    Size batch = 16;
+    Size in_channels = 16, height = 4, width = 4;      // stem input (16ch, 4x4)
+    // Uniform channels keep the global-average-pool's N*C per-channel reductions
+    // small (the GAP dominates wall-clock at low spatial); channel growth is
+    // exercised by the tower test. Downsampling (spatial) + projections remain.
+    std::vector<Size> stage_channels = {16, 16, 16, 16};
+    Size blocks_per_stage = 1;                          // fast default; [2,2,2,2] in the tower test
+    Size num_classes = 16;
+    float eps = 1e-3f;
+    std::uint64_t seed = 1000;
+};
+
+/// Built network: the graph is populated into the caller's KernelGraph; this
+/// carries the per-node weights, the synthetic input, the host-oracle output,
+/// and the sink node id.
+struct ResNet18 {
+    std::unordered_map<std::size_t, NodeData> node_data;
+    std::vector<float> input;
+    std::vector<float> oracle;   // [batch, num_classes]
+    std::size_t output_node = 0;
+    std::size_t num_nodes = 0;
+};
+
+namespace detail {
+
+inline std::vector<float> rn_synth(std::size_t n, std::uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    std::uint64_t s = seed * 2654435761ULL + 12345ULL;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<std::uint32_t>(s >> 33);
+        x = (static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+
+inline sw::kpu::Conv2DConfig rn_conv_cfg(Size N, Size Cin, Size Cout, Size H, Size W,
+                                         Size K, Size stride, Size pad) {
+    sw::kpu::Conv2DConfig c;
+    c.batch_size = N; c.in_channels = Cin; c.out_channels = Cout;
+    c.input_height = H; c.input_width = W;
+    c.kernel_height = c.kernel_width = K;
+    c.stride_h = c.stride_w = stride; c.padding_h = c.padding_w = pad;
+    return c;
+}
+inline schedule::Conv2DGeometry rn_geom(const sw::kpu::Conv2DConfig& c) {
+    schedule::Conv2DGeometry g;
+    g.N = static_cast<Size>(c.batch_size); g.C_in = static_cast<Size>(c.in_channels);
+    g.H_in = static_cast<Size>(c.input_height); g.W_in = static_cast<Size>(c.input_width);
+    g.C_out = static_cast<Size>(c.out_channels); g.Kh = static_cast<Size>(c.kernel_height);
+    g.Kw = static_cast<Size>(c.kernel_width); g.stride_h = static_cast<Size>(c.stride_h);
+    g.stride_w = static_cast<Size>(c.stride_w); g.pad_h = static_cast<Size>(c.padding_h);
+    g.pad_w = static_cast<Size>(c.padding_w);
+    return g;
+}
+
+struct RnBN { std::vector<float> gamma, beta, mean, var; float eps; };
+inline RnBN rn_bn(Size C, std::uint64_t seed, float eps) {
+    RnBN b; b.eps = eps;
+    b.gamma = rn_synth(C, seed * 4 + 1, 0.4f); for (auto& g : b.gamma) g += 1.0f;
+    b.beta  = rn_synth(C, seed * 4 + 2, 0.2f);
+    b.mean  = rn_synth(C, seed * 4 + 3, 0.3f);
+    b.var   = rn_synth(C, seed * 4 + 4, 0.2f); for (auto& v : b.var) v = std::abs(v) + 0.5f;
+    return b;
+}
+inline void rn_set_bn(NodeData& nd, const RnBN& bn) {
+    nd.gamma = bn.gamma; nd.beta = bn.beta; nd.mean = bn.mean; nd.var = bn.var; nd.eps = bn.eps;
+}
+// conv (no bias) -> BN inference -> optional ReLU (the host oracle for a conv+BN block).
+inline std::vector<float> rn_conv_bn(const std::vector<float>& x, const std::vector<float>& w,
+                                     const sw::kpu::Conv2DConfig& cc, const RnBN& bn, bool relu) {
+    const auto g = rn_geom(cc);
+    auto z = schedule::conv2d_reference(x, w, {}, g, false);
+    schedule::BatchNormGeometry bg; bg.N = g.N; bg.C = g.C_out; bg.H = g.H_out(); bg.W = g.W_out();
+    auto y = schedule::batchnorm_reference(z, bn.gamma, bn.beta, bn.mean, bn.var, bn.eps, bg);
+    if (relu) for (auto& v : y) v = std::max(0.0f, v);
+    return y;
+}
+
+} // namespace detail
+
+/**
+ * @brief Build the full ResNet-18 into `g`; return weights + input + oracle.
+ *
+ * Topology: stem (3x3 conv -> BN -> ReLU) + four stages of BasicBlocks (the first
+ * block of stages 2-4 stride-2 downsamples with a 1x1 projection skip) ->
+ * global-average-pool -> FC. Execute the returned graph through GraphCspExecutor
+ * and compare its output to `oracle` (tolerance ~5e-3 over the depth).
+ */
+[[nodiscard]] inline ResNet18 build_resnet18(KernelGraph& g, const ResNet18Spec& sp) {
+    using namespace detail;
+    using sw::kpu::Kernel;
+    using sw::kpu::ElementwiseOp;
+    using sw::kpu::ActivationType;
+
+    ResNet18 net;
+    auto& nd = net.node_data;
+    const Size N = sp.batch;
+    std::uint64_t seed = sp.seed;
+
+    net.input = rn_synth(static_cast<std::size_t>(N) * sp.in_channels * sp.height * sp.width,
+                         seed, 1.0f);
+    std::vector<float> ox = net.input;
+    Size cur_ch = sp.in_channels, cur_H = sp.height, cur_W = sp.width;
+
+    auto out_dim = [](Size in, Size K, Size stride, Size pad) {
+        return (in + 2 * pad - K) / stride + 1;
+    };
+
+    // ----- stem: 3x3 s1 conv -> BN -> ReLU ------------------------------------
+    std::size_t in_node;
+    {
+        auto cc = rn_conv_cfg(N, sp.in_channels, sp.in_channels, cur_H, cur_W, 3, 1, 1);
+        auto w = rn_synth(static_cast<std::size_t>(sp.in_channels) * sp.in_channels * 9, seed, 0.1f);
+        auto bn = rn_bn(sp.in_channels, seed, sp.eps);
+        auto c = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "stem_conv");
+        auto b = g.add_kernel(Kernel::create_batchnorm(N, sp.in_channels, cur_H, cur_W, sp.eps), "stem_bn");
+        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU, {sp.in_channels * cur_H * cur_W}), "stem_relu");
+        g.add_edge(c, b); g.add_edge(b, r);
+        nd[c].filter = w; rn_set_bn(nd[b], bn);
+        ox = rn_conv_bn(ox, w, cc, bn, true);
+        in_node = r;
+        ++seed;
+    }
+
+    // ----- 4 stages of BasicBlocks --------------------------------------------
+    for (std::size_t s = 0; s < sp.stage_channels.size(); ++s) {
+        const Size out_ch = sp.stage_channels[s];
+        for (Size blk = 0; blk < sp.blocks_per_stage; ++blk) {
+            const bool downsample = (s > 0 && blk == 0);
+            const Size stride = downsample ? 2 : 1;
+            const Size in_ch = cur_ch;
+            const Size Hd = out_dim(cur_H, 3, stride, 1), Wd = out_dim(cur_W, 3, stride, 1);
+
+            auto cc1 = rn_conv_cfg(N, in_ch, out_ch, cur_H, cur_W, 3, stride, 1);
+            auto cc2 = rn_conv_cfg(N, out_ch, out_ch, Hd, Wd, 3, 1, 1);
+            auto w1 = rn_synth(static_cast<std::size_t>(out_ch) * in_ch * 9, seed, 0.1f);
+            auto w2 = rn_synth(static_cast<std::size_t>(out_ch) * out_ch * 9, seed + 1, 0.1f);
+            auto bn1 = rn_bn(out_ch, seed, sp.eps), bn2 = rn_bn(out_ch, seed + 1, sp.eps);
+
+            auto c1 = g.add_kernel(Kernel::create_conv2d(cc1, false, ActivationType::NONE), "conv1");
+            auto b1 = g.add_kernel(Kernel::create_batchnorm(N, out_ch, Hd, Wd, sp.eps), "bn1");
+            auto r1 = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU, {out_ch * Hd * Wd}), "relu1");
+            auto c2 = g.add_kernel(Kernel::create_conv2d(cc2, false, ActivationType::NONE), "conv2");
+            auto b2 = g.add_kernel(Kernel::create_batchnorm(N, out_ch, Hd, Wd, sp.eps), "bn2");
+            auto ad = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::ADD, {out_ch * Hd * Wd}), "add");
+            auto r2 = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU, {out_ch * Hd * Wd}), "relu2");
+            g.add_edge(in_node, c1); g.add_edge(c1, b1); g.add_edge(b1, r1);
+            g.add_edge(r1, c2); g.add_edge(c2, b2); g.add_edge(b2, ad); g.add_edge(ad, r2);
+            nd[c1].filter = w1; rn_set_bn(nd[b1], bn1);
+            nd[c2].filter = w2; rn_set_bn(nd[b2], bn2);
+
+            auto o1 = rn_conv_bn(ox, w1, cc1, bn1, true);
+            auto o2 = rn_conv_bn(o1, w2, cc2, bn2, false);
+
+            std::vector<float> skip;
+            if (downsample) {
+                auto ccp = rn_conv_cfg(N, in_ch, out_ch, cur_H, cur_W, 1, stride, 0);
+                auto wp = rn_synth(static_cast<std::size_t>(out_ch) * in_ch, seed + 2, 0.1f);
+                auto bnp = rn_bn(out_ch, seed + 2, sp.eps);
+                auto cp = g.add_kernel(Kernel::create_conv2d(ccp, false, ActivationType::NONE), "conv_proj");
+                auto bp = g.add_kernel(Kernel::create_batchnorm(N, out_ch, Hd, Wd, sp.eps), "bn_proj");
+                g.add_edge(in_node, cp); g.add_edge(cp, bp); g.add_edge(bp, ad, "C", "B");
+                nd[cp].filter = wp; rn_set_bn(nd[bp], bnp);
+                skip = rn_conv_bn(ox, wp, ccp, bnp, false);
+            } else {
+                g.add_edge(in_node, ad, "C", "B");
+                skip = ox;
+            }
+            std::vector<float> ores(o2.size());
+            for (std::size_t i = 0; i < o2.size(); ++i) ores[i] = std::max(0.0f, o2[i] + skip[i]);
+            ox = std::move(ores);
+
+            in_node = r2; cur_ch = out_ch; cur_H = Hd; cur_W = Wd;
+            seed += 3;
+        }
+    }
+
+    // ----- head: global-average-pool -> FC ------------------------------------
+    auto gp = g.add_kernel(Kernel::create_global_avg_pool2d(N, cur_ch, cur_H, cur_W), "gap");
+    auto fc = g.add_kernel(Kernel::create_matmul(N, sp.num_classes, cur_ch), "fc");
+    g.add_edge(in_node, gp); g.add_edge(gp, fc);
+
+    auto wfc = rn_synth(static_cast<std::size_t>(cur_ch) * sp.num_classes, seed, 0.1f);
+    auto bfc = rn_synth(sp.num_classes, seed + 1, 0.2f);
+    nd[fc].fc_weight = wfc; nd[fc].fc_bias = bfc;
+    nd[fc].fc_M = N; nd[fc].fc_K = cur_ch; nd[fc].fc_N = sp.num_classes;
+
+    // oracle head
+    schedule::Pool2DGeometry pg; pg.N = N; pg.C = cur_ch; pg.H = cur_H; pg.W = cur_W;
+    auto gap = schedule::global_avg_pool_reference(ox, pg);   // [N*cur_ch]
+    net.oracle.assign(static_cast<std::size_t>(N) * sp.num_classes, 0.0f);
+    for (Size m = 0; m < N; ++m)
+        for (Size n = 0; n < sp.num_classes; ++n) {
+            float acc = bfc[n];
+            for (Size k = 0; k < cur_ch; ++k)
+                acc += gap[m * cur_ch + k] * wfc[k * sp.num_classes + n];
+            net.oracle[m * sp.num_classes + n] = acc;
+        }
+
+    net.output_node = fc;
+    net.num_nodes = g.num_nodes();
+    return net;
+}
+
+} // namespace sw::kpu::timing::graph

--- a/tests/coverage/pattern_coverage.json
+++ b/tests/coverage/pattern_coverage.json
@@ -466,7 +466,7 @@
     {
       "id": "M2",
       "issue": 130,
-      "achieved": false,
+      "achieved": true,
       "requires": [
         {
           "operator": "conv2d",

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -293,6 +293,16 @@ set_tests_properties(test_m2_resnet_head PROPERTIES
     LABELS "timing;m2;resnet;v0.9"
 )
 
+# M2 full ResNet-18 network (issue #206, milestone M2): the complete network built
+# via resnet18.hpp, executed end-to-end as a KernelGraph DFG on the CSP executor
+kpu_add_component_test(test_m2_resnet18 "timing"
+    test_m2_resnet18.cpp
+)
+
+set_tests_properties(test_m2_resnet18 PROPERTIES
+    LABELS "timing;m2;resnet;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_m2_resnet18.cpp
+++ b/tests/timing/test_m2_resnet18.cpp
@@ -1,0 +1,49 @@
+// ============================================================================
+// tests/timing/test_m2_resnet18.cpp
+// M2-T4 (#206): the FULL ResNet-18 (stem + 4 stages + GAP + FC) built via the
+// reusable resnet18.hpp builder, executed end-to-end as a KernelGraph DFG on the
+// CSP value path through GraphCspExecutor, validated against the composed
+// whole-network host oracle. The demonstrate+validate tier of milestone M2 (#130).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/resnet18.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+using namespace sw::kpu::timing::graph;
+
+TEST_CASE("M2 full ResNet-18 (stem + stages + GAP + FC) on the CSP executor",
+          "[timing][m2][resnet][network]") {
+    ResNet18Spec spec;                 // scaled demo: batch 16, 16ch 8x8 input
+    sw::kpu::KernelGraph g;
+    auto net = build_resnet18(g, spec);
+
+    // Structural: the whole network is one connected DAG. Default spec is
+    // [1,1,1,1]: stem (3) + stage1 identity block (7) + 3 downsample blocks (9
+    // each) + head gap/fc (2) = 39 nodes.
+    REQUIRE(g.num_nodes() == net.num_nodes);
+    REQUIRE(g.get_execution_order().size() == g.num_nodes());
+    REQUIRE(g.num_nodes() == 39);
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, net.input, net.node_data, /*T*/16);
+
+    REQUIRE(result.output.size() == net.oracle.size());   // [batch, num_classes]
+    // Fusion contract: stem conv (1) + identity block (4) + 3 downsample blocks
+    // (5 each) + gap + fc = 22 CSP ops (every BN folded, block ReLUs fused).
+    REQUIRE(result.stats.ops == 22);
+
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < net.oracle.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - net.oracle[i]));
+    INFO("ResNet-18 end-to-end max_err=" << max_err << " ops=" << result.stats.ops
+         << " cycles=" << result.stats.total_cycles);
+    REQUIRE(max_err < 5e-3f);
+}


### PR DESCRIPTION
## Summary

M2-T4 (#206), the capstone of **DNN Milestone M2 (#130)**: ResNet-18 runs
**end-to-end as a KernelGraph DFG on the credit-based CSP executor** — the
demonstrate + validate + benchmark tiers that close the milestone.

## What landed

- **`include/sw/kpu/timing/graph/resnet18.hpp`** — reusable `build_resnet18`:
  constructs the full network (stem + 4 stages of BasicBlocks with stride-2
  downsampling + 1×1 projection + global-average-pool + FC) as **one KernelGraph**,
  with matching deterministic weights and a composed whole-network host oracle.
- **`test_m2_resnet18`** — the full network executed through `GraphCspExecutor`,
  validated elementwise vs the oracle (max error ~3e-8), with the exact node/op
  **fusion contract** asserted.
- **`examples/milestones/m2_resnet`** — the demonstrate/validate/benchmark driver:
  runs a spec sweep, prints a cycles / ops / cyc-per-op / DMA-BM-STR stall table,
  validates, and emits the `KernelGraph` via `--dot`. CI smoke test (~4s).
- **`docs/milestones/M2_resnet.md`** — the milestone writeup.
- Coverage manifest: **M2 marked achieved** (all five gate cells done + the demo).

## Benchmark (scaled demo)

```
configuration           nodes   ops     cycles    cyc/op   dmaStl    bmStl   strStl
resnet18 (base)            39    22      39881      1813     4322     7696     2939
resnet18 [2,2,2,2]         67    38      51469      1354     7290    13548     5043
resnet18 (batch 32)        39    22      72169      3280    10226     8061     2171
```

The `[2,2,2,2]` network's **67 graph nodes execute as 38 CSP ops** — every
BatchNorm folded into its conv, every block-internal ReLU fused as an epilogue.

## Test results

| Check | Result |
|-------|--------|
| `test_m2_resnet18` (full network) | PASS — 0.9s, max err ~3e-8 |
| `m2_resnet` demo smoke test | PASS — 4.4s |
| Full `timing` suite | PASS — 49/49 |
| clang `-Wshorten-64-to-32` (MSVC C4267 guard) | clean |

## Scaling notes

Demo dims are scaled for the tile-by-tile CSP simulation: **batch 16** (the FC's
GEMM `M` = batch must be tile-aligned, and it keeps every conv's
`M = N·Hout·Wout` aligned), and uniform channels keep the global-average-pool's
`N·C` per-channel reductions small (the GAP dominates wall-clock at low spatial).
The full **`[2,2,2,2]` residual depth with channel growth** is validated by
`test_m2_resnet18_tower` (part A). Trained-weight loading, ResNet-50, a unified
Chrome trace, and the DFX conv compiler are named follow-ons.

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #130
Relates to #206

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end ResNet-18 milestone demonstration running on the CSP executor.
  - Added configurable ResNet-18 graph generation with convolution, batch normalization, ReLU, residual blocks, pooling, and fully connected layers.
  - Added optional Graphviz graph export and benchmark sweeps with timing and stall statistics.

- **Validation**
  - Added integration coverage comparing execution results against a host reference, including fusion checks and numerical accuracy validation.

- **Documentation**
  - Added milestone documentation covering usage, validation, benchmarking, and simulation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->