### PR TITLE
feat(m3): depthwise conv + ReLU6 on the CSP executor (M3-T2, #209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **M3 depthwise convolution + ReLU6 on the CSP executor — M3-T2 (#209).**
+  `run_depthwise_conv` delivers depthwise conv (`groups = C`) by reusing the E7
+  pooling per-channel window unfold for movement (`pool_window_channel`, 0-filled
+  at padding) and reducing each window row by a **dot-product with that channel's
+  folded filter** (a weighted sum) instead of pooling's max/mean - the M3 design's
+  decision, so depthwise is a Vector-Engine op with no new kernel. Optional folded
+  BatchNorm and a ReLU6 (`min(max(x,0),6)`) epilogue apply in the reduce.
+  `run_relu6` adds the standalone clamp. `test_m3_depthwise` validates the runner
+  elementwise against a host depthwise reference (3x3 s1p1, 3x3 s2p1 downsample,
+  and folded BN + ReLU6). Validated at channel counts up to 16; the underlying
+  pooling windowed schedule deadlocks at C >= 32 (#210, a pre-existing E7
+  limitation) - larger-C depthwise is blocked on that fix. Milestone M3 (#131),
+  design docs/plans/m3_mobilenet_dfg.md.
+
 - **DNN Milestone M2: ResNet-18 as a DFG on the CSP executor — M2-T4 (#206);
   milestone #130 achieved.** The full ResNet-18 (stem + four stages of
   BasicBlocks with stride-2 downsampling + 1x1 projections + global-average-pool +

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -317,6 +317,146 @@ run_matmul(const std::vector<float>& a, const std::vector<float>& w,
 }
 
 /**
+ * @brief Depthwise convolution on the CSP executor (M3-T2, #209).
+ *
+ * Each output channel is the 2D conv of a single input channel with its own
+ * Kh*Kw filter (groups = C). Reuses the E7 pooling per-channel window unfold for
+ * movement (pool_window_channel, 0-filled at padding) and reduces each window row
+ * by a dot-product with that channel's folded filter (a weighted sum) - the M3
+ * design's decision. Optional folded BatchNorm and a ReLU6 epilogue apply in the
+ * reduce, so depthwise+BN+ReLU6 is one CSP op.
+ *
+ *   y[n,c,ho,wo] = act( sum_k window(n,c,ho,wo)[k] * filter[c][k] + bias[c] )
+ *
+ * @param filter per-channel filters, size C*Kh*Kw (row-major [C, Kh, Kw])
+ * @param bn     optional folded BatchNorm affine (size C), or nullptr
+ * @param bias   optional per-channel bias (size C), or empty
+ * @param relu6  apply ReLU6 = min(max(x,0),6) as the epilogue
+ * @param T      tile size (must divide N*Hout*Wout)
+ *
+ * @note Validated at channel counts up to 16. The underlying pooling windowed
+ *       schedule currently deadlocks at C >= 32 (issue #210) - a pre-existing
+ *       E7 limitation, not the reduce; larger-C depthwise is blocked on that fix.
+ */
+[[nodiscard]] inline std::vector<float>
+run_depthwise_conv(const std::vector<float>& input,
+                   const schedule::Pool2DGeometry& geom,
+                   const std::vector<float>& filter, const BatchNormAffine* bn,
+                   const std::vector<float>& bias, bool relu6, Size T, RunStats& stats) {
+    using namespace sw::kpu::timing::schedule;
+    const Size C = geom.C, K = geom.window();
+    const Size Hout = geom.H_out(), Wout = geom.W_out();
+    const Size Mpos = geom.N * Hout * Wout;                 // positions per channel
+    if (input.size() != geom.elems())
+        throw std::invalid_argument("run_depthwise_conv: input size does not match geometry");
+    if (filter.size() != static_cast<std::size_t>(C) * K)
+        throw std::invalid_argument("run_depthwise_conv: filter size must be C*Kh*Kw");
+    if (T == 0 || Mpos % T != 0)
+        throw std::invalid_argument("run_depthwise_conv: T must be > 0 and divide N*Hout*Wout");
+    if (bn && bn->scale.size() != static_cast<std::size_t>(C))
+        throw std::invalid_argument("run_depthwise_conv: bn size must be C");
+    if (!bias.empty() && bias.size() != static_cast<std::size_t>(C))
+        throw std::invalid_argument("run_depthwise_conv: bias size must be C");
+
+    // Fold BN into the per-channel filter + bias.
+    std::vector<float> fw(filter);
+    std::vector<float> fb(bias.empty() ? std::vector<float>(C, 0.0f) : bias);
+    if (bn) {
+        for (Size c = 0; c < C; ++c) {
+            for (Size k = 0; k < K; ++k) fw[c * K + k] *= bn->scale[c];
+            fb[c] = fb[c] * bn->scale[c] + bn->shift[c];
+        }
+    }
+
+    // Per-(n,c) window rows [Hout*Wout, K], 0-filled at padding (AVG mode).
+    std::vector<std::vector<float>> win(static_cast<std::size_t>(geom.N) * C);
+    for (Size n = 0; n < geom.N; ++n)
+        for (Size c = 0; c < C; ++c)
+            win[static_cast<std::size_t>(n) * C + c] =
+                pool_window_channel(input, geom, n, c, PoolType::AVG).rows;
+
+    PoolingScheduleGenerator::Config cfg;
+    cfg.geom = geom; cfg.mode = PoolingScheduleGenerator::Mode::WINDOWED; cfg.Ti = T;
+    cfg.l3_buffer_count = 128; cfg.l2_bank_count = 128;
+    cfg.input_base = 0x100000; cfg.output_base = 0x400000;
+    auto schedule = PoolingScheduleGenerator(cfg).generate();
+    if (!schedule.valid)
+        throw std::runtime_error("run_depthwise_conv: schedule refused: " + schedule.error_message);
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.max_cycles = 50'000'000;
+    ecfg.l3_buffer_count = 128; ecfg.l2_bank_count = 128;
+    ConcurrentTimingExecutor exec(ecfg);
+    // Seed each window tile (channel c = id.ti, output-tile ti = id.tj).
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        const auto id = op.tile.tile_id;
+        const Size c = id.ti, tb = id.tj;
+        std::vector<float> blk(static_cast<std::size_t>(T) * K);
+        for (Size r = 0; r < T; ++r) {
+            const Size p = tb * T + r;                       // flattened position
+            const Size n = p / (Hout * Wout), m = p % (Hout * Wout);
+            const auto& wr = win[static_cast<std::size_t>(n) * C + c];
+            for (Size k = 0; k < K; ++k) blk[r * K + k] = wr[static_cast<std::size_t>(m) * K + k];
+        }
+        exec.set_tile_payload(id, TilePayload{T, K, std::move(blk)});
+    }
+
+    ScheduleExecutor se(exec);
+    se.set_functional_compute_binder(
+        [&fw, &fb, K, C, relu6](const ScheduleOperation& op)
+            -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+            const Size c = op.tile.tile_id.ti;               // output channel
+            ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+            spec.input_tiles = op.dependency_tiles;          // {window tile}
+            spec.operation = [&fw, &fb, K, c, relu6](const std::vector<TilePayload>& in) {
+                const auto& x = in.at(0);                    // [Ti, K]
+                const float* f = &fw[static_cast<std::size_t>(c) * K];
+                const float b = fb[c];
+                TilePayload out{x.rows, 1, std::vector<float>(x.rows)};
+                for (Size r = 0; r < x.rows; ++r) {
+                    const float* row = &x.values[static_cast<std::size_t>(r) * K];
+                    float acc = b;
+                    for (Size k = 0; k < K; ++k) acc += row[k] * f[k];
+                    if (relu6) acc = std::min(std::max(0.0f, acc), 6.0f);
+                    out.values[r] = acc;
+                }
+                return out;
+            };
+            return spec;
+        });
+    (void)C;
+    auto result = se.execute(schedule);
+    if (!result.success)
+        throw std::runtime_error("run_depthwise_conv: execution failed: " + result.error_message);
+    stats.total_cycles += result.total_cycles;
+    ++stats.ops;
+
+    // Read output [C, Mpos] (per-channel positions) -> NCHW.
+    std::vector<float> y(static_cast<std::size_t>(geom.N) * C * Hout * Wout);
+    for (const auto& op : schedule.operations) {
+        if (op.type != ScheduleOpType::STORE) continue;
+        const auto id = op.tile.tile_id;
+        const Size c = id.ti, tb = id.tj;
+        const auto& p = exec.tile_payload_at(MemoryLevel::DRAM, id);
+        for (Size r = 0; r < T; ++r) {
+            const Size pos = tb * T + r;
+            const Size n = pos / (Hout * Wout), m = pos % (Hout * Wout);
+            const Size ho = m / Wout, wo = m % Wout;
+            y[((static_cast<std::size_t>(n) * C + c) * Hout + ho) * Wout + wo] = p.values[r];
+        }
+    }
+    return y;
+}
+
+/// ReLU6 = min(max(x, 0), 6) on the CSP executor (two elementwise ops).
+[[nodiscard]] inline std::vector<float>
+run_relu6(const std::vector<float>& x, RunStats& stats) {
+    auto r = run_elementwise(sw::kpu::isa::VEOp::MAX, x, std::vector<float>(x.size(), 0.0f), stats);
+    return run_elementwise(sw::kpu::isa::VEOp::MIN, r, std::vector<float>(x.size(), 6.0f), stats);
+}
+
+/**
  * @brief Global average pool on the CSP executor: mean over the H*W plane per
  *        (n, c). Input is NCHW; output is [N*C] row-major (the [N,C,1,1] tensor).
  *

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -404,7 +404,7 @@ run_depthwise_conv(const std::vector<float>& input,
 
     ScheduleExecutor se(exec);
     se.set_functional_compute_binder(
-        [&fw, &fb, K, C, relu6](const ScheduleOperation& op)
+        [&fw, &fb, K, relu6](const ScheduleOperation& op)
             -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
             const Size c = op.tile.tile_id.ti;               // output channel
             ConcurrentTimingExecutor::FunctionalComputeSpec spec;
@@ -425,7 +425,6 @@ run_depthwise_conv(const std::vector<float>& input,
             };
             return spec;
         });
-    (void)C;
     auto result = se.execute(schedule);
     if (!result.success)
         throw std::runtime_error("run_depthwise_conv: execution failed: " + result.error_message);

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -303,6 +303,16 @@ set_tests_properties(test_m2_resnet18 PROPERTIES
     LABELS "timing;m2;resnet;v0.9"
 )
 
+# M3 depthwise conv (issue #209, milestone M3): per-channel window unfold + filter
+# dot-product reduce on the CSP executor vs a host depthwise reference; ReLU6
+kpu_add_component_test(test_m3_depthwise "timing"
+    test_m3_depthwise.cpp
+)
+
+set_tests_properties(test_m3_depthwise PROPERTIES
+    LABELS "timing;m3;mobilenet;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_m3_depthwise.cpp
+++ b/tests/timing/test_m3_depthwise.cpp
@@ -1,0 +1,140 @@
+// ============================================================================
+// tests/timing/test_m3_depthwise.cpp
+// M3-T2 (#209): depthwise convolution on the CSP executor via the pooling-window
+// unfold + a per-channel filter dot-product reduce, validated vs a host
+// depthwise reference (with and without folded BN + ReLU6). Plus run_relu6.
+// See docs/plans/m3_mobilenet_dfg.md.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/timing/graph/csp_op_runners.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+using namespace sw::kpu::timing::graph;
+using sw::kpu::timing::schedule::Pool2DGeometry;
+using sw::kpu::timing::schedule::BatchNormAffine;
+using sw::kpu::timing::schedule::bn_fold;
+using G = sw::kpu::timing::Size;
+
+namespace {
+
+std::vector<float> synth(std::size_t n, std::uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    std::uint64_t s = seed * 2654435761ULL + 12345ULL;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<std::uint32_t>(s >> 33);
+        x = (2.0f * static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+
+// Host depthwise conv reference: per-channel 2D conv, optional BN + ReLU6. NCHW.
+std::vector<float> depthwise_reference(const std::vector<float>& x,
+                                       const std::vector<float>& filter,
+                                       const Pool2DGeometry& g,
+                                       const std::vector<float>* gamma,
+                                       const std::vector<float>* beta,
+                                       const std::vector<float>* mean,
+                                       const std::vector<float>* var, float eps,
+                                       bool relu6) {
+    const G Hout = g.H_out(), Wout = g.W_out();
+    std::vector<float> y(static_cast<std::size_t>(g.N) * g.C * Hout * Wout);
+    for (G n = 0; n < g.N; ++n)
+        for (G c = 0; c < g.C; ++c) {
+            const std::size_t plane = (static_cast<std::size_t>(n) * g.C + c) * g.H * g.W;
+            for (G ho = 0; ho < Hout; ++ho)
+                for (G wo = 0; wo < Wout; ++wo) {
+                    float acc = 0.0f;
+                    for (G kh = 0; kh < g.Kh; ++kh) {
+                        const long ih = static_cast<long>(ho * g.stride_h + kh) - static_cast<long>(g.pad_h);
+                        if (ih < 0 || ih >= static_cast<long>(g.H)) continue;
+                        for (G kw = 0; kw < g.Kw; ++kw) {
+                            const long iw = static_cast<long>(wo * g.stride_w + kw) - static_cast<long>(g.pad_w);
+                            if (iw < 0 || iw >= static_cast<long>(g.W)) continue;
+                            acc += x[plane + static_cast<std::size_t>(ih) * g.W + iw] *
+                                   filter[(static_cast<std::size_t>(c) * g.Kh + kh) * g.Kw + kw];
+                        }
+                    }
+                    if (gamma) acc = (*gamma)[c] * (acc - (*mean)[c]) / std::sqrt((*var)[c] + eps) + (*beta)[c];
+                    if (relu6) acc = std::min(std::max(0.0f, acc), 6.0f);
+                    y[((static_cast<std::size_t>(n) * g.C + c) * Hout + ho) * Wout + wo] = acc;
+                }
+        }
+    return y;
+}
+
+Pool2DGeometry geom(G N, G C, G H, G W, G K, G s, G p) {
+    Pool2DGeometry g; g.N = N; g.C = C; g.H = H; g.W = W;
+    g.Kh = g.Kw = K; g.stride_h = g.stride_w = s; g.pad_h = g.pad_w = p;
+    return g;
+}
+
+float maxerr(const std::vector<float>& a, const std::vector<float>& b) {
+    float e = 0.0f;
+    for (std::size_t i = 0; i < a.size() && i < b.size(); ++i) e = std::max(e, std::abs(a[i] - b[i]));
+    return e;
+}
+
+} // namespace
+
+TEST_CASE("M3 depthwise conv on the CSP executor matches host reference",
+          "[timing][m3][depthwise]") {
+    // batch 16 keeps M = N*Hout*Wout tile-aligned; C independent per channel.
+    RunStats st;
+
+    SECTION("3x3 stride1 pad1") {
+        auto g = geom(16, 16, 4, 4, 3, 1, 1);
+        auto x = synth(g.elems(), 1, 1.0f);
+        auto f = synth(static_cast<std::size_t>(g.C) * g.window(), 2, 0.5f);
+        auto csp = run_depthwise_conv(x, g, f, nullptr, {}, false, 16, st);
+        auto ref = depthwise_reference(x, f, g, nullptr, nullptr, nullptr, nullptr, 0.0f, false);
+        REQUIRE(csp.size() == ref.size());
+        REQUIRE(maxerr(csp, ref) < 1e-4f);
+    }
+    SECTION("3x3 stride2 pad1 (downsample)") {
+        auto g = geom(16, 16, 8, 8, 3, 2, 1);
+        auto x = synth(g.elems(), 3, 1.0f);
+        auto f = synth(static_cast<std::size_t>(g.C) * g.window(), 4, 0.5f);
+        auto csp = run_depthwise_conv(x, g, f, nullptr, {}, false, 16, st);
+        auto ref = depthwise_reference(x, f, g, nullptr, nullptr, nullptr, nullptr, 0.0f, false);
+        REQUIRE(maxerr(csp, ref) < 1e-4f);
+    }
+    SECTION("with folded BN + ReLU6") {
+        auto g = geom(16, 16, 4, 4, 3, 1, 1);
+        auto x = synth(g.elems(), 5, 1.0f);
+        auto f = synth(static_cast<std::size_t>(g.C) * g.window(), 6, 0.5f);
+        auto gamma = synth(g.C, 7, 0.3f); for (auto& v : gamma) v += 1.0f;
+        auto beta  = synth(g.C, 8, 0.3f);
+        auto mean  = synth(g.C, 9, 0.3f);
+        auto var   = synth(g.C, 10, 0.2f); for (auto& v : var) v = std::abs(v) + 0.5f;
+        const float eps = 1e-3f;
+        auto affine = bn_fold(gamma, beta, mean, var, eps);
+        auto csp = run_depthwise_conv(x, g, f, &affine, {}, /*relu6*/true, 16, st);
+        auto ref = depthwise_reference(x, f, g, &gamma, &beta, &mean, &var, eps, true);
+        REQUIRE(maxerr(csp, ref) < 1e-3f);
+    }
+}
+
+TEST_CASE("M3 run_relu6 clamps to [0,6] on the CSP executor",
+          "[timing][m3][depthwise]") {
+    RunStats st;
+    std::vector<float> x(256);
+    for (std::size_t i = 0; i < x.size(); ++i)
+        x[i] = -8.0f + 0.1f * static_cast<float>(i);   // spans below 0 and above 6
+    auto csp = run_relu6(x, st);
+    REQUIRE(csp.size() == x.size());
+    for (std::size_t i = 0; i < x.size(); ++i)
+        REQUIRE_THAT(csp[i], Catch::Matchers::WithinAbs(std::min(std::max(0.0f, x[i]), 6.0f), 1e-5));
+}


### PR DESCRIPTION
## Summary

M3-T2 (#209), following the merged M3 design (#208). Depthwise convolution and
ReLU6 on the CSP value path — the core new operators MobileNetV2 needs — added to
the M2 graph→CSP runner set.

## What landed

- **`run_depthwise_conv`** — delivers depthwise conv (`groups = C`) via the M3
  design's decision: reuse the **E7 pooling per-channel window unfold** for
  movement (`pool_window_channel`, 0-filled at padding) and reduce each window row
  by a **dot-product with that channel's folded filter** (a weighted sum) instead
  of pooling's max/mean. It's a Vector-Engine op — no new kernel, no grouped GEMM.
  Optional folded BatchNorm and a ReLU6 (`min(max(x,0),6)`) epilogue apply in the
  reduce, so depthwise+BN+ReLU6 is one CSP op.
- **`run_relu6`** — the standalone clamp.
- **`test_m3_depthwise`** — validates the runner elementwise vs a host depthwise
  reference (`3×3 s1p1`, `3×3 s2p1` downsample, folded BN + ReLU6) and `run_relu6`.

## Test results

| Check | Result |
|-------|--------|
| `test_m3_depthwise` | PASS — depthwise ±BN ±ReLU6, run_relu6 (0.23s) |
| Full `timing` suite | PASS — 50/50 |
| clang `-Wshorten-64-to-32` (MSVC C4267 guard) | clean |

## Known limitation (filed)

Validated at channel counts **up to 16**. The underlying **pooling windowed
schedule deadlocks at C ≥ 32** — isolated by testing (C=16/8×8/s2 completes,
C=32/8×8/s2 deadlocks, only the channel count differs; a generous envelope
doesn't help). This is a **pre-existing E7 limitation** (the pooling regression
only went to C=16), not the depthwise reduce — filed as **#210** and noted on the
runner. Larger-C depthwise is blocked on that fix; the M3 demo will use modest
channel counts (as the M2 demo did).

## Next

Sigmoid + broadcast-multiply (squeeze-and-excitation, EfficientNet-only) come with
the EfficientNet block in T3; MobileNetV2 (T3a) needs only depthwise + ReLU6 +
pointwise (done) + add (done).

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC)
- [ ] CodeRabbit review resolved
- [ ] Promote to ready

Relates to #131
Relates to #209

Generated with [Claude Code](https://claude.com/claude-code)