### PR TITLE
feat(m3): full MobileNetV2 network as a KernelGraph DFG + demo (M3-T4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Full MobileNetV2 network as a KernelGraph DFG on the CSP executor — M3-T4
+  (#131), MobileNetV2 milestone achieved.** `build_mobilenetv2`
+  (`include/sw/kpu/timing/graph/mobilenetv2.hpp`) assembles the whole network
+  (stem `3x3 conv->BN->ReLU6` + inverted-residual bottleneck stack + `1x1` head
+  conv `->BN->ReLU6` + global-average-pool + FC) as a reusable `KernelGraph`
+  builder with matching per-node weights and a composed host oracle, executed
+  end-to-end through `GraphCspExecutor`. Every operator lowers through the M2/M3
+  bridge unchanged: BN folds into each conv, pointwise `1x1` convs dispatch to
+  im2col->GEMM and depthwise convs (`groups == Cin`) to the pooling-window path,
+  ReLU6 runs as a standalone VE clamp, and the identity residuals join via
+  explicit graph edges (so blocks thread correctly through the stack - the
+  external-input fallback would resolve to the whole-network input). Delivered
+  demonstrate / validate / benchmark: `examples/milestones/m3_mobilenet.cpp`
+  (`--dot` KernelGraph export + a base/deeper/batch-32 sweep with cycles/ops/stall
+  table), `test_m3_mobilenet` (full network vs oracle, `max_err ~1e-7`, +
+  tile-alignment guard), and writeup `docs/milestones/M3_mobilenet.md`. Milestone
+  M3 (#131); EfficientNet-B0 MBConv + SE remains a tracked follow-on.
+
 - **MobileNetV2 inverted-residual block as a KernelGraph DFG on the CSP executor
   — M3-T3 (#131).** The inverted-residual bottleneck (`1x1 expand -> BN -> ReLU6
   -> 3x3 depthwise -> BN -> ReLU6 -> 1x1 project -> BN`, with a residual add when

--- a/docs/milestones/M3_mobilenet.md
+++ b/docs/milestones/M3_mobilenet.md
@@ -38,7 +38,9 @@ reusing the M2 bridge unchanged and the M3 depthwise/ReLU6 dispatch:
 - **inverted-residual bottleneck stack** — each block is `1×1 expand → BN → ReLU6
   → 3×3 depthwise (stride s) → BN → ReLU6 → 1×1 project → BN`, with an **identity
   residual** (an explicit graph edge, so blocks thread correctly through the
-  stack) when `stride == 1 && Cin == Cout`. The project is a *linear* bottleneck
+  stack) when `stride == 1 && Cin == Cout`. As in real MobileNetV2, the `t == 1`
+  bottleneck omits the expansion conv and feeds the input straight into the
+  depthwise. The project is a *linear* bottleneck
   (no activation), and there is **no activation after the residual add** — the
   MobileNetV2 distinction from ResNet.
 - **head** — `1×1 conv → BN → ReLU6 → global-average-pool → FC`.

--- a/docs/milestones/M3_mobilenet.md
+++ b/docs/milestones/M3_mobilenet.md
@@ -1,0 +1,86 @@
+# DNN Milestone M3: MobileNetV2 on the CSP Executor
+
+**Status:** MobileNetV2 achieved (capability + demo). Issue #131.
+**Demo:** `examples/milestones/m3_mobilenet.cpp` (`ctest -R m3_mobilenet`).
+**Design:** `docs/plans/m3_mobilenet_dfg.md`. **Template:** M2 (`docs/milestones/M2_resnet.md`).
+
+---
+
+## What M3 delivers
+
+**MobileNetV2** — the inverted-residual, depthwise-separable CNN — expressed as a
+**dataflow graph (DFG)** and executed end-to-end on the credit-based CSP
+concurrent executor, with real fp32 values flowing DRAM → L3 → L2 → compute → …
+The whole network runs through one `KernelGraph`, and its classification output
+is validated elementwise against a composed host oracle.
+
+Beyond M2's operator set, M3 adds the two things that define MobileNetV2:
+
+- **Depthwise convolution** (`groups = Cin`) — each output channel is the 2D conv
+  of a *single* input channel with its own `Kh×Kw` filter. It lowers not through
+  im2col+GEMM (which assumes a full cross-channel reduction) but through the E7
+  **pooling-window unfold + a per-channel filter dot-product reduce**
+  (`run_depthwise_conv`), the M3 design's key decision — a Vector-Engine op, no
+  new systolic kernel.
+- **ReLU6** (`min(max(x, 0), 6)`) — MobileNetV2's activation, a first-class typed
+  elementwise op (`ElementwiseOp::RELU6`) on the CSP path.
+
+Both were delivered in M3-T2/T3; M3-T4 (this milestone) assembles them into the
+**full network** and its demonstrate / validate / benchmark artifact.
+
+## Architecture: a KernelGraph DFG + the M2/M3 bridge
+
+MobileNetV2 is built by `build_mobilenetv2` (`include/sw/kpu/timing/graph/
+mobilenetv2.hpp`) as a **`KernelGraph`** and executed by **`GraphCspExecutor`**,
+reusing the M2 bridge unchanged and the M3 depthwise/ReLU6 dispatch:
+
+- **stem** — `3×3 s1 conv → BN → ReLU6`.
+- **inverted-residual bottleneck stack** — each block is `1×1 expand → BN → ReLU6
+  → 3×3 depthwise (stride s) → BN → ReLU6 → 1×1 project → BN`, with an **identity
+  residual** (an explicit graph edge, so blocks thread correctly through the
+  stack) when `stride == 1 && Cin == Cout`. The project is a *linear* bottleneck
+  (no activation), and there is **no activation after the residual add** — the
+  MobileNetV2 distinction from ResNet.
+- **head** — `1×1 conv → BN → ReLU6 → global-average-pool → FC`.
+
+As it lowers, the bridge folds each BatchNorm into its conv, dispatches pointwise
+`1×1` convs to the im2col→GEMM path and depthwise convs (`groups == Cin`) to the
+pooling-window path, runs ReLU6 as a standalone Vector-Engine clamp, and joins the
+identity residuals with an elementwise ADD.
+
+## Definition of done
+
+- **Demonstrate** — the whole network runs end-to-end on the CSP executor;
+  `--dot FILE` emits the `KernelGraph` for visualization.
+- **Validate** — the classification output is compared elementwise against a
+  composed whole-network host oracle (pointwise conv / depthwise conv / BN /
+  ReLU6 / add / GAP / FC references), `max_err < 5e-3` (observed ~1e-7).
+- **Benchmark** — cycles, CSP ops (post-fusion), cyc/op, and DMA/BM/STR stall
+  breakdown across a small spec sweep (base / an extra bottleneck stage / batch
+  32).
+
+## Scale and honest scope
+
+Dimensions are scaled for a fast CSP simulation (as M2), preserving the
+tile-alignment discipline: batch `N` (the FC/conv `M` axis) and all channel counts
+are multiples of the tile size. The default topology is a compact but complete
+MobileNetV2 — expansion, depthwise, a stride-2 downsample, identity residuals, the
+`1×1` head, GAP and FC — kept small so the tile-by-tile CSP simulation stays fast
+(the global-average-pool's `N·C` per-channel reductions dominate wall-clock at low
+spatial, so the head width is kept modest; channel/depth scaling is exercised by
+the sweep). The DFX tiling/dataflow compiler remains matmul-only (unchanged from
+M2) — M3 tests operator-level fusions + the depthwise pooling-window reuse, not a
+full CNN compiler.
+
+**EfficientNet-B0** (MBConv + squeeze-and-excitation) is the remaining M3 block
+and is tracked separately: its SE gate needs a sigmoid runner and a per-channel
+broadcast-multiply on the CSP path (SiLU approximated by ReLU6 for the subset).
+
+## Files
+
+- `include/sw/kpu/timing/graph/mobilenetv2.hpp` — reusable `build_mobilenetv2`
+  builder + composed host oracle + `MobileNetV2Spec`.
+- `examples/milestones/m3_mobilenet.cpp` — demonstrate / validate / benchmark
+  driver (`--dot`, spec sweep).
+- `tests/timing/test_m3_mobilenet.cpp` — full network vs oracle + spec guard.
+- `tests/timing/test_m3_mobilenet_block.cpp` — the inverted-residual block (M3-T3).

--- a/docs/sessions/2026-07-16_v0.9_m3t4-mobilenet-model.md
+++ b/docs/sessions/2026-07-16_v0.9_m3t4-mobilenet-model.md
@@ -1,0 +1,80 @@
+# Session Log — 2026-07-16 — M3-T4: full MobileNetV2 network + demo
+
+**Milestone:** M3 (#131) — MobileNetV2 (achieved) + EfficientNet-B0 (follow-on)
+**Branch:** `feat/m3t4-mobilenet-model`
+**Fidelity tier:** CYCLE_ACCURATE (CSP timing executor, value path)
+**Builds on:** M2 graph->CSP bridge, M3-T3 MobileNetV2 block (#213), #210 fix.
+
+## Goal
+
+Assemble the full MobileNetV2 network as a `KernelGraph` DFG on the CSP value
+path and deliver the three-tier DoD (demonstrate / validate / benchmark) +
+writeup, mirroring the M2 ResNet-18 milestone.
+
+## Decision: MobileNetV2 full model before EfficientNet SE
+
+At the M3-T3/T4 boundary the choice was (a) EfficientNet MBConv+SE block or
+(b) full MobileNetV2 model + demo. A scout confirmed the SE gate needs two new
+non-trivial CSP runners (a sigmoid — no `VEOp::SIGMOID`/`kernels::sigmoid` — and
+a per-channel `[N,C]x[N,C,H,W]` broadcast-multiply, which no schedule generator
+currently provides). The user chose the MobileNetV2 full model: fully unblocked,
+high-certainty, proves the milestone end-to-end, and reuses the proven M2
+`resnet18.hpp` + demo pattern. EfficientNet SE is a tracked follow-on.
+
+## What was done
+
+- **`include/sw/kpu/timing/graph/mobilenetv2.hpp`** — `MobileNetV2Spec` +
+  `build_mobilenetv2` (stem + inverted-residual bottleneck stack + `1x1` head
+  conv + GAP + FC), reusable builder with per-node weights and a composed host
+  oracle (pointwise conv+BN+ReLU6, per-channel depthwise+BN+ReLU6, residual, GAP,
+  FC). No new runners - the whole network dispatches through the M2/M3 bridge.
+- **`examples/milestones/m3_mobilenet.cpp`** — demonstrate/validate/benchmark
+  driver (`--dot`, base/deeper/batch-32 sweep), mirroring `m2_resnet.cpp`.
+- **`tests/timing/test_m3_mobilenet.cpp`** — full network vs oracle
+  (`max_err ~1e-7`) + a tile-alignment guard.
+- Writeup `docs/milestones/M3_mobilenet.md`; CMake registration of both targets.
+
+## Wrong decisions
+
+- **Depthwise oracle dropped the ReLU6.** `mb_dw_conv_bn` computed the affine but
+  never clamped; caught immediately by `-Werror=unused-parameter` on the `relu6`
+  arg (a real correctness bug, not just an unused parameter). Fixed.
+- **Identity residual used the external-input fallback.** The block's residual ADD
+  was wired with only the main-branch edge, relying on the bridge's "one edge ->
+  second operand is the external input" fallback. For a block deep in the stack
+  that resolves to the *whole-network* input (wrong value, and a size mismatch ->
+  "run_elementwise: operand size mismatch"). This is exactly the trap the ResNet
+  tower fixed. Fixed by making the identity skip an explicit graph edge from the
+  block's input node. Lesson: in a stacked network, every skip must be an explicit
+  edge; the external-input fallback only serves the graph source.
+- **Default demo spec too heavy.** The first default (5 blocks, head 32) ran the
+  demo sweep in 90s. Shrunk to a compact-but-complete topology (3 blocks, head 16,
+  expansion t<=2) - still covers expansion / depthwise / stride-2 downsample /
+  identity residual / head / GAP / FC - bringing the test to ~4s and the demo
+  sweep to ~32s. Lesson (from M2): GAP wall-clock scales with N*C, so keep the
+  head width modest.
+
+## Validation
+
+- `test_m3_mobilenet`: full network `max_err < 5e-3` (observed ~1e-7); node/op
+  counts sane (base 34 nodes -> 31 CSP ops); tile-alignment guard throws.
+- Demo: base/deeper/batch-32 all PASS, `max_err ~3.7e-8`.
+- Full timing suite: **100% (53/53) passed**.
+- Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the new TUs
+  (the builder header is covered transitively).
+
+## Modified files
+
+- `include/sw/kpu/timing/graph/mobilenetv2.hpp` — new reusable builder + oracle.
+- `examples/milestones/m3_mobilenet.cpp` — new demo driver.
+- `examples/milestones/CMakeLists.txt` — register `m3_mobilenet`.
+- `tests/timing/test_m3_mobilenet.cpp` — new full-network test.
+- `tests/timing/CMakeLists.txt` — register the test.
+- `docs/milestones/M3_mobilenet.md` — new writeup.
+- `CHANGELOG.md`, `docs/sessions/2026-07-16_v0.9_m3t4-mobilenet-model.md`.
+
+## Follow-on
+
+- EfficientNet-B0 MBConv + squeeze-and-excitation (sigmoid + per-channel
+  broadcast-multiply runners) — the remaining M3 block.
+- Optional: trained-weights upgrade + a larger-scale MobileNetV2 config.

--- a/examples/milestones/CMakeLists.txt
+++ b/examples/milestones/CMakeLists.txt
@@ -30,3 +30,16 @@ if(KPU_BUILD_TESTS)
         LABELS "timing;resnet;milestone;v0.9"
     )
 endif()
+
+# M3: MobileNetV2 demo + benchmark (issue #131)
+add_executable(m3_mobilenet m3_mobilenet.cpp)
+target_link_libraries(m3_mobilenet PRIVATE kpu_simulator)
+set_target_properties(m3_mobilenet PROPERTIES
+    FOLDER "Examples/Milestones"
+)
+if(KPU_BUILD_TESTS)
+    add_test(NAME m3_mobilenet COMMAND m3_mobilenet)
+    set_tests_properties(m3_mobilenet PROPERTIES
+        LABELS "timing;mobilenet;milestone;v0.9"
+    )
+endif()

--- a/examples/milestones/m3_mobilenet.cpp
+++ b/examples/milestones/m3_mobilenet.cpp
@@ -1,0 +1,152 @@
+/**
+ * @file m3_mobilenet.cpp
+ * @brief DNN Milestone M3: MobileNetV2 as a dataflow graph on the CSP executor.
+ *
+ * The third rung of the DNN milestone ladder (issue #131). The full MobileNetV2
+ * (stem + inverted-residual bottleneck stack + 1x1 head conv + global-average-
+ * pool + FC) is expressed as a KernelGraph DFG and executed end-to-end on the
+ * credit-based CSP value path through GraphCspExecutor, which folds BatchNorm
+ * into its conv, lowers pointwise conv via im2col->GEMM and depthwise conv via
+ * the pooling-window unfold + per-channel filter reduce, applies ReLU6, and
+ * joins the identity residuals.
+ *
+ * Three-tier definition of done:
+ *  - Demonstrate: the whole network runs end-to-end on the CSP executor;
+ *    `--dot FILE` emits the KernelGraph for visualization.
+ *  - Validate: the classification output is compared elementwise against a
+ *    composed whole-network host oracle (conv/depthwise/BN/ReLU6/add/GAP/FC).
+ *  - Benchmark: cycles, CSP ops (post-fusion), cyc/op, and DMA/BM/STR stall
+ *    breakdown across a small spec sweep.
+ *
+ * Usage: m3_mobilenet [--dot FILE]
+ * Writeup: docs/milestones/M3_mobilenet.md
+ */
+
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/mobilenetv2.hpp>
+
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing::graph;
+
+namespace {
+
+struct Row {
+    std::string name;
+    std::size_t nodes = 0, ops = 0;
+    bool pass = false;
+    bool dot_ok = true;
+    float max_err = 0.0f;
+    RunStats stats;
+};
+
+Row run_spec(const std::string& name, const MobileNetV2Spec& spec,
+             const std::string& dot_path) {
+    sw::kpu::KernelGraph g;
+    auto net = build_mobilenetv2(g, spec);
+    bool dot_ok = true;
+    if (!dot_path.empty()) {
+        std::ofstream f(dot_path);
+        f << g.to_dot(true);
+        dot_ok = static_cast<bool>(f);
+    }
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, net.input, net.node_data, /*T*/16);
+
+    Row r;
+    r.name = name;
+    r.nodes = net.num_nodes;
+    r.ops = result.stats.ops;
+    r.stats = result.stats;
+    r.dot_ok = dot_ok;
+    r.pass = result.output.size() == net.oracle.size();
+    for (std::size_t i = 0; i < result.output.size() && i < net.oracle.size(); ++i)
+        r.max_err = std::max(r.max_err, std::abs(result.output[i] - net.oracle[i]));
+    r.pass = r.pass && r.max_err < 5e-3f;
+    return r;
+}
+
+void print_row(const Row& r) {
+    double cyc_per_op = r.ops ? static_cast<double>(r.stats.total_cycles) / static_cast<double>(r.ops) : 0.0;
+    std::cout << "  " << std::left << std::setw(24) << r.name << std::right
+              << std::setw(7) << r.nodes
+              << std::setw(6) << r.ops
+              << std::setw(11) << r.stats.total_cycles
+              << std::setw(10) << std::fixed << std::setprecision(0) << cyc_per_op
+              << std::setw(9) << r.stats.dma_stalls
+              << std::setw(9) << r.stats.bm_stalls
+              << std::setw(9) << r.stats.str_stalls
+              << std::setw(11) << std::scientific << std::setprecision(1) << r.max_err
+              << std::setw(7) << (r.pass ? "PASS" : "FAIL") << "\n"
+              << std::defaultfloat;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    std::string dot_path;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--dot") == 0 && i + 1 < argc) {
+            dot_path = argv[++i];
+        } else {
+            std::cout << "Usage: " << argv[0] << " [--dot FILE]\n";
+            return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
+        }
+    }
+
+    std::cout << "\n"
+        "======================================================================\n"
+        "DNN Milestone M3: MobileNetV2 as a DFG on the CSP concurrent executor\n"
+        "The whole network runs through the credit-based dataflow (pointwise conv\n"
+        "im2col->GEMM, depthwise conv via pooling-window unfold, folded BN, ReLU6,\n"
+        "inverted-residual adds, global-avg-pool, FC); outputs are validated\n"
+        "elementwise against a composed whole-network host oracle.\n"
+        "======================================================================\n\n";
+
+    std::vector<Row> rows;
+
+    MobileNetV2Spec base;                              // default fast scaled topology
+    rows.push_back(run_spec("mobilenetv2 (base)", base, dot_path));
+
+    MobileNetV2Spec deeper = base;                     // an extra bottleneck stage
+    deeper.stages.push_back({3, 32, 2, 1});
+    rows.push_back(run_spec("mobilenetv2 (deeper)", deeper, {}));
+
+    MobileNetV2Spec batch32 = base; batch32.batch = 32;
+    rows.push_back(run_spec("mobilenetv2 (batch 32)", batch32, {}));
+
+    std::cout << "  " << std::left << std::setw(24) << "configuration" << std::right
+              << std::setw(7) << "nodes" << std::setw(6) << "ops"
+              << std::setw(11) << "cycles" << std::setw(10) << "cyc/op"
+              << std::setw(9) << "dmaStl" << std::setw(9) << "bmStl"
+              << std::setw(9) << "strStl" << std::setw(11) << "maxErr"
+              << std::setw(7) << "check" << "\n";
+    std::cout << "  " << std::string(101, '-') << "\n";
+
+    bool all_pass = true;
+    for (const auto& r : rows) { print_row(r); all_pass = all_pass && r.pass; }
+
+    std::cout << "\n  Fusion: BatchNorm folded into each conv; the base network's "
+              << rows.front().nodes << " graph nodes\n  execute as "
+              << rows.front().ops << " CSP ops (depthwise convs dispatch to the "
+                 "pooling-window path).\n";
+    std::cout << "  Validation: " << (all_pass ? "ALL PASS" : "FAILURES PRESENT")
+              << " (oracle: composed whole-network host reference, tol 5e-3)\n";
+    if (!dot_path.empty()) {
+        if (rows.front().dot_ok) {
+            std::cout << "  KernelGraph written to " << dot_path << " (Graphviz dot)\n";
+        } else {
+            std::cerr << "  error: could not write KernelGraph to " << dot_path << "\n";
+            all_pass = false;
+        }
+    }
+    std::cout << "\n";
+    return all_pass ? 0 : 1;
+}

--- a/examples/milestones/m3_mobilenet.cpp
+++ b/examples/milestones/m3_mobilenet.cpp
@@ -58,7 +58,7 @@ Row run_spec(const std::string& name, const MobileNetV2Spec& spec,
     }
 
     GraphCspExecutor exec;
-    auto result = exec.run(g, net.input, net.node_data, /*T*/16);
+    auto result = exec.run(g, net.input, net.node_data, spec.tile);
 
     Row r;
     r.name = name;
@@ -67,9 +67,15 @@ Row run_spec(const std::string& name, const MobileNetV2Spec& spec,
     r.stats = result.stats;
     r.dot_ok = dot_ok;
     r.pass = result.output.size() == net.oracle.size();
-    for (std::size_t i = 0; i < result.output.size() && i < net.oracle.size(); ++i)
-        r.max_err = std::max(r.max_err, std::abs(result.output[i] - net.oracle[i]));
-    r.pass = r.pass && r.max_err < 5e-3f;
+    bool finite = true;
+    for (std::size_t i = 0; i < result.output.size() && i < net.oracle.size(); ++i) {
+        const float d = std::abs(result.output[i] - net.oracle[i]);
+        // std::max(x, NaN) returns x, so a NaN would be silently masked -
+        // flag non-finite outputs/diffs explicitly.
+        if (!std::isfinite(result.output[i]) || !std::isfinite(d)) finite = false;
+        r.max_err = std::max(r.max_err, d);
+    }
+    r.pass = r.pass && finite && r.max_err < 5e-3f;
     return r;
 }
 

--- a/include/sw/kpu/timing/graph/mobilenetv2.hpp
+++ b/include/sw/kpu/timing/graph/mobilenetv2.hpp
@@ -191,6 +191,8 @@ inline std::vector<float> mb_dw_conv_bn(const std::vector<float>& x, const std::
         throw std::invalid_argument("build_mobilenetv2: in/head/class channels must be multiples of tile");
     if (sp.height == 0 || sp.width == 0 || sp.stages.empty())
         throw std::invalid_argument("build_mobilenetv2: invalid geometry");
+    if (!std::isfinite(sp.eps) || sp.eps <= 0.0f)
+        throw std::invalid_argument("build_mobilenetv2: eps must be finite and positive");
     for (const auto& st : sp.stages)
         if (st.t == 0 || !aligned(st.c) || st.n == 0 || (st.s != 1 && st.s != 2))
             throw std::invalid_argument("build_mobilenetv2: invalid stage");

--- a/include/sw/kpu/timing/graph/mobilenetv2.hpp
+++ b/include/sw/kpu/timing/graph/mobilenetv2.hpp
@@ -231,34 +231,47 @@ inline std::vector<float> mb_dw_conv_bn(const std::vector<float>& x, const std::
             const Size in_ch = cur_ch;
             const Size out_ch = st.c;
             const Size hidden = st.t * in_ch;
+            // MobileNetV2's t==1 bottleneck has NO expansion conv - it goes
+            // straight from the input into the depthwise (hidden == in_ch).
+            const bool expand = (st.t > 1);
             const bool residual = (stride == 1 && in_ch == out_ch);
             const Size Hd = out_dim(cur_H, 3, stride, 1), Wd = out_dim(cur_W, 3, stride, 1);
 
-            auto cce = mb_conv_cfg(N, in_ch, hidden, cur_H, cur_W, 1, 1, 0);              // expand 1x1
             auto ccd = mb_conv_cfg(N, hidden, hidden, cur_H, cur_W, 3, stride, 1, hidden); // depthwise 3x3
             auto ccp = mb_conv_cfg(N, hidden, out_ch, Hd, Wd, 1, 1, 0);                    // project 1x1
-            auto we = mb_synth(static_cast<std::size_t>(hidden) * in_ch, seed, 0.12f);
             auto wd = mb_synth(static_cast<std::size_t>(hidden) * 9, seed + 1, 0.25f);
             auto wp = mb_synth(static_cast<std::size_t>(out_ch) * hidden, seed + 2, 0.12f);
-            auto bne = mb_bn(hidden, seed, sp.eps), bnd = mb_bn(hidden, seed + 1, sp.eps),
-                 bnp = mb_bn(out_ch, seed + 2, sp.eps);
+            auto bnd = mb_bn(hidden, seed + 1, sp.eps), bnp = mb_bn(out_ch, seed + 2, sp.eps);
 
-            auto ce = g.add_kernel(Kernel::create_conv2d(cce, false, ActivationType::NONE), "expand");
-            auto be = g.add_kernel(Kernel::create_batchnorm(N, hidden, cur_H, cur_W, bne.eps), "bn_e");
-            auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * cur_H * cur_W}), "relu6_e");
+            // Expansion (1x1 -> BN -> ReLU6), only when t > 1. dw_in is the node
+            // and activation feeding the depthwise: the expanded output, or the
+            // block input directly for t == 1.
+            std::size_t dw_in_node = in_node;
+            std::vector<float> dw_in = ox;
+            if (expand) {
+                auto cce = mb_conv_cfg(N, in_ch, hidden, cur_H, cur_W, 1, 1, 0);
+                auto we  = mb_synth(static_cast<std::size_t>(hidden) * in_ch, seed, 0.12f);
+                auto bne = mb_bn(hidden, seed, sp.eps);
+                auto ce = g.add_kernel(Kernel::create_conv2d(cce, false, ActivationType::NONE), "expand");
+                auto be = g.add_kernel(Kernel::create_batchnorm(N, hidden, cur_H, cur_W, bne.eps), "bn_e");
+                auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * cur_H * cur_W}), "relu6_e");
+                g.add_edge(in_node, ce); g.add_edge(ce, be); g.add_edge(be, re);
+                nd[ce].filter = we; mb_set_bn(nd[be], bne);
+                dw_in = mb_pw_conv_bn(ox, we, cce, bne, true);
+                dw_in_node = re;
+            }
+
             auto cd = g.add_kernel(Kernel::create_conv2d(ccd, false, ActivationType::NONE), "depthwise");
             auto bd = g.add_kernel(Kernel::create_batchnorm(N, hidden, Hd, Wd, bnd.eps), "bn_d");
             auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * Hd * Wd}), "relu6_d");
             auto cp = g.add_kernel(Kernel::create_conv2d(ccp, false, ActivationType::NONE), "project");
             auto bp = g.add_kernel(Kernel::create_batchnorm(N, out_ch, Hd, Wd, bnp.eps), "bn_p");
-            g.add_edge(in_node, ce); g.add_edge(ce, be); g.add_edge(be, re); g.add_edge(re, cd);
-            g.add_edge(cd, bd); g.add_edge(bd, rd); g.add_edge(rd, cp); g.add_edge(cp, bp);
-            nd[ce].filter = we; mb_set_bn(nd[be], bne);
+            g.add_edge(dw_in_node, cd); g.add_edge(cd, bd); g.add_edge(bd, rd);
+            g.add_edge(rd, cp); g.add_edge(cp, bp);
             nd[cd].filter = wd; mb_set_bn(nd[bd], bnd);
             nd[cp].filter = wp; mb_set_bn(nd[bp], bnp);
 
-            auto e = mb_pw_conv_bn(ox, we, cce, bne, true);
-            auto d = mb_dw_conv_bn(e, wd, ccd, bnd, true);
+            auto d = mb_dw_conv_bn(dw_in, wd, ccd, bnd, true);
             auto p = mb_pw_conv_bn(d, wp, ccp, bnp, false);   // linear bottleneck
 
             std::size_t sink = bp;

--- a/include/sw/kpu/timing/graph/mobilenetv2.hpp
+++ b/include/sw/kpu/timing/graph/mobilenetv2.hpp
@@ -1,0 +1,321 @@
+// ============================================================================
+// include/sw/kpu/timing/graph/mobilenetv2.hpp
+// Reusable MobileNetV2 builder: constructs the network (stem + inverted-residual
+// bottleneck stack + 1x1 head conv + global-average-pool + FC) as a KernelGraph
+// DFG, with matching per-node weights and a composed host oracle (M3-T4, #131).
+// See docs/plans/m3_mobilenet_dfg.md and docs/milestones/M3_mobilenet.md.
+//
+// Executed through GraphCspExecutor on the CSP value path; every operator lowers
+// through the M2/M3 bridge (pointwise conv im2col->GEMM, depthwise conv via the
+// pooling-window unfold, folded BN, standalone ReLU6, residual add, GAP, FC) -
+// no new runners. Dims are scaled for a fast CSP demo; batch N keeps every conv
+// GEMM's M = N*Hout*Wout tile-aligned (the FC's M = N, so N >= tile).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/kernel.hpp>
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/graph_csp_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+namespace sw::kpu::timing::graph {
+
+/// MobileNetV2 topology (scaled for the CSP demo). All channels are tile-aligned
+/// and the batch keeps every conv GEMM's M = batch*Hout*Wout a multiple of the
+/// tile size (the FC's M = batch, so batch >= tile). Each bottleneck stage is
+/// {expansion t, out_channels c, repeats n, first-block stride s}: the first
+/// block of a stage strides by s and changes channels (no residual), the rest
+/// stride 1 with identity residuals. The default is a fast, CI-friendly scale
+/// exercising the full structure (stem, expansion, depthwise, downsampling,
+/// identity residuals, head conv, GAP, FC).
+struct MobileNetV2Spec {
+    struct Stage { Size t, c, n, s; };
+
+    Size batch = 16;
+    Size in_channels = 16, height = 8, width = 8;   // stem input (16ch, 8x8)
+    std::vector<Stage> stages = {
+        {1, 16, 1, 1},   // t=1, 16ch, s1  identity residual   (hidden = 16)
+        {2, 32, 1, 2},   // t=2, 32ch, s2  downsample 8->4, no residual (hidden = 32)
+        {2, 32, 1, 1},   // t=2, 32ch, s1  identity residual   (hidden = 64)
+    };
+    Size head_channels = 16;   ///< final 1x1 conv width (scaled from 1280)
+    Size num_classes = 16;
+    Size tile = 16;   ///< GEMM tile; batch/channels/num_classes must be multiples
+    float eps = 1e-3f;
+    std::uint64_t seed = 2000;
+};
+
+/// Built network: the graph is populated into the caller's KernelGraph; this
+/// carries the per-node weights, the synthetic input, the host-oracle output,
+/// and the sink node id.
+struct MobileNetV2 {
+    std::unordered_map<std::size_t, NodeData> node_data;
+    std::vector<float> input;
+    std::vector<float> oracle;   // [batch, num_classes]
+    std::size_t output_node = 0;
+    std::size_t num_nodes = 0;
+};
+
+namespace detail {
+
+inline std::vector<float> mb_synth(std::size_t n, std::uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    std::uint64_t s = seed * 2654435761ULL + 12345ULL;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<std::uint32_t>(s >> 33);       // [0, 0x7FFFFFFF]
+        x = (2.0f * static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+
+// groups defaults to 1 (standard conv); set groups = Cin for depthwise.
+inline sw::kpu::Conv2DConfig mb_conv_cfg(Size N, Size Cin, Size Cout, Size H, Size W,
+                                         Size K, Size stride, Size pad, Size groups = 1) {
+    sw::kpu::Conv2DConfig c;
+    c.batch_size = N; c.in_channels = Cin; c.out_channels = Cout;
+    c.input_height = H; c.input_width = W;
+    c.kernel_height = c.kernel_width = K;
+    c.stride_h = c.stride_w = stride; c.padding_h = c.padding_w = pad;
+    c.groups = groups;
+    return c;
+}
+inline schedule::Conv2DGeometry mb_geom(const sw::kpu::Conv2DConfig& c) {
+    schedule::Conv2DGeometry g;
+    g.N = static_cast<Size>(c.batch_size); g.C_in = static_cast<Size>(c.in_channels);
+    g.H_in = static_cast<Size>(c.input_height); g.W_in = static_cast<Size>(c.input_width);
+    g.C_out = static_cast<Size>(c.out_channels); g.Kh = static_cast<Size>(c.kernel_height);
+    g.Kw = static_cast<Size>(c.kernel_width); g.stride_h = static_cast<Size>(c.stride_h);
+    g.stride_w = static_cast<Size>(c.stride_w); g.pad_h = static_cast<Size>(c.padding_h);
+    g.pad_w = static_cast<Size>(c.padding_w);
+    return g;
+}
+
+struct MbBN { std::vector<float> gamma, beta, mean, var; float eps; };
+inline MbBN mb_bn(Size C, std::uint64_t seed, float eps) {
+    MbBN b; b.eps = eps;
+    b.gamma = mb_synth(C, seed * 4 + 1, 0.4f); for (auto& g : b.gamma) g += 1.0f;
+    b.beta  = mb_synth(C, seed * 4 + 2, 0.2f);
+    b.mean  = mb_synth(C, seed * 4 + 3, 0.3f);
+    b.var   = mb_synth(C, seed * 4 + 4, 0.2f); for (auto& v : b.var) v = std::abs(v) + 0.5f;
+    return b;
+}
+inline void mb_set_bn(NodeData& nd, const MbBN& bn) {
+    nd.gamma = bn.gamma; nd.beta = bn.beta; nd.mean = bn.mean; nd.var = bn.var; nd.eps = bn.eps;
+}
+inline void relu6_ip(std::vector<float>& v) {
+    for (auto& x : v) x = std::min(std::max(0.0f, x), 6.0f);
+}
+
+// Standard (pointwise) conv -> BN inference -> optional ReLU6. NCHW.
+inline std::vector<float> mb_pw_conv_bn(const std::vector<float>& x, const std::vector<float>& w,
+                                        const sw::kpu::Conv2DConfig& cc, const MbBN& bn, bool relu6) {
+    const auto g = mb_geom(cc);
+    auto z = schedule::conv2d_reference(x, w, {}, g, false);
+    schedule::BatchNormGeometry bg; bg.N = g.N; bg.C = g.C_out; bg.H = g.H_out(); bg.W = g.W_out();
+    auto y = schedule::batchnorm_reference(z, bn.gamma, bn.beta, bn.mean, bn.var, bn.eps, bg);
+    if (relu6) relu6_ip(y);
+    return y;
+}
+
+// Per-channel depthwise conv -> BN inference -> optional ReLU6. NCHW.
+inline std::vector<float> mb_dw_conv_bn(const std::vector<float>& x, const std::vector<float>& filter,
+                                        const sw::kpu::Conv2DConfig& cc, const MbBN& bn, bool relu6) {
+    const auto g = mb_geom(cc);
+    const Size Hout = g.H_out(), Wout = g.W_out();
+    std::vector<float> y(static_cast<std::size_t>(g.N) * g.C_out * Hout * Wout);
+    for (Size n = 0; n < g.N; ++n)
+        for (Size c = 0; c < g.C_out; ++c) {
+            const std::size_t plane = (static_cast<std::size_t>(n) * g.C_in + c) * g.H_in * g.W_in;
+            const float scale = bn.gamma[c] / std::sqrt(bn.var[c] + bn.eps);
+            const float shift = bn.beta[c] - bn.mean[c] * scale;
+            for (Size ho = 0; ho < Hout; ++ho)
+                for (Size wo = 0; wo < Wout; ++wo) {
+                    float acc = 0.0f;
+                    for (Size kh = 0; kh < g.Kh; ++kh) {
+                        const long ih = static_cast<long>(ho * g.stride_h + kh) - static_cast<long>(g.pad_h);
+                        if (ih < 0 || ih >= static_cast<long>(g.H_in)) continue;
+                        for (Size kw = 0; kw < g.Kw; ++kw) {
+                            const long iw = static_cast<long>(wo * g.stride_w + kw) - static_cast<long>(g.pad_w);
+                            if (iw < 0 || iw >= static_cast<long>(g.W_in)) continue;
+                            acc += x[plane + static_cast<std::size_t>(ih) * g.W_in + iw] *
+                                   filter[(static_cast<std::size_t>(c) * g.Kh + kh) * g.Kw + kw];
+                        }
+                    }
+                    acc = acc * scale + shift;
+                    if (relu6) acc = std::min(std::max(0.0f, acc), 6.0f);
+                    y[((static_cast<std::size_t>(n) * g.C_out + c) * Hout + ho) * Wout + wo] = acc;
+                }
+        }
+    return y;
+}
+
+} // namespace detail
+
+/**
+ * @brief Build MobileNetV2 into `g`; return weights + input + oracle.
+ *
+ * Topology: stem (3x3 s1 conv -> BN -> ReLU6) + a stack of inverted-residual
+ * bottlenecks (1x1 expand -> BN -> ReLU6 -> 3x3 depthwise -> BN -> ReLU6 -> 1x1
+ * project -> BN, with an identity residual when stride==1 and Cin==Cout) + a 1x1
+ * head conv -> BN -> ReLU6 + global-average-pool + FC. Execute the returned graph
+ * through GraphCspExecutor and compare its output to `oracle` (tol ~5e-3).
+ */
+[[nodiscard]] inline MobileNetV2 build_mobilenetv2(KernelGraph& g, const MobileNetV2Spec& sp) {
+    using namespace detail;
+    using sw::kpu::Kernel;
+    using sw::kpu::ElementwiseOp;
+    using sw::kpu::ActivationType;
+
+    // Tile-alignment: batch (FC/conv M axis), channels (K/N), num_classes (FC N),
+    // and head_channels must be nonzero multiples of the tile. Expansion hidden =
+    // t*Cin is a multiple whenever Cin is. Fail fast with a clear message.
+    auto aligned = [&](Size v) { return v != 0 && v % sp.tile == 0; };
+    if (sp.tile == 0 || !aligned(sp.batch))
+        throw std::invalid_argument("build_mobilenetv2: batch must be a nonzero multiple of tile");
+    if (!aligned(sp.in_channels) || !aligned(sp.head_channels) || !aligned(sp.num_classes))
+        throw std::invalid_argument("build_mobilenetv2: in/head/class channels must be multiples of tile");
+    if (sp.height == 0 || sp.width == 0 || sp.stages.empty())
+        throw std::invalid_argument("build_mobilenetv2: invalid geometry");
+    for (const auto& st : sp.stages)
+        if (st.t == 0 || !aligned(st.c) || st.n == 0 || (st.s != 1 && st.s != 2))
+            throw std::invalid_argument("build_mobilenetv2: invalid stage");
+
+    MobileNetV2 net;
+    auto& nd = net.node_data;
+    const Size N = sp.batch;
+    std::uint64_t seed = sp.seed;
+
+    net.input = mb_synth(static_cast<std::size_t>(N) * sp.in_channels * sp.height * sp.width, seed, 1.0f);
+    std::vector<float> ox = net.input;
+    Size cur_ch = sp.in_channels, cur_H = sp.height, cur_W = sp.width;
+
+    auto out_dim = [](Size in, Size K, Size stride, Size pad) { return (in + 2 * pad - K) / stride + 1; };
+
+    // ----- stem: 3x3 s1 conv -> BN -> ReLU6 -----------------------------------
+    std::size_t in_node;
+    {
+        auto cc = mb_conv_cfg(N, sp.in_channels, sp.in_channels, cur_H, cur_W, 3, 1, 1);
+        auto w  = mb_synth(static_cast<std::size_t>(sp.in_channels) * sp.in_channels * 9, seed, 0.1f);
+        auto bn = mb_bn(sp.in_channels, seed, sp.eps);
+        auto c = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "stem_conv");
+        auto b = g.add_kernel(Kernel::create_batchnorm(N, sp.in_channels, cur_H, cur_W, sp.eps), "stem_bn");
+        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {sp.in_channels * cur_H * cur_W}), "stem_relu6");
+        g.add_edge(c, b); g.add_edge(b, r);
+        nd[c].filter = w; mb_set_bn(nd[b], bn);
+        ox = mb_pw_conv_bn(ox, w, cc, bn, true);
+        in_node = r;
+        ++seed;
+    }
+
+    // ----- inverted-residual bottleneck stack ---------------------------------
+    for (const auto& st : sp.stages) {
+        for (Size blk = 0; blk < st.n; ++blk) {
+            const Size stride = (blk == 0) ? st.s : 1;
+            const Size in_ch = cur_ch;
+            const Size out_ch = st.c;
+            const Size hidden = st.t * in_ch;
+            const bool residual = (stride == 1 && in_ch == out_ch);
+            const Size Hd = out_dim(cur_H, 3, stride, 1), Wd = out_dim(cur_W, 3, stride, 1);
+
+            auto cce = mb_conv_cfg(N, in_ch, hidden, cur_H, cur_W, 1, 1, 0);              // expand 1x1
+            auto ccd = mb_conv_cfg(N, hidden, hidden, cur_H, cur_W, 3, stride, 1, hidden); // depthwise 3x3
+            auto ccp = mb_conv_cfg(N, hidden, out_ch, Hd, Wd, 1, 1, 0);                    // project 1x1
+            auto we = mb_synth(static_cast<std::size_t>(hidden) * in_ch, seed, 0.12f);
+            auto wd = mb_synth(static_cast<std::size_t>(hidden) * 9, seed + 1, 0.25f);
+            auto wp = mb_synth(static_cast<std::size_t>(out_ch) * hidden, seed + 2, 0.12f);
+            auto bne = mb_bn(hidden, seed, sp.eps), bnd = mb_bn(hidden, seed + 1, sp.eps),
+                 bnp = mb_bn(out_ch, seed + 2, sp.eps);
+
+            auto ce = g.add_kernel(Kernel::create_conv2d(cce, false, ActivationType::NONE), "expand");
+            auto be = g.add_kernel(Kernel::create_batchnorm(N, hidden, cur_H, cur_W, bne.eps), "bn_e");
+            auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * cur_H * cur_W}), "relu6_e");
+            auto cd = g.add_kernel(Kernel::create_conv2d(ccd, false, ActivationType::NONE), "depthwise");
+            auto bd = g.add_kernel(Kernel::create_batchnorm(N, hidden, Hd, Wd, bnd.eps), "bn_d");
+            auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * Hd * Wd}), "relu6_d");
+            auto cp = g.add_kernel(Kernel::create_conv2d(ccp, false, ActivationType::NONE), "project");
+            auto bp = g.add_kernel(Kernel::create_batchnorm(N, out_ch, Hd, Wd, bnp.eps), "bn_p");
+            g.add_edge(in_node, ce); g.add_edge(ce, be); g.add_edge(be, re); g.add_edge(re, cd);
+            g.add_edge(cd, bd); g.add_edge(bd, rd); g.add_edge(rd, cp); g.add_edge(cp, bp);
+            nd[ce].filter = we; mb_set_bn(nd[be], bne);
+            nd[cd].filter = wd; mb_set_bn(nd[bd], bnd);
+            nd[cp].filter = wp; mb_set_bn(nd[bp], bnp);
+
+            auto e = mb_pw_conv_bn(ox, we, cce, bne, true);
+            auto d = mb_dw_conv_bn(e, wd, ccd, bnd, true);
+            auto p = mb_pw_conv_bn(d, wp, ccp, bnp, false);   // linear bottleneck
+
+            std::size_t sink = bp;
+            if (residual) {
+                auto ad = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::ADD, {out_ch * Hd * Wd}), "add");
+                // Identity skip is an EXPLICIT edge from the block's input node
+                // (not the external-input fallback, which resolves to the whole-
+                // network input - wrong for a block deep in the stack).
+                g.add_edge(bp, ad);                  // main branch (project BN output)
+                g.add_edge(in_node, ad, "C", "B");   // identity skip = block input
+                for (std::size_t i = 0; i < p.size(); ++i) p[i] += ox[i];
+                sink = ad;
+            }
+            ox = std::move(p);
+            in_node = sink; cur_ch = out_ch; cur_H = Hd; cur_W = Wd;
+            seed += 3;
+        }
+    }
+
+    // ----- head: 1x1 conv -> BN -> ReLU6 --------------------------------------
+    {
+        auto cc = mb_conv_cfg(N, cur_ch, sp.head_channels, cur_H, cur_W, 1, 1, 0);
+        auto w  = mb_synth(static_cast<std::size_t>(sp.head_channels) * cur_ch, seed, 0.12f);
+        auto bn = mb_bn(sp.head_channels, seed, sp.eps);
+        auto c = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "head_conv");
+        auto b = g.add_kernel(Kernel::create_batchnorm(N, sp.head_channels, cur_H, cur_W, sp.eps), "head_bn");
+        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {sp.head_channels * cur_H * cur_W}), "head_relu6");
+        g.add_edge(in_node, c); g.add_edge(c, b); g.add_edge(b, r);
+        nd[c].filter = w; mb_set_bn(nd[b], bn);
+        ox = mb_pw_conv_bn(ox, w, cc, bn, true);
+        in_node = r; cur_ch = sp.head_channels;
+        ++seed;
+    }
+
+    // ----- head: global-average-pool -> FC ------------------------------------
+    auto gp = g.add_kernel(Kernel::create_global_avg_pool2d(N, cur_ch, cur_H, cur_W), "gap");
+    auto fc = g.add_kernel(Kernel::create_matmul(N, sp.num_classes, cur_ch), "fc");
+    g.add_edge(in_node, gp); g.add_edge(gp, fc);
+
+    auto wfc = mb_synth(static_cast<std::size_t>(cur_ch) * sp.num_classes, seed, 0.1f);
+    auto bfc = mb_synth(sp.num_classes, seed + 1, 0.2f);
+    nd[fc].fc_weight = wfc; nd[fc].fc_bias = bfc;
+    nd[fc].fc_M = N; nd[fc].fc_K = cur_ch; nd[fc].fc_N = sp.num_classes;
+
+    // oracle head: GAP over the plane per (n,c), then FC.
+    schedule::Pool2DGeometry pg; pg.N = N; pg.C = cur_ch; pg.H = cur_H; pg.W = cur_W;
+    auto gap = schedule::global_avg_pool_reference(ox, pg);   // [N*cur_ch]
+    net.oracle.assign(static_cast<std::size_t>(N) * sp.num_classes, 0.0f);
+    for (Size m = 0; m < N; ++m)
+        for (Size n = 0; n < sp.num_classes; ++n) {
+            float acc = bfc[n];
+            for (Size k = 0; k < cur_ch; ++k)
+                acc += gap[m * cur_ch + k] * wfc[k * sp.num_classes + n];
+            net.oracle[m * sp.num_classes + n] = acc;
+        }
+
+    net.output_node = fc;
+    net.num_nodes = g.num_nodes();
+    return net;
+}
+
+} // namespace sw::kpu::timing::graph

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -323,6 +323,16 @@ set_tests_properties(test_m3_mobilenet_block PROPERTIES
     LABELS "timing;m3;mobilenet;v0.9"
 )
 
+# M3-T4 full MobileNetV2 network (milestone M3, #131): whole network as a
+# KernelGraph DFG on the CSP value path vs a composed host oracle.
+kpu_add_component_test(test_m3_mobilenet "timing"
+    test_m3_mobilenet.cpp
+)
+
+set_tests_properties(test_m3_mobilenet PROPERTIES
+    LABELS "timing;m3;mobilenet;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_m3_mobilenet.cpp
+++ b/tests/timing/test_m3_mobilenet.cpp
@@ -1,0 +1,57 @@
+// ============================================================================
+// tests/timing/test_m3_mobilenet.cpp
+// M3-T4 (#131): the full MobileNetV2 network (stem + inverted-residual bottleneck
+// stack + 1x1 head conv + global-average-pool + FC) built as a KernelGraph DFG
+// and executed end-to-end on the CSP value path through GraphCspExecutor,
+// validated against a composed whole-network host oracle. See
+// docs/plans/m3_mobilenet_dfg.md and docs/milestones/M3_mobilenet.md.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/mobilenetv2.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+using namespace sw::kpu::timing::graph;
+
+TEST_CASE("M3 MobileNetV2 full network on the CSP executor matches host oracle",
+          "[timing][m3][mobilenet]") {
+    sw::kpu::KernelGraph g;
+    MobileNetV2Spec sp;                       // default fast scaled topology
+    auto net = build_mobilenetv2(g, sp);
+
+    REQUIRE(g.num_nodes() == net.num_nodes);
+    REQUIRE(g.get_execution_order().size() == net.num_nodes);
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, net.input, net.node_data, /*T*/16);
+
+    REQUIRE(result.output.size() == net.oracle.size());
+    REQUIRE(result.output.size() == static_cast<std::size_t>(sp.batch) * sp.num_classes);
+
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < net.oracle.size(); ++i)
+        max_err = std::max(max_err, std::abs(result.output[i] - net.oracle[i]));
+    INFO("max_err=" << max_err << " nodes=" << net.num_nodes
+         << " ops=" << result.stats.ops << " cycles=" << result.stats.total_cycles);
+    REQUIRE(max_err < 5e-3f);
+
+    // Fusion collapses each conv+BN(+fused activation is not used here) so the CSP
+    // op count is well below the graph node count, but every block still executes.
+    REQUIRE(result.stats.ops > 0);
+    REQUIRE(result.stats.ops < net.num_nodes);
+}
+
+TEST_CASE("M3 MobileNetV2 builder rejects non-tile-aligned specs",
+          "[timing][m3][mobilenet]") {
+    sw::kpu::KernelGraph g;
+    MobileNetV2Spec sp;
+    sp.num_classes = 20;   // not a multiple of tile (16)
+    REQUIRE_THROWS_AS(build_mobilenetv2(g, sp), std::invalid_argument);
+}

--- a/tests/timing/test_m3_mobilenet.cpp
+++ b/tests/timing/test_m3_mobilenet.cpp
@@ -36,8 +36,13 @@ TEST_CASE("M3 MobileNetV2 full network on the CSP executor matches host oracle",
     REQUIRE(result.output.size() == static_cast<std::size_t>(sp.batch) * sp.num_classes);
 
     float max_err = 0.0f;
-    for (std::size_t i = 0; i < net.oracle.size(); ++i)
+    for (std::size_t i = 0; i < net.oracle.size(); ++i) {
+        // std::max(x, NaN) returns x, so require finite values before comparing
+        // (a NaN output would otherwise slip past the max_err bound).
+        REQUIRE(std::isfinite(result.output[i]));
+        REQUIRE(std::isfinite(net.oracle[i]));
         max_err = std::max(max_err, std::abs(result.output[i] - net.oracle[i]));
+    }
     INFO("max_err=" << max_err << " nodes=" << net.num_nodes
          << " ops=" << result.stats.ops << " cycles=" << result.stats.total_cycles);
     REQUIRE(max_err < 5e-3f);


### PR DESCRIPTION
## Summary

M3-T4 (milestone #131) — **MobileNetV2 milestone achieved**. The full MobileNetV2 network runs end-to-end as a `KernelGraph` DFG on the credit-based CSP value path, validated against a composed whole-network host oracle. Mirrors the M2 ResNet-18 milestone; reuses the M2/M3 bridge unchanged (**no new runners**).

## What's delivered

- **`include/sw/kpu/timing/graph/mobilenetv2.hpp`** — reusable `build_mobilenetv2` (stem `3×3 conv→BN→ReLU6` + inverted-residual bottleneck stack + `1×1` head conv `→BN→ReLU6` + global-average-pool + FC) with per-node weights + a composed host oracle, plus `MobileNetV2Spec`.
- **`examples/milestones/m3_mobilenet.cpp`** — demonstrate / validate / benchmark driver (`--dot` KernelGraph export, base/deeper/batch-32 sweep with cycles/ops/stall table).
- **`tests/timing/test_m3_mobilenet.cpp`** — full network vs oracle (`max_err ~1e-7`) + tile-alignment guard.
- **`docs/milestones/M3_mobilenet.md`** — writeup.

## How it lowers

Every operator dispatches through the existing bridge: BN folds into each conv; pointwise `1×1` convs → im2col→GEMM; depthwise convs (`groups == Cin`) → the pooling-window unfold + per-channel filter reduce; ReLU6 → a standalone VE clamp; identity residuals (`stride==1 && Cin==Cout`) join via an elementwise ADD. The linear bottleneck (no activation on project, none after the add) is the MobileNetV2 distinction from ResNet.

## Notes / bugs caught during bring-up

- The identity residual is wired as an **explicit** skip edge from the block's input node — the external-input fallback would resolve to the whole-network input (the ResNet-tower trap), which failed with a size mismatch until fixed.
- The depthwise host oracle initially dropped its ReLU6 (caught by `-Werror=unused-parameter`) — a real correctness bug, fixed.
- Default topology kept compact (GAP wall-clock scales with `N·C`, per the M2 lesson) — test ~4s, demo sweep ~32s.

## Test Results

| Target | build | test |
|--------|-------|------|
| test_m3_mobilenet | OK | PASS (max_err ~1e-7) |
| m3_mobilenet demo | OK | PASS (base/deeper/batch-32, max_err ~3.7e-8) |
| full timing suite | OK | 100% (53/53) |

Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the new TUs.

## Scope

EfficientNet-B0 MBConv + squeeze-and-excitation (needs sigmoid + per-channel broadcast-multiply CSP runners) remains a tracked M3 follow-on.

Part of milestone #131.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end MobileNetV2 milestone running on the CSP executor.
  - Added configurable MobileNetV2 graph construction with stem, bottleneck blocks, residual connections, and classification head.
  - Added a demo supporting execution, validation, benchmarking, and optional Graphviz output.

- **Tests**
  - Added correctness and configuration-validation tests.
  - Added timing and performance reporting across multiple model configurations.

- **Documentation**
  - Added milestone documentation, validation results, usage instructions, and follow-up notes for EfficientNet-B0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->