### PR TITLE
feat(m3): MobileNetV2 inverted-residual block as a KernelGraph DFG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MobileNetV2 inverted-residual block as a KernelGraph DFG on the CSP executor
+  — M3-T3 (#131).** The inverted-residual bottleneck (`1x1 expand -> BN -> ReLU6
+  -> 3x3 depthwise -> BN -> ReLU6 -> 1x1 project -> BN`, with a residual add when
+  `stride == 1 && Cin == Cout`) now builds as a `KernelGraph` and executes
+  end-to-end through `GraphCspExecutor`, validated against a composed host oracle
+  (`test_m3_mobilenet_block`: identity-skip and stride-2 downsample variants,
+  max_err < 1e-3). Bridge additions (`graph_csp_executor.hpp`): a `CONV2D` node
+  with `groups == in_channels` dispatches to `run_depthwise_conv` (pooling-window
+  unfold + per-channel filter reduce) instead of im2col GEMM, with BN folding
+  identically; a new `ElementwiseOp::RELU6` runs as a standalone clamp
+  (`run_relu6`, the design's permitted form). Fusion Pass 2 never folds an
+  activation onto a depthwise node (`run_depthwise_conv` applies only ReLU6, so a
+  fused plain-RELU could not be honored). `ElementwiseOp::RELU6` also implemented
+  in the behavioral and transactional compute fabrics. This M3 block reuses the
+  M2 pointwise-conv / BN-fold / residual-add path unchanged and exercises the
+  #210 fix (depthwise at realistic channel counts). Design
+  docs/plans/m3_mobilenet_dfg.md.
+
 - **M3 depthwise convolution + ReLU6 on the CSP executor — M3-T2 (#209).**
   `run_depthwise_conv` delivers depthwise conv (`groups = C`) by reusing the E7
   pooling per-channel window unfold for movement (`pool_window_channel`, 0-filled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   identically; a new `ElementwiseOp::RELU6` runs as a standalone clamp
   (`run_relu6`, the design's permitted form). Fusion Pass 2 never folds an
   activation onto a depthwise node (`run_depthwise_conv` applies only ReLU6, so a
-  fused plain-RELU could not be honored). `ElementwiseOp::RELU6` also implemented
-  in the behavioral and transactional compute fabrics. This M3 block reuses the
+  fused plain-RELU could not be honored), and the bridge rejects a depthwise
+  channel multiplier (`Cout != Cin`) rather than mis-sizing the result.
+  `ElementwiseOp::RELU6` is a first-class typed activation - `kernels::relu6` +
+  `dispatch_relu6` across all float formats (FP32/FP16/BF16/FP8/FP4), routed
+  through the behavioral fabric's typed dispatch alongside RELU/GELU/SILU (the
+  transactional fabric stays FP32-only, consistent with its other elementwise
+  ops). This M3 block reuses the
   M2 pointwise-conv / BN-fold / residual-add path unchanged and exercises the
   #210 fix (depthwise at realistic channel counts). Design
   docs/plans/m3_mobilenet_dfg.md.

--- a/docs/sessions/2026-07-16_v0.9_m3t3-mobilenet-block.md
+++ b/docs/sessions/2026-07-16_v0.9_m3t3-mobilenet-block.md
@@ -1,0 +1,94 @@
+# Session Log — 2026-07-16 — M3-T3: MobileNetV2 inverted-residual block DFG
+
+**Milestone:** M3 (#131) — MobileNetV2 + EfficientNet-B0
+**Branch:** `feat/m3t3-mobilenet-block`
+**Fidelity tier:** CYCLE_ACCURATE (CSP timing executor, value path)
+**Builds on:** M2 graph->CSP bridge, M3-T2 depthwise/ReLU6 runners (#209), #210 fix.
+
+## Goal
+
+Express the MobileNetV2 inverted-residual bottleneck as a `KernelGraph` DFG and
+run it end-to-end on the CSP executor, reusing the M2 bridge and the M3-T2
+`run_depthwise_conv` / `run_relu6` runners.
+
+Block: `1x1 expand -> BN -> ReLU6 -> 3x3 depthwise (stride s) -> BN -> ReLU6 ->
+1x1 project -> BN`, residual add when `stride == 1 && Cin == Cout` (linear
+bottleneck, no activation after the add).
+
+## What was done
+
+The M3-T2 runners existed but the bridge did not dispatch to them, and ReLU6 was
+absent from every enum. Added:
+
+- **`ElementwiseOp::RELU6`** (`resource_api.hpp`) + name string, and implemented
+  it in the behavioral and transactional compute fabrics (both switches are
+  exhaustive with no default, so `-Wswitch` required the case).
+- **Bridge depthwise dispatch** (`graph_csp_executor.hpp`): a `CONV2D` node with
+  `groups > 1 && groups == in_channels` builds a `Pool2DGeometry` and calls
+  `run_depthwise_conv` (BN folds via the existing CONV2D fold path); pointwise
+  1x1 convs stay on `run_conv2d_fused`.
+- **Bridge ReLU6 dispatch**: a standalone `ELEMENTWISE RELU6` node runs
+  `run_relu6` (the design's permitted clamp form).
+- **Fusion guard**: Pass 2 never fuses an activation onto a depthwise conv
+  (`run_depthwise_conv` applies only ReLU6, so a fused plain-RELU could not be
+  honored and would be silently dropped) — depthwise activations stay standalone.
+- **`test_m3_mobilenet_block`**: identity-skip (stride 1, Cin=Cout=16, hidden=32)
+  and stride-2 downsample (Cin=16 -> Cout=32, hidden=48) variants, validated vs a
+  composed host oracle (pointwise conv+BN+ReLU6, per-channel depthwise+BN+ReLU6,
+  residual). Asserts the fused CSP op-count contract.
+
+## Decisions
+
+- **ReLU6 as a standalone VE op, not a fused conv epilogue.** The design prefers
+  the fused form where the producer is a conv/depthwise, but `run_conv2d_fused`
+  only applies plain ReLU (adding ReLU6 there means touching the compute-fabric
+  activation epilogue / `ActivationType`). The design's honest scope (Section 4)
+  explicitly permits the post-op clamp `min(relu(x),6)`, which `run_relu6` already
+  is. Standalone is uniform across the expand (pointwise) and depthwise legs and
+  needs no epilogue surgery. Fused ReLU6 remains an optimization follow-on.
+- **`ElementwiseOp::RELU6` (new enum value) vs MAX/MIN-with-constants.** The
+  enum value mirrors the existing unary `RELU` cleanly; the MAX/MIN composition
+  would need constant operand tensors and MAX/MIN bridge dispatch. Verified the
+  blast radius: only the two compute-fabric switches (exhaustive, no default)
+  needed a case; all name/compiler switches have defaults.
+- **Depthwise detection by `groups == in_channels`** (per the M3 design), guarded
+  with `groups > 1` so a 1-channel normal conv is not misclassified (and is
+  numerically identical anyway).
+
+## Wrong decisions
+
+- Initially assumed appending an `ElementwiseOp` value was switch-safe because
+  the existing switches "must have defaults." Two compute-fabric switches are in
+  fact exhaustive with no default; the build caught it via `-Werror=switch`.
+  Corrected by implementing `RELU6` in both fabrics. Lesson: appending an enum
+  value is only free where every switch has a `default:` — verify, don't assume.
+- Initially expected each ReLU6 node = 1 CSP op; `run_relu6` issues 2 VE ops
+  (MAX then MIN). Values were already correct; only the op-count contract was
+  off. Fixed the expected count (7 ops without residual, 8 with).
+
+## Validation
+
+- `test_m3_mobilenet_block`: both variants pass, max_err < 1e-3, op-count
+  contract met (identity 9 nodes -> 8 ops; downsample 8 nodes -> 7 ops).
+- Full timing suite: **100% (51/51) passed**.
+- Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the test TU
+  (the bridge header is covered transitively).
+
+## Modified files
+
+- `include/sw/kpu/resource_api.hpp` — `ElementwiseOp::RELU6` + name.
+- `include/sw/kpu/timing/graph/graph_csp_executor.hpp` — depthwise + ReLU6
+  dispatch; fusion guard against fusing onto depthwise.
+- `src/models/behavioral/compute/compute_fabric.cpp` — RELU6 case.
+- `src/models/transactional/compute/compute_fabric.cpp` — RELU6 case.
+- `tests/timing/test_m3_mobilenet_block.cpp` — new block test.
+- `tests/timing/CMakeLists.txt` — register the test.
+- `CHANGELOG.md`, `docs/sessions/2026-07-16_v0.9_m3t3-mobilenet-block.md`.
+
+## Follow-on
+
+- EfficientNet-B0 MBConv + squeeze-and-excitation (sigmoid unary +
+  channel-broadcast multiply runners) — the remaining T3 half.
+- M3-T4: full MobileNetV2 + EfficientNet-B0 builders (reusable header like
+  `resnet18.hpp`), demo, benchmark, writeup `docs/milestones/M3_mobilenet.md`.
+- Optional: fused ReLU6 conv epilogue (op-count reduction).

--- a/docs/sessions/2026-07-16_v0.9_m3t3-mobilenet-block.md
+++ b/docs/sessions/2026-07-16_v0.9_m3t3-mobilenet-block.md
@@ -74,14 +74,33 @@ absent from every enum. Added:
 - Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the test TU
   (the bridge header is covered transitively).
 
+## CodeRabbit review (PR #213)
+
+Two Major findings, both addressed:
+
+1. **Depthwise channel multiplier.** `groups == Cin` also admits `Cout = k*Cin`
+   (k>1); `run_depthwise_conv` emits one output channel per input channel, so
+   such a graph would be mis-sized. The bridge now rejects `Cout != Cin` with a
+   clear throw (regression: "channel multiplier is rejected" test case).
+2. **RELU6 typed dispatch.** RELU6 fell to the behavioral fabric's FP32-only
+   fallback, silently producing no output for non-FP32. Made RELU6 a first-class
+   typed activation (`kernels::relu6` + `dispatch_relu6` over all float formats),
+   routed through the typed dispatch alongside RELU/GELU/SILU. Rejected the
+   alternative of building only an FP32 special-case (leaves the silent-drop trap)
+   and the do-nothing "consistent with SUB/DIV" reply (RELU6 is an activation and
+   belongs with the typed activations).
+
 ## Modified files
 
 - `include/sw/kpu/resource_api.hpp` — `ElementwiseOp::RELU6` + name.
 - `include/sw/kpu/timing/graph/graph_csp_executor.hpp` — depthwise + ReLU6
-  dispatch; fusion guard against fusing onto depthwise.
-- `src/models/behavioral/compute/compute_fabric.cpp` — RELU6 case.
-- `src/models/transactional/compute/compute_fabric.cpp` — RELU6 case.
-- `tests/timing/test_m3_mobilenet_block.cpp` — new block test.
+  dispatch; fusion guard against fusing onto depthwise; channel-multiplier reject.
+- `include/sw/kpu/quantization/kernels.hpp` — `kernels::relu6` template.
+- `include/sw/kpu/quantization/type_dispatch.hpp` — `execute_typed_relu6` +
+  `dispatch_relu6` (all float formats).
+- `src/models/behavioral/compute/compute_fabric.cpp` — RELU6 typed dispatch + FP32 case.
+- `src/models/transactional/compute/compute_fabric.cpp` — RELU6 FP32 case.
+- `tests/timing/test_m3_mobilenet_block.cpp` — new block test + multiplier-reject.
 - `tests/timing/CMakeLists.txt` — register the test.
 - `CHANGELOG.md`, `docs/sessions/2026-07-16_v0.9_m3t3-mobilenet-block.md`.
 

--- a/include/sw/kpu/quantization/kernels.hpp
+++ b/include/sw/kpu/quantization/kernels.hpp
@@ -199,6 +199,17 @@ void relu(const Scalar* X, Scalar* Y, size_t count) {
     }
 }
 
+/// ReLU6 activation: Y = min(max(0, X), 6) - MobileNetV2 activation
+template<typename Scalar>
+void relu6(const Scalar* X, Scalar* Y, size_t count) {
+    const Scalar zero = Scalar(0);
+    const Scalar six = Scalar(6);
+    for (size_t i = 0; i < count; ++i) {
+        const Scalar x = X[i];
+        Y[i] = (x < zero) ? zero : (x > six ? six : x);
+    }
+}
+
 /// In-place ReLU activation
 template<typename Scalar>
 void relu_inplace(Scalar* X, size_t count) {

--- a/include/sw/kpu/quantization/type_dispatch.hpp
+++ b/include/sw/kpu/quantization/type_dispatch.hpp
@@ -98,6 +98,14 @@ void execute_typed_relu(const void* input, void* output, uint64_t count) {
                   static_cast<size_t>(count));
 }
 
+/// Execute ReLU6 with explicit scalar type
+template<typename Scalar>
+void execute_typed_relu6(const void* input, void* output, uint64_t count) {
+    kernels::relu6(static_cast<const Scalar*>(input),
+                   static_cast<Scalar*>(output),
+                   static_cast<size_t>(count));
+}
+
 /// Execute GELU with explicit scalar type
 template<typename Scalar>
 void execute_typed_gelu(const void* input, void* output, uint64_t count) {
@@ -315,6 +323,39 @@ inline void dispatch_relu(DataType dtype, const void* input, void* output, uint6
         default:
             throw std::invalid_argument(
                 "Unsupported DataType for ReLU dispatch: " + dtype_name(dtype));
+    }
+}
+
+/// Dispatch elementwise ReLU6 based on DataType
+inline void dispatch_relu6(DataType dtype, const void* input, void* output, uint64_t count) {
+    switch (dtype) {
+        case DataType::FLOAT32:
+            detail::execute_typed_relu6<float>(input, output, count);
+            break;
+        case DataType::FLOAT16:
+            detail::execute_typed_relu6<fp16_t>(input, output, count);
+            break;
+        case DataType::BFLOAT16:
+            detail::execute_typed_relu6<bf16_t>(input, output, count);
+            break;
+        case DataType::FP8_E4M3:
+            detail::execute_typed_relu6<fp8e4m3_t>(input, output, count);
+            break;
+        case DataType::FP8_E5M2:
+            detail::execute_typed_relu6<fp8e5m2_t>(input, output, count);
+            break;
+        case DataType::FP8_E3M4:
+            detail::execute_typed_relu6<fp8e3m4_t>(input, output, count);
+            break;
+        case DataType::FP8_E2M5:
+            detail::execute_typed_relu6<fp8e2m5_t>(input, output, count);
+            break;
+        case DataType::FP4:
+            detail::execute_typed_relu6<fp4_t>(input, output, count);
+            break;
+        default:
+            throw std::invalid_argument(
+                "Unsupported DataType for ReLU6 dispatch: " + dtype_name(dtype));
     }
 }
 

--- a/include/sw/kpu/resource_api.hpp
+++ b/include/sw/kpu/resource_api.hpp
@@ -482,6 +482,7 @@ enum class ElementwiseOp : uint8_t {
     EXP = 13,
     LOG = 14,
     SILU = 15,
+    RELU6 = 16,   // min(max(x,0),6) - MobileNetV2 activation (M3)
     // Scalar operations (second operand is scalar, broadcast)
     ADD_SCALAR = 20,
     MUL_SCALAR = 21,
@@ -509,6 +510,7 @@ inline const char* elementwise_op_name(ElementwiseOp op) {
         case ElementwiseOp::EXP: return "exp";
         case ElementwiseOp::LOG: return "log";
         case ElementwiseOp::SILU: return "silu";
+        case ElementwiseOp::RELU6: return "relu6";
         case ElementwiseOp::ADD_SCALAR: return "add_scalar";
         case ElementwiseOp::MUL_SCALAR: return "mul_scalar";
         case ElementwiseOp::POW_SCALAR: return "pow_scalar";

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -106,6 +106,11 @@ public:
             if (g.get_kernel(*prod).op_type() == KernelOpType::CONV2D) conv = *prod;
             else if (auto it = bn_to_conv.find(*prod); it != bn_to_conv.end()) conv = it->second;
             if (conv != static_cast<std::size_t>(-1)) {
+                // Never fuse onto a depthwise conv: run_depthwise_conv applies
+                // only ReLU6, so a fused plain-RELU could not be honored and
+                // would be silently dropped - keep it as a standalone node.
+                const auto& conv_cc = g.get_kernel(conv).conv2d_config();
+                if (conv_cc.groups > 1 && conv_cc.groups == conv_cc.in_channels) continue;
                 fuse_relu[conv] = id;
                 consumed[id] = true;
             }
@@ -136,7 +141,32 @@ public:
                         bn = &affine;
                     }
                     const bool relu = fuse_relu.count(id) > 0;
-                    auto y = run_conv2d_fused(x, nd->filter, geom, bn, nd->bias, relu, T, result.stats);
+                    std::vector<float> y;
+                    // Depthwise conv (groups == Cin, MobileNet): each output
+                    // channel is the 2D conv of a single input channel with its
+                    // own filter - delivered via the pooling-window unfold +
+                    // per-channel filter reduce (run_depthwise_conv), not im2col
+                    // GEMM. BN folds identically. Activations stay standalone
+                    // nodes (never fused onto depthwise - see fusion Pass 2),
+                    // so relu6 is always false here; run_depthwise_conv applies
+                    // only ReLU6, so a fused plain-RELU must not reach it.
+                    if (cc.groups > 1 && cc.groups == cc.in_channels) {
+                        schedule::Pool2DGeometry pg;
+                        pg.N = static_cast<Size>(cc.batch_size);
+                        pg.C = static_cast<Size>(cc.in_channels);
+                        pg.H = static_cast<Size>(cc.input_height);
+                        pg.W = static_cast<Size>(cc.input_width);
+                        pg.Kh = static_cast<Size>(cc.kernel_height);
+                        pg.Kw = static_cast<Size>(cc.kernel_width);
+                        pg.stride_h = static_cast<Size>(cc.stride_h);
+                        pg.stride_w = static_cast<Size>(cc.stride_w);
+                        pg.pad_h = static_cast<Size>(cc.padding_h);
+                        pg.pad_w = static_cast<Size>(cc.padding_w);
+                        y = run_depthwise_conv(x, pg, nd->filter, bn, nd->bias,
+                                               /*relu6*/ false, T, result.stats);
+                    } else {
+                        y = run_conv2d_fused(x, nd->filter, geom, bn, nd->bias, relu, T, result.stats);
+                    }
                     out[id] = y;
                     // Fused BN / ReLU nodes alias this output for their consumers.
                     if (auto it = fold_bn.find(id); it != fold_bn.end()) out[it->second] = y;
@@ -156,6 +186,10 @@ public:
                         out[id] = run_elementwise(sw::kpu::isa::VEOp::ADD, a, b, result.stats);
                     } else if (op == ElementwiseOp::RELU) {
                         out[id] = run_relu(input_of(g, id, out, input), result.stats);
+                    } else if (op == ElementwiseOp::RELU6) {
+                        // MobileNetV2 activation clamp min(max(x,0),6), run as a
+                        // standalone VE op (the design's permitted clamp form).
+                        out[id] = run_relu6(input_of(g, id, out, input), result.stats);
                     } else {
                         throw std::runtime_error("GraphCspExecutor: unsupported elementwise op");
                     }

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -150,7 +150,15 @@ public:
                     // nodes (never fused onto depthwise - see fusion Pass 2),
                     // so relu6 is always false here; run_depthwise_conv applies
                     // only ReLU6, so a fused plain-RELU must not reach it.
-                    if (cc.groups > 1 && cc.groups == cc.in_channels) {
+                    const bool depthwise = cc.groups > 1 && cc.groups == cc.in_channels;
+                    // groups == Cin also admits a channel-multiplier depthwise
+                    // (Cout = k*Cin, k>1); run_depthwise_conv produces exactly
+                    // one output channel per input channel, so reject k>1 rather
+                    // than silently mis-size the result.
+                    if (depthwise && cc.out_channels != cc.in_channels)
+                        throw std::runtime_error(
+                            "GraphCspExecutor: depthwise channel multiplier (Cout != Cin) unsupported");
+                    if (depthwise) {
                         schedule::Pool2DGeometry pg;
                         pg.N = static_cast<Size>(cc.batch_size);
                         pg.C = static_cast<Size>(cc.in_channels);

--- a/src/models/behavioral/compute/compute_fabric.cpp
+++ b/src/models/behavioral/compute/compute_fabric.cpp
@@ -174,6 +174,10 @@ std::optional<uint64_t> BehavioralComputeFabric::submit_elementwise(
             dispatch_relu(desc.dtype, a_data, output_data, desc.count);
             dispatched = true;
             break;
+        case ElementwiseOp::RELU6:
+            dispatch_relu6(desc.dtype, a_data, output_data, desc.count);
+            dispatched = true;
+            break;
         case ElementwiseOp::GELU:
             dispatch_gelu(desc.dtype, a_data, output_data, desc.count);
             dispatched = true;

--- a/src/models/behavioral/compute/compute_fabric.cpp
+++ b/src/models/behavioral/compute/compute_fabric.cpp
@@ -613,6 +613,11 @@ void BehavioralComputeFabric::execute_elementwise_fp32(
         case ElementwiseOp::RELU:
             for (uint64_t i = 0; i < count; ++i) output[i] = std::max(0.0f, a[i]);
             break;
+        case ElementwiseOp::RELU6:
+            // ReLU6(x) = min(max(x, 0), 6) - MobileNetV2 activation.
+            for (uint64_t i = 0; i < count; ++i)
+                output[i] = std::min(std::max(0.0f, a[i]), 6.0f);
+            break;
         case ElementwiseOp::GELU:
             // GELU(x) = x * 0.5 * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
             for (uint64_t i = 0; i < count; ++i) {

--- a/src/models/transactional/compute/compute_fabric.cpp
+++ b/src/models/transactional/compute/compute_fabric.cpp
@@ -621,6 +621,11 @@ void TransactionalComputeFabric::execute_elementwise_fp32(
         case ElementwiseOp::RELU:
             for (uint64_t i = 0; i < count; ++i) output[i] = std::max(0.0f, a[i]);
             break;
+        case ElementwiseOp::RELU6:
+            // ReLU6(x) = min(max(x, 0), 6) - MobileNetV2 activation.
+            for (uint64_t i = 0; i < count; ++i)
+                output[i] = std::min(std::max(0.0f, a[i]), 6.0f);
+            break;
         case ElementwiseOp::GELU:
             for (uint64_t i = 0; i < count; ++i) {
                 float x = a[i];

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -313,6 +313,16 @@ set_tests_properties(test_m3_depthwise PROPERTIES
     LABELS "timing;m3;mobilenet;v0.9"
 )
 
+# M3 MobileNetV2 inverted-residual block (milestone M3): expand/depthwise/project
+# + ReLU6 + residual as a KernelGraph DFG on the CSP value path vs a host oracle.
+kpu_add_component_test(test_m3_mobilenet_block "timing"
+    test_m3_mobilenet_block.cpp
+)
+
+set_tests_properties(test_m3_mobilenet_block PROPERTIES
+    LABELS "timing;m3;mobilenet;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_m3_mobilenet_block.cpp
+++ b/tests/timing/test_m3_mobilenet_block.cpp
@@ -252,3 +252,21 @@ TEST_CASE("M3 MobileNetV2 inverted-residual block (stride-2 downsample, no skip)
     INFO("downsample max_err=" << max_err);
     REQUIRE(max_err < 1e-3f);
 }
+
+TEST_CASE("M3 depthwise channel multiplier (Cout != Cin) is rejected",
+          "[timing][m3][mobilenet]") {
+    // groups == Cin also admits a channel-multiplier depthwise (Cout = k*Cin);
+    // run_depthwise_conv produces one output channel per input channel, so the
+    // bridge must reject k>1 rather than silently mis-size the result.
+    const G N = 16, C = 16, H = 8, W = 8;
+    auto cc = conv_cfg(N, C, 2 * C, H, W, 3, 1, 1, /*groups*/C);   // Cout = 2*Cin
+    auto x = synth(static_cast<std::size_t>(N) * C * H * W, 3, 1.0f);
+
+    KernelGraph g;
+    std::unordered_map<std::size_t, NodeData> nd;
+    auto cd = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "dw_mult");
+    nd[cd].filter = synth(static_cast<std::size_t>(C) * 9, 4, 0.3f);
+
+    GraphCspExecutor exec;
+    REQUIRE_THROWS_AS(exec.run(g, x, nd, /*T*/16), std::runtime_error);
+}

--- a/tests/timing/test_m3_mobilenet_block.cpp
+++ b/tests/timing/test_m3_mobilenet_block.cpp
@@ -1,0 +1,254 @@
+// ============================================================================
+// tests/timing/test_m3_mobilenet_block.cpp
+// M3-T3 (#131): a MobileNetV2 inverted-residual block expressed as a KernelGraph
+// DFG, executed on the CSP value path through GraphCspExecutor, validated vs a
+// composed host oracle. Exercises the M3 bridge additions - depthwise conv
+// dispatch (groups == Cin -> run_depthwise_conv) and the standalone ReLU6 op -
+// in composition with the M2 pointwise-conv/BN-fold/residual-add path.
+//
+//   expand 1x1 (Cin -> hidden) -> BN -> ReLU6
+//   3x3 depthwise (groups=hidden, stride s) -> BN -> ReLU6
+//   project 1x1 (hidden -> Cout) -> BN            (linear bottleneck, no act)
+//   + residual  when s == 1 && Cin == Cout        (no activation after add)
+//
+// See docs/plans/m3_mobilenet_dfg.md.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/kernel.hpp>
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/graph_csp_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+using namespace sw::kpu;
+using namespace sw::kpu::timing::graph;
+using sw::kpu::timing::schedule::Conv2DGeometry;
+using sw::kpu::timing::schedule::BatchNormGeometry;
+using sw::kpu::timing::schedule::Pool2DGeometry;
+using G = sw::kpu::timing::Size;
+
+namespace {
+
+// Deterministic weights in [-scale, +scale] (both signs exercise ReLU6 clamps).
+std::vector<float> synth(std::size_t n, std::uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    std::uint64_t s = seed * 2654435761ULL + 12345ULL;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<std::uint32_t>(s >> 33);
+        x = (2.0f * static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+
+void relu6_ip(std::vector<float>& v) {
+    for (auto& x : v) x = std::min(std::max(0.0f, x), 6.0f);
+}
+
+sw::kpu::Conv2DConfig conv_cfg(G N, G Cin, G Cout, G H, G W, G K, G stride, G pad, G groups) {
+    sw::kpu::Conv2DConfig c;
+    c.batch_size = N; c.in_channels = Cin; c.out_channels = Cout;
+    c.input_height = H; c.input_width = W;
+    c.kernel_height = c.kernel_width = K;
+    c.stride_h = c.stride_w = stride; c.padding_h = c.padding_w = pad;
+    c.groups = groups;
+    return c;
+}
+Conv2DGeometry geom_of(const sw::kpu::Conv2DConfig& c) {
+    Conv2DGeometry g;
+    g.N = static_cast<G>(c.batch_size); g.C_in = static_cast<G>(c.in_channels);
+    g.H_in = static_cast<G>(c.input_height); g.W_in = static_cast<G>(c.input_width);
+    g.C_out = static_cast<G>(c.out_channels); g.Kh = static_cast<G>(c.kernel_height);
+    g.Kw = static_cast<G>(c.kernel_width); g.stride_h = static_cast<G>(c.stride_h);
+    g.stride_w = static_cast<G>(c.stride_w); g.pad_h = static_cast<G>(c.padding_h);
+    g.pad_w = static_cast<G>(c.padding_w);
+    return g;
+}
+Pool2DGeometry dw_geom(const sw::kpu::Conv2DConfig& c) {
+    Pool2DGeometry g;
+    g.N = static_cast<G>(c.batch_size); g.C = static_cast<G>(c.in_channels);
+    g.H = static_cast<G>(c.input_height); g.W = static_cast<G>(c.input_width);
+    g.Kh = static_cast<G>(c.kernel_height); g.Kw = static_cast<G>(c.kernel_width);
+    g.stride_h = static_cast<G>(c.stride_h); g.stride_w = static_cast<G>(c.stride_w);
+    g.pad_h = static_cast<G>(c.padding_h); g.pad_w = static_cast<G>(c.padding_w);
+    return g;
+}
+
+struct BN { std::vector<float> gamma, beta, mean, var; float eps = 1e-3f; };
+BN synth_bn(G C, std::uint64_t seed) {
+    BN b;
+    b.gamma = synth(C, seed + 1, 0.4f); for (auto& g : b.gamma) g += 1.0f;   // ~1
+    b.beta  = synth(C, seed + 2, 0.2f);
+    b.mean  = synth(C, seed + 3, 0.3f);
+    b.var   = synth(C, seed + 4, 0.2f); for (auto& v : b.var) v = std::abs(v) + 0.5f;  // >0
+    return b;
+}
+void set_bn(NodeData& nd, const BN& bn) {
+    nd.gamma = bn.gamma; nd.beta = bn.beta; nd.mean = bn.mean; nd.var = bn.var; nd.eps = bn.eps;
+}
+
+// Host oracle: standard (pointwise) conv -> BN inference -> optional ReLU6. NCHW.
+std::vector<float> pw_conv_bn(const std::vector<float>& x, const std::vector<float>& w,
+                              const sw::kpu::Conv2DConfig& cc, const BN& bn, bool relu6) {
+    const auto g = geom_of(cc);
+    auto z = sw::kpu::timing::schedule::conv2d_reference(x, w, {}, g, false);
+    BatchNormGeometry bg; bg.N = g.N; bg.C = g.C_out; bg.H = g.H_out(); bg.W = g.W_out();
+    auto y = sw::kpu::timing::schedule::batchnorm_reference(z, bn.gamma, bn.beta,
+                                                            bn.mean, bn.var, bn.eps, bg);
+    if (relu6) relu6_ip(y);
+    return y;
+}
+
+// Host oracle: per-channel depthwise conv -> BN inference -> optional ReLU6. NCHW.
+std::vector<float> dw_conv_bn(const std::vector<float>& x, const std::vector<float>& filter,
+                              const sw::kpu::Conv2DConfig& cc, const BN& bn, bool relu6) {
+    const auto g = dw_geom(cc);
+    const G Hout = g.H_out(), Wout = g.W_out();
+    std::vector<float> y(static_cast<std::size_t>(g.N) * g.C * Hout * Wout);
+    for (G n = 0; n < g.N; ++n)
+        for (G c = 0; c < g.C; ++c) {
+            const std::size_t plane = (static_cast<std::size_t>(n) * g.C + c) * g.H * g.W;
+            const float scale = bn.gamma[c] / std::sqrt(bn.var[c] + bn.eps);
+            const float shift = bn.beta[c] - bn.mean[c] * scale;
+            for (G ho = 0; ho < Hout; ++ho)
+                for (G wo = 0; wo < Wout; ++wo) {
+                    float acc = 0.0f;
+                    for (G kh = 0; kh < g.Kh; ++kh) {
+                        const long ih = static_cast<long>(ho * g.stride_h + kh) - static_cast<long>(g.pad_h);
+                        if (ih < 0 || ih >= static_cast<long>(g.H)) continue;
+                        for (G kw = 0; kw < g.Kw; ++kw) {
+                            const long iw = static_cast<long>(wo * g.stride_w + kw) - static_cast<long>(g.pad_w);
+                            if (iw < 0 || iw >= static_cast<long>(g.W)) continue;
+                            acc += x[plane + static_cast<std::size_t>(ih) * g.W + iw] *
+                                   filter[(static_cast<std::size_t>(c) * g.Kh + kh) * g.Kw + kw];
+                        }
+                    }
+                    acc = acc * scale + shift;
+                    if (relu6) acc = std::min(std::max(0.0f, acc), 6.0f);
+                    y[((static_cast<std::size_t>(n) * g.C + c) * Hout + ho) * Wout + wo] = acc;
+                }
+        }
+    return y;
+}
+
+// Build the inverted-residual block graph + node data + host oracle. Returns the
+// expected output and the number of CSP ops the fusion should collapse to.
+struct BuildResult { std::vector<float> oracle; std::size_t expected_ops; std::size_t nodes; };
+
+BuildResult build_block(KernelGraph& g, std::unordered_map<std::size_t, NodeData>& nd,
+                        const std::vector<float>& x, G N, G Cin, G Cout, G H, G W,
+                        G hidden, G stride) {
+    const bool residual = (stride == 1 && Cin == Cout);
+    const G Hd = (H + 2 * 1 - 3) / stride + 1, Wd = (W + 2 * 1 - 3) / stride + 1;
+
+    // configs
+    auto cce = conv_cfg(N, Cin, hidden, H, W, 1, 1, 0, 1);            // expand 1x1
+    auto ccd = conv_cfg(N, hidden, hidden, H, W, 3, stride, 1, hidden); // depthwise 3x3
+    auto ccp = conv_cfg(N, hidden, Cout, Hd, Wd, 1, 1, 0, 1);         // project 1x1
+
+    // weights
+    auto we = synth(static_cast<std::size_t>(hidden) * Cin, 10, 0.15f);
+    auto wd = synth(static_cast<std::size_t>(hidden) * 9, 20, 0.30f);  // [hidden,3,3]
+    auto wp = synth(static_cast<std::size_t>(Cout) * hidden, 30, 0.15f);
+    BN bne = synth_bn(hidden, 100), bnd = synth_bn(hidden, 200), bnp = synth_bn(Cout, 300);
+
+    // --- host oracle ---------------------------------------------------------
+    auto e  = pw_conv_bn(x, we, cce, bne, /*relu6*/true);
+    auto d  = dw_conv_bn(e, wd, ccd, bnd, /*relu6*/true);
+    auto p  = pw_conv_bn(d, wp, ccp, bnp, /*relu6*/false);
+    std::vector<float> oref = p;
+    if (residual) for (std::size_t i = 0; i < oref.size(); ++i) oref[i] += x[i];
+
+    // --- DFG -----------------------------------------------------------------
+    auto ce = g.add_kernel(Kernel::create_conv2d(cce, false, ActivationType::NONE), "expand");
+    auto be = g.add_kernel(Kernel::create_batchnorm(N, hidden, H, W, bne.eps), "bn_e");
+    auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * H * W}), "relu6_e");
+    auto cd = g.add_kernel(Kernel::create_conv2d(ccd, false, ActivationType::NONE), "depthwise");
+    auto bd = g.add_kernel(Kernel::create_batchnorm(N, hidden, Hd, Wd, bnd.eps), "bn_d");
+    auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * Hd * Wd}), "relu6_d");
+    auto cp = g.add_kernel(Kernel::create_conv2d(ccp, false, ActivationType::NONE), "project");
+    auto bp = g.add_kernel(Kernel::create_batchnorm(N, Cout, Hd, Wd, bnp.eps), "bn_p");
+    g.add_edge(ce, be); g.add_edge(be, re); g.add_edge(re, cd);
+    g.add_edge(cd, bd); g.add_edge(bd, rd); g.add_edge(rd, cp); g.add_edge(cp, bp);
+
+    nd[ce].filter = we; set_bn(nd[be], bne);
+    nd[cd].filter = wd; set_bn(nd[bd], bnd);
+    nd[cp].filter = wp; set_bn(nd[bp], bnp);
+
+    std::size_t nodes = 8;
+    // CSP op count (each fused conv/depthwise = 1 op; run_relu6 issues 2 VE ops,
+    // MAX then MIN): expand(1) + ReLU6(2) + depthwise(1) + ReLU6(2) + project(1)
+    // = 7; + the residual ADD (1) when present.
+    std::size_t ops = 7;
+    if (residual) {
+        auto ad = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::ADD, {Cout * Hd * Wd}), "add");
+        g.add_edge(bp, ad, "C", "B");   // main branch; 2nd operand = block input (identity skip)
+        ++nodes; ++ops;
+    }
+    return {oref, ops, nodes};
+}
+
+} // namespace
+
+TEST_CASE("M3 MobileNetV2 inverted-residual block (identity skip) on the CSP executor",
+          "[timing][m3][mobilenet]") {
+    // Tile-aligned (T=16): N=16, Cin=Cout=16, hidden=32 (expansion t=2), stride 1.
+    const G N = 16, C = 16, H = 8, W = 8, hidden = 32;
+    auto x = synth(static_cast<std::size_t>(N) * C * H * W, 1, 1.0f);
+
+    KernelGraph g;
+    std::unordered_map<std::size_t, NodeData> nd;
+    auto built = build_block(g, nd, x, N, C, C, H, W, hidden, /*stride*/1);
+
+    REQUIRE(g.num_nodes() == built.nodes);   // 9: 3 conv + 3 BN + 2 relu6 + add
+    REQUIRE(g.get_execution_order().size() == built.nodes);
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, x, nd, /*T*/16);
+
+    REQUIRE(result.output.size() == built.oracle.size());
+    REQUIRE(result.stats.ops == built.expected_ops);   // 8
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < built.oracle.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - built.oracle[i]));
+    INFO("identity max_err=" << max_err << " ops=" << result.stats.ops
+         << " cycles=" << result.stats.total_cycles);
+    REQUIRE(max_err < 1e-3f);
+}
+
+TEST_CASE("M3 MobileNetV2 inverted-residual block (stride-2 downsample, no skip)",
+          "[timing][m3][mobilenet]") {
+    // Downsampling block: stride 2, channel change 16 -> 32, hidden = 48 (t=3).
+    // No residual (stride != 1), so the block sink is the project BN.
+    const G N = 16, Cin = 16, Cout = 32, H = 8, W = 8, hidden = 48;
+    auto x = synth(static_cast<std::size_t>(N) * Cin * H * W, 2, 1.0f);
+
+    KernelGraph g;
+    std::unordered_map<std::size_t, NodeData> nd;
+    auto built = build_block(g, nd, x, N, Cin, Cout, H, W, hidden, /*stride*/2);
+
+    REQUIRE(g.num_nodes() == built.nodes);   // 8: no add
+    GraphCspExecutor exec;
+    auto result = exec.run(g, x, nd, 16);
+
+    REQUIRE(result.output.size() == built.oracle.size());
+    REQUIRE(result.stats.ops == built.expected_ops);   // 7
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < built.oracle.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - built.oracle[i]));
+    INFO("downsample max_err=" << max_err);
+    REQUIRE(max_err < 1e-3f);
+}


### PR DESCRIPTION
## Summary

M3-T3 (milestone #131). Expresses the **MobileNetV2 inverted-residual bottleneck** as a `KernelGraph` DFG and runs it end-to-end on the CSP value path through `GraphCspExecutor`, validated against a composed host oracle. Reuses the M2 pointwise-conv / BN-fold / residual-add path unchanged and the M3-T2 depthwise/ReLU6 runners; exercises the #210 fix at realistic depthwise channel counts.

Block:
```
1x1 expand  -> BN -> ReLU6
3x3 depthwise (stride s) -> BN -> ReLU6
1x1 project -> BN                       (linear bottleneck, no activation)
+ residual   when stride==1 && Cin==Cout (no activation after add)
```

## Bridge additions (`graph_csp_executor.hpp`)

- **Depthwise dispatch**: a `CONV2D` node with `groups > 1 && groups == in_channels` builds a `Pool2DGeometry` and calls `run_depthwise_conv` (pooling-window unfold + per-channel filter reduce) instead of im2col GEMM; BN folds via the existing CONV2D fold path. Pointwise 1×1 convs stay on `run_conv2d_fused`.
- **ReLU6**: new `ElementwiseOp::RELU6` runs as a standalone clamp via `run_relu6` (the design's permitted post-op form, `docs/plans/m3_mobilenet_dfg.md` §4). Also implemented in the behavioral + transactional compute fabrics (both switches are exhaustive with no default, so `-Wswitch` requires the case).
- **Fusion guard**: Pass 2 never fuses an activation onto a depthwise conv — `run_depthwise_conv` applies only ReLU6, so a fused plain-RELU could not be honored and would be silently dropped, so it stays a standalone node.

## Design notes

- **ReLU6 standalone, not fused epilogue.** `run_conv2d_fused` only applies plain ReLU; adding fused ReLU6 means touching the compute-fabric activation epilogue. The design explicitly permits the `min(relu(x),6)` clamp, which `run_relu6` already is, and it is uniform across the pointwise expand and the depthwise legs. Fused ReLU6 is a named optimization follow-on.
- Each `run_relu6` is **2 VE ops** (MAX then MIN), reflected in the op-count contract.

## Test

`test_m3_mobilenet_block` — identity-skip (stride 1, Cin=Cout=16, hidden=32) and stride-2 downsample (16→32, hidden=48) variants, validated vs a host oracle (pointwise conv+BN+ReLU6, per-channel depthwise+BN+ReLU6, residual). `max_err < 1e-3`; fused op-count contract (9 nodes → 8 ops; 8 nodes → 7 ops).

## Test Results

| Target | build | test |
|--------|-------|------|
| test_m3_mobilenet_block | OK | PASS |
| full timing suite | OK | 100% (51/51) |

Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the touched test TU (bridge header covered transitively).

## Scope / follow-on

- EfficientNet-B0 MBConv + squeeze-and-excitation (sigmoid + channel-broadcast multiply runners) — the remaining T3 half.
- M3-T4: full MobileNetV2 + EfficientNet-B0 builders, demo, benchmark, writeup.

Part of milestone #131.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MobileNetV2 inverted-residual blocks, including depthwise convolutions and identity skip connections.
  * Added RELU6 activation support.
  * Enabled end-to-end execution through the CSP graph executor.

* **Bug Fixes**
  * Improved depthwise convolution handling to preserve correct activation execution.

* **Tests**
  * Added coverage for identity and stride-2 MobileNetV2 block variants, including output accuracy and performance-contract validation.

* **Documentation**
  * Added release notes and a session log documenting the MobileNetV2 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->