### PR TITLE
feat(m3): EfficientNet MBConv block with squeeze-and-excitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **EfficientNet MBConv block with squeeze-and-excitation on the CSP executor —
+  M3 (#131).** The EfficientNet MBConv bottleneck (inverted residual + an SE gate
+  between the depthwise and the project) runs as a `KernelGraph` DFG through
+  `GraphCspExecutor`, validated vs a composed host oracle
+  (`test_m3_efficientnet_block`, max_err < 2e-3). Two new CSP value-path runners
+  (`csp_op_runners.hpp`): **`run_sigmoid`** = `1/(1+e^-x)` composed from four
+  unary/scalar VE ops (`POW_S(ADD_S(EXP(NEG(x)),1),-1)` - the Vector Engine has no
+  sigmoid op), and **`run_channel_broadcast_mul`** = the SE scale, a per-channel
+  `[N,C]` gate times an `[N,C,H,W]` activation (gate index `i/(H·W)`, geometry-free,
+  the `C·H·W` multiplies run on the CSP data path). `GraphCspExecutor` gains
+  `ElementwiseOp::SIGMOID` dispatch and an `ElementwiseOp::MUL` arm that routes to
+  the channel-broadcast multiply when the two operands differ in size (the SE
+  scale) and to a plain product otherwise. The SE gate = `GAP → FC_reduce → ReLU
+  → FC_expand → sigmoid → channel-broadcast-multiply`, reusing GAP + matmul (with
+  ReLU epilogue) + the new runners; SiLU/swish is approximated by ReLU6 for the M3
+  subset (per the design). Also corrected a stale `run_depthwise_conv` note (the
+  #210 CAM cap is fixed; C=48 works).
+
 - **Full MobileNetV2 network as a KernelGraph DFG on the CSP executor — M3-T4
   (#131), MobileNetV2 milestone achieved.** `build_mobilenetv2`
   (`include/sw/kpu/timing/graph/mobilenetv2.hpp`) assembles the whole network

--- a/docs/sessions/2026-07-16_v0.9_m3-efficientnet-mbconv-se.md
+++ b/docs/sessions/2026-07-16_v0.9_m3-efficientnet-mbconv-se.md
@@ -1,0 +1,91 @@
+# Session Log — 2026-07-16 — EfficientNet MBConv + squeeze-and-excitation
+
+**Milestone:** M3 (#131) — EfficientNet-B0 block (the remaining T3 half)
+**Branch:** `feat/m3-efficientnet-mbconv-se`
+**Fidelity tier:** CYCLE_ACCURATE (CSP timing executor, value path)
+**Builds on:** M2/M3 graph->CSP bridge, M3-T3 block (#213), M3-T4 model (#214).
+
+## Goal
+
+Deliver the EfficientNet MBConv bottleneck with squeeze-and-excitation as a
+`KernelGraph` DFG on the CSP value path — the SE gate being the one M3 op the
+MobileNetV2 work did not need.
+
+## What was done
+
+Two new CSP value-path runners (`include/sw/kpu/timing/graph/csp_op_runners.hpp`):
+
+- **`run_sigmoid`** — the Vector Engine has no sigmoid op, so `1/(1+e^-x)` is
+  composed from four unary/scalar VE ops: `POW_S(ADD_S(EXP(NEG(x)), 1), -1)`, via
+  a new `run_ve_unary` helper (`Form::UNARY` on the functional elementwise path).
+- **`run_channel_broadcast_mul`** — the SE scale: a per-channel `[N,C]` gate times
+  an `[N,C,H,W]` activation. Both row-major, so activation element `i`'s gate
+  index is `i / (H*W)` with `H*W = activation.size()/gate.size()` — geometry-free.
+  The gate is expanded host-side (like `run_relu`'s zeros) and the `C*H*W`
+  multiplies run on the CSP data path via a binary MUL.
+
+Bridge (`graph_csp_executor.hpp`): `ElementwiseOp::SIGMOID` → `run_sigmoid`; an
+`ElementwiseOp::MUL` arm that routes to `run_channel_broadcast_mul` when the two
+operands differ in size (SE scale: larger = activation, smaller = gate) and to a
+plain product when equal.
+
+`test_m3_efficientnet_block`: MBConv+SE bottleneck (`expand → BN → ReLU6 → 3x3
+depthwise → BN → ReLU6 → SE(GAP→FC_reduce→ReLU→FC_expand→sigmoid→scale) → project
+→ BN → residual`) as a `KernelGraph`, validated vs a full host oracle, max_err
+< 2e-3. The SE branch fans out from the depthwise activation (one edge to GAP, one
+to the scale). SiLU approximated by ReLU6 for the M3 subset (per design).
+
+## Decisions
+
+- **Sigmoid by VE composition, not a new kernel/VEOp.** The gate is tiny
+  (`[N, hidden]`), so four cheap VE ops on the value path are simpler than adding
+  a `VEOp::SIGMOID` (which would touch `apply_ve_op` + the fabrics). Reuses the
+  proven functional-elementwise path entirely.
+- **Channel-broadcast multiply by host-side gate expansion + binary MUL, not a
+  new per-channel-broadcast schedule generator.** The E2 broadcast machinery
+  broadcasts one tile against a stream (scalar-along-contiguous), not the
+  per-channel `[N,C]` layout SE needs. Expanding the gate host-side (the output
+  is that size anyway) and running the real multiplies on the CSP executor is
+  functionally exact and reuses `run_elementwise`. A credit-efficient
+  deliver-gate-once broadcast generator remains an optimization follow-on.
+- **SE scale MUL detected by operand-size inequality** in the bridge — no new
+  enum needed; equal sizes = plain product, unequal = channel broadcast.
+
+## Wrong decisions / issues caught
+
+- Depthwise oracle again dropped its ReLU6 (unused `relu6` param) — caught by
+  `-Werror=unused-parameter`; fixed to honor the flag.
+- Single-block residual initially added a spurious skip edge from the depthwise
+  activation (`rd`) instead of relying on the external-input fallback (block input
+  == network input for a single block); that mis-sized the ADD. Fixed to one main
+  edge + fallback.
+- **Large-scale depthwise livelock (observation, not fixed here).** At hidden=64
+  @ 8x8 spatial the depthwise produces ~4096 output tiles and trips the executor's
+  livelock detector. hidden=64 @ 4x4 (1024 tiles, as in the M3-T4 model) and the
+  C=48 case (768 tiles) both pass, so the #210 CAM cap is not the cause — this is
+  a separate large-tile-count characteristic of the pooling-window path. The SE
+  test uses a demonstrative scale (hidden=32 @ 4x4, ~512 tiles). Corrected the now-
+  stale `run_depthwise_conv` note (it still claimed a C>=32 deadlock from #210).
+
+## Validation
+
+- `test_m3_efficientnet_block`: MBConv+SE block vs oracle, max_err < 2e-3.
+- Full timing suite: **100% (54/54) passed**.
+- Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the new TU.
+
+## Modified files
+
+- `include/sw/kpu/timing/graph/csp_op_runners.hpp` — `run_ve_unary`,
+  `run_sigmoid`, `run_channel_broadcast_mul`; corrected the depthwise note.
+- `include/sw/kpu/timing/graph/graph_csp_executor.hpp` — SIGMOID + MUL dispatch.
+- `tests/timing/test_m3_efficientnet_block.cpp` — new block test.
+- `tests/timing/CMakeLists.txt` — register the test.
+- `CHANGELOG.md`, `docs/sessions/2026-07-16_v0.9_m3-efficientnet-mbconv-se.md`.
+
+## Follow-on
+
+- Full EfficientNet-B0 builder + demo + writeup (mirrors the M3-T4 MobileNetV2
+  artifact), if pursued.
+- Large-tile-count depthwise (livelock-detector headroom / envelope) — a separate
+  investigation for scaling depthwise beyond ~1-2k output tiles per op.
+- A dedicated SiLU activation (currently approximated by ReLU6).

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -234,6 +234,73 @@ run_relu(const std::vector<float>& x, RunStats& stats) {
 }
 
 /**
+ * @brief Run a unary/scalar VE op (NEG/EXP/... or ADD_S/MUL_S/POW_S) on the CSP
+ *        executor via the value-producing functional path (UNARY form).
+ */
+[[nodiscard]] inline std::vector<float>
+run_ve_unary(sw::kpu::isa::VEOp op, const std::vector<float>& x, float scalar,
+             RunStats& stats) {
+    using schedule::ElementwiseScheduleGenerator;
+    using schedule::FunctionalElementwiseExecutor;
+
+    ElementwiseScheduleGenerator::Config gcfg;
+    gcfg.num_elements = static_cast<Size>(x.size());
+    gcfg.tile_elems = 256;
+    gcfg.form = ElementwiseScheduleGenerator::Form::UNARY;
+    gcfg.a_base = 0x100000; gcfg.b_base = 0x400000; gcfg.c_base = 0x700000;
+
+    ConcurrentTimingExecutor::Config ecfg;
+    ecfg.max_cycles = 20'000'000;
+
+    FunctionalElementwiseExecutor exec(gcfg, ecfg);
+    auto result = exec.run(op, x, {}, scalar);
+    if (!result.execution.success)
+        throw std::runtime_error("run_ve_unary: execution failed: " +
+                                 result.execution.error_message);
+    stats.total_cycles += result.execution.total_cycles;
+    ++stats.ops;
+    return result.values;
+}
+
+/**
+ * @brief Sigmoid = 1/(1 + e^-x) on the CSP executor (EfficientNet SE gate).
+ *
+ * The Vector Engine has no sigmoid op, so it is composed from four unary/scalar
+ * VE ops on the value path: POW_S(ADD_S(EXP(NEG(x)), 1), -1).
+ */
+[[nodiscard]] inline std::vector<float>
+run_sigmoid(const std::vector<float>& x, RunStats& stats) {
+    using VEOp = sw::kpu::isa::VEOp;
+    auto t = run_ve_unary(VEOp::NEG, x, 0.0f, stats);          // -x
+    t = run_ve_unary(VEOp::EXP, t, 0.0f, stats);               // e^-x
+    t = run_ve_unary(VEOp::ADD_S, t, 1.0f, stats);             // 1 + e^-x
+    return run_ve_unary(VEOp::POW_S, t, -1.0f, stats);         // 1/(1 + e^-x)
+}
+
+/**
+ * @brief Channel-broadcast multiply for the squeeze-and-excitation gate: scale
+ *        an [N,C,H,W] activation by a per-channel [N,C] gate on the CSP executor.
+ *
+ * Each activation element (n,c,h,w) is multiplied by gate[n,c]. Because both are
+ * row-major, the gate index of activation element i is i / (H*W) where the plane
+ * size H*W = activation.size()/gate.size(), so no explicit geometry is needed.
+ * The gate is expanded host-side (like run_relu's zeros / run_matmul's blocking)
+ * and the C*H*W multiplies run on the CSP data path via a binary MUL.
+ */
+[[nodiscard]] inline std::vector<float>
+run_channel_broadcast_mul(const std::vector<float>& activation,
+                          const std::vector<float>& gate, RunStats& stats) {
+    if (gate.empty() || activation.size() % gate.size() != 0)
+        throw std::invalid_argument(
+            "run_channel_broadcast_mul: activation size must be a multiple of gate size");
+    const std::size_t plane = activation.size() / gate.size();
+    std::vector<float> gate_full(activation.size());
+    for (std::size_t i = 0; i < activation.size(); ++i)
+        gate_full[i] = gate[i / plane];
+    return run_elementwise(sw::kpu::isa::VEOp::MUL, activation, gate_full, stats);
+}
+
+/**
  * @brief Run a matmul C = act(A @ W + bias) on the CSP executor (the FC layer).
  *
  * A is [M, K] row-major, W is [K, N] row-major. Reuses the value-producing GEMM
@@ -334,9 +401,10 @@ run_matmul(const std::vector<float>& a, const std::vector<float>& w,
  * @param relu6  apply ReLU6 = min(max(x,0),6) as the epilogue
  * @param T      tile size (must divide N*Hout*Wout)
  *
- * @note Validated at channel counts up to 16. The underlying pooling windowed
- *       schedule currently deadlocks at C >= 32 (issue #210) - a pre-existing
- *       E7 limitation, not the reduce; larger-C depthwise is blocked on that fix.
+ * @note The #210 compute-result-CAM cap is fixed, so high channel counts work
+ *       (validated to C=48, 768 output tiles). Very large output-tile counts
+ *       (roughly a few thousand, e.g. hidden=64 at 8x8 spatial) can still trip
+ *       the executor's livelock detector; keep per-op tile counts modest.
  */
 [[nodiscard]] inline std::vector<float>
 run_depthwise_conv(const std::vector<float>& input,

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -198,6 +198,26 @@ public:
                         // MobileNetV2 activation clamp min(max(x,0),6), run as a
                         // standalone VE op (the design's permitted clamp form).
                         out[id] = run_relu6(input_of(g, id, out, input), result.stats);
+                    } else if (op == ElementwiseOp::SIGMOID) {
+                        // EfficientNet SE gate: 1/(1+e^-x) composed from VE ops.
+                        out[id] = run_sigmoid(input_of(g, id, out, input), result.stats);
+                    } else if (op == ElementwiseOp::MUL) {
+                        // Two operands: a full elementwise product when equal
+                        // length, else the squeeze-and-excitation channel-
+                        // broadcast (larger = [N,C,H,W] activation, smaller =
+                        // per-channel [N,C] gate).
+                        auto ins = edge_inputs(g, id, out);
+                        if (ins.size() < 2)
+                            throw std::runtime_error("GraphCspExecutor: MUL needs two operands");
+                        const std::vector<float>& a = *ins[0];
+                        const std::vector<float>& b = *ins[1];
+                        if (a.size() == b.size()) {
+                            out[id] = run_elementwise(sw::kpu::isa::VEOp::MUL, a, b, result.stats);
+                        } else {
+                            const std::vector<float>& act  = a.size() >= b.size() ? a : b;
+                            const std::vector<float>& gate = a.size() >= b.size() ? b : a;
+                            out[id] = run_channel_broadcast_mul(act, gate, result.stats);
+                        }
                     } else {
                         throw std::runtime_error("GraphCspExecutor: unsupported elementwise op");
                     }

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -333,6 +333,16 @@ set_tests_properties(test_m3_mobilenet PROPERTIES
     LABELS "timing;m3;mobilenet;v0.9"
 )
 
+# M3 EfficientNet MBConv + squeeze-and-excitation block (milestone M3, #131): SE
+# gate (GAP->FC->ReLU->FC->sigmoid->channel-broadcast-mul) on the CSP value path.
+kpu_add_component_test(test_m3_efficientnet_block "timing"
+    test_m3_efficientnet_block.cpp
+)
+
+set_tests_properties(test_m3_efficientnet_block PROPERTIES
+    LABELS "timing;m3;efficientnet;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_m3_efficientnet_block.cpp
+++ b/tests/timing/test_m3_efficientnet_block.cpp
@@ -1,0 +1,242 @@
+// ============================================================================
+// tests/timing/test_m3_efficientnet_block.cpp
+// M3 (#131): an EfficientNet MBConv block with squeeze-and-excitation, expressed
+// as a KernelGraph DFG and executed on the CSP value path through
+// GraphCspExecutor, validated vs a composed host oracle. Exercises the SE gate
+// additions - a sigmoid runner (composed from VE ops) and the channel-broadcast
+// multiply (per-channel [N,C] gate x [N,C,H,W] activation) - on top of the
+// inverted-residual (expand / depthwise / project / residual) path.
+//
+//   expand 1x1 -> BN -> ReLU6
+//   3x3 depthwise (stride s) -> BN -> ReLU6            = A
+//   SE: GAP(A) -> FC_reduce -> ReLU -> FC_expand -> sigmoid = gate[N,hidden]
+//       A_scaled = A * gate            (channel broadcast)
+//   project 1x1 -> BN
+//   + residual  when s == 1 && Cin == Cout
+//
+// SiLU/swish is approximated by ReLU6 for the M3 subset (per the design). See
+// docs/plans/m3_mobilenet_dfg.md.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <sw/kpu/kernel.hpp>
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/graph_csp_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+using namespace sw::kpu;
+using namespace sw::kpu::timing::graph;
+using sw::kpu::timing::schedule::Conv2DGeometry;
+using sw::kpu::timing::schedule::BatchNormGeometry;
+using sw::kpu::timing::schedule::Pool2DGeometry;
+using G = sw::kpu::timing::Size;
+
+namespace {
+
+std::vector<float> synth(std::size_t n, std::uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    std::uint64_t s = seed * 2654435761ULL + 12345ULL;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<std::uint32_t>(s >> 33);
+        x = (2.0f * static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+void relu6_ip(std::vector<float>& v) { for (auto& x : v) x = std::min(std::max(0.0f, x), 6.0f); }
+float sigmoidf(float x) { return 1.0f / (1.0f + std::exp(-x)); }
+
+sw::kpu::Conv2DConfig conv_cfg(G N, G Cin, G Cout, G H, G W, G K, G stride, G pad, G groups) {
+    sw::kpu::Conv2DConfig c;
+    c.batch_size = N; c.in_channels = Cin; c.out_channels = Cout;
+    c.input_height = H; c.input_width = W;
+    c.kernel_height = c.kernel_width = K;
+    c.stride_h = c.stride_w = stride; c.padding_h = c.padding_w = pad;
+    c.groups = groups;
+    return c;
+}
+Conv2DGeometry geom_of(const sw::kpu::Conv2DConfig& c) {
+    Conv2DGeometry g;
+    g.N = static_cast<G>(c.batch_size); g.C_in = static_cast<G>(c.in_channels);
+    g.H_in = static_cast<G>(c.input_height); g.W_in = static_cast<G>(c.input_width);
+    g.C_out = static_cast<G>(c.out_channels); g.Kh = static_cast<G>(c.kernel_height);
+    g.Kw = static_cast<G>(c.kernel_width); g.stride_h = static_cast<G>(c.stride_h);
+    g.stride_w = static_cast<G>(c.stride_w); g.pad_h = static_cast<G>(c.padding_h);
+    g.pad_w = static_cast<G>(c.padding_w);
+    return g;
+}
+
+struct BN { std::vector<float> gamma, beta, mean, var; float eps = 1e-3f; };
+BN synth_bn(G C, std::uint64_t seed) {
+    BN b;
+    b.gamma = synth(C, seed + 1, 0.4f); for (auto& g : b.gamma) g += 1.0f;
+    b.beta  = synth(C, seed + 2, 0.2f);
+    b.mean  = synth(C, seed + 3, 0.3f);
+    b.var   = synth(C, seed + 4, 0.2f); for (auto& v : b.var) v = std::abs(v) + 0.5f;
+    return b;
+}
+void set_bn(NodeData& nd, const BN& bn) {
+    nd.gamma = bn.gamma; nd.beta = bn.beta; nd.mean = bn.mean; nd.var = bn.var; nd.eps = bn.eps;
+}
+
+std::vector<float> pw_conv_bn(const std::vector<float>& x, const std::vector<float>& w,
+                              const sw::kpu::Conv2DConfig& cc, const BN& bn, bool relu6) {
+    const auto g = geom_of(cc);
+    auto z = sw::kpu::timing::schedule::conv2d_reference(x, w, {}, g, false);
+    BatchNormGeometry bg; bg.N = g.N; bg.C = g.C_out; bg.H = g.H_out(); bg.W = g.W_out();
+    auto y = sw::kpu::timing::schedule::batchnorm_reference(z, bn.gamma, bn.beta,
+                                                            bn.mean, bn.var, bn.eps, bg);
+    if (relu6) relu6_ip(y);
+    return y;
+}
+std::vector<float> dw_conv_bn(const std::vector<float>& x, const std::vector<float>& filter,
+                              const sw::kpu::Conv2DConfig& cc, const BN& bn, bool relu6) {
+    const auto g = geom_of(cc);
+    const G Hout = g.H_out(), Wout = g.W_out();
+    std::vector<float> y(static_cast<std::size_t>(g.N) * g.C_out * Hout * Wout);
+    for (G n = 0; n < g.N; ++n)
+        for (G c = 0; c < g.C_out; ++c) {
+            const std::size_t plane = (static_cast<std::size_t>(n) * g.C_in + c) * g.H_in * g.W_in;
+            const float scale = bn.gamma[c] / std::sqrt(bn.var[c] + bn.eps);
+            const float shift = bn.beta[c] - bn.mean[c] * scale;
+            for (G ho = 0; ho < Hout; ++ho)
+                for (G wo = 0; wo < Wout; ++wo) {
+                    float acc = 0.0f;
+                    for (G kh = 0; kh < g.Kh; ++kh) {
+                        const long ih = static_cast<long>(ho * g.stride_h + kh) - static_cast<long>(g.pad_h);
+                        if (ih < 0 || ih >= static_cast<long>(g.H_in)) continue;
+                        for (G kw = 0; kw < g.Kw; ++kw) {
+                            const long iw = static_cast<long>(wo * g.stride_w + kw) - static_cast<long>(g.pad_w);
+                            if (iw < 0 || iw >= static_cast<long>(g.W_in)) continue;
+                            acc += x[plane + static_cast<std::size_t>(ih) * g.W_in + iw] *
+                                   filter[(static_cast<std::size_t>(c) * g.Kh + kh) * g.Kw + kw];
+                        }
+                    }
+                    acc = acc * scale + shift;
+                    if (relu6) acc = std::min(std::max(0.0f, acc), 6.0f);
+                    y[((static_cast<std::size_t>(n) * g.C_out + c) * Hout + ho) * Wout + wo] = acc;
+                }
+        }
+    return y;
+}
+
+// Host matmul C[M,N] = A[M,K] @ W[K,N] + bias, optional ReLU.
+std::vector<float> matmul(const std::vector<float>& a, const std::vector<float>& w,
+                          const std::vector<float>& bias, G M, G Kd, G Nd, bool relu) {
+    std::vector<float> c(static_cast<std::size_t>(M) * Nd);
+    for (G m = 0; m < M; ++m)
+        for (G n = 0; n < Nd; ++n) {
+            float acc = bias.empty() ? 0.0f : bias[n];
+            for (G k = 0; k < Kd; ++k) acc += a[m * Kd + k] * w[k * Nd + n];
+            c[m * Nd + n] = relu ? std::max(0.0f, acc) : acc;
+        }
+    return c;
+}
+
+float maxerr(const std::vector<float>& a, const std::vector<float>& b) {
+    float e = 0.0f;
+    for (std::size_t i = 0; i < a.size() && i < b.size(); ++i) e = std::max(e, std::abs(a[i] - b[i]));
+    return e;
+}
+
+} // namespace
+
+TEST_CASE("M3 EfficientNet MBConv+SE block on the CSP executor matches host oracle",
+          "[timing][m3][efficientnet]") {
+    // Tile-aligned (T=16): N=16, Cin=Cout=16, hidden=32 (t=2), SE reduce = 16.
+    const G N = 16, C = 16, H = 4, W = 4, hidden = 32, se = 16;
+    auto x = synth(static_cast<std::size_t>(N) * C * H * W, 1, 1.0f);
+
+    auto cce = conv_cfg(N, C, hidden, H, W, 1, 1, 0, 1);            // expand 1x1
+    auto ccd = conv_cfg(N, hidden, hidden, H, W, 3, 1, 1, hidden);  // depthwise 3x3 s1
+    auto ccp = conv_cfg(N, hidden, C, H, W, 1, 1, 0, 1);            // project 1x1
+    auto we = synth(static_cast<std::size_t>(hidden) * C, 10, 0.15f);
+    auto wd = synth(static_cast<std::size_t>(hidden) * 9, 20, 0.30f);
+    auto wp = synth(static_cast<std::size_t>(C) * hidden, 30, 0.15f);
+    BN bne = synth_bn(hidden, 100), bnd = synth_bn(hidden, 200), bnp = synth_bn(C, 300);
+    auto wr = synth(static_cast<std::size_t>(hidden) * se, 40, 0.15f);   // FC_reduce [hidden, se]
+    auto br = synth(se, 41, 0.1f);
+    auto wx = synth(static_cast<std::size_t>(se) * hidden, 42, 0.15f);   // FC_expand [se, hidden]
+    auto bx = synth(hidden, 43, 0.1f);
+
+    // --- host oracle ---------------------------------------------------------
+    auto e = pw_conv_bn(x, we, cce, bne, /*relu6*/true);
+    auto d = dw_conv_bn(e, wd, ccd, bnd, /*relu6*/true);            // A [N,hidden,H,W]
+    // SE squeeze: mean over the H*W plane per (n,c).
+    std::vector<float> sq(static_cast<std::size_t>(N) * hidden, 0.0f);
+    for (G n = 0; n < N; ++n)
+        for (G c = 0; c < hidden; ++c) {
+            float s = 0.0f;
+            for (G p = 0; p < H * W; ++p) s += d[(static_cast<std::size_t>(n) * hidden + c) * H * W + p];
+            sq[n * hidden + c] = s / static_cast<float>(H * W);
+        }
+    auto red  = matmul(sq, wr, br, N, hidden, se, /*relu*/true);    // [N, se]
+    auto ex   = matmul(red, wx, bx, N, se, hidden, /*relu*/false);  // [N, hidden]
+    std::vector<float> gate(ex.size());
+    for (std::size_t i = 0; i < ex.size(); ++i) gate[i] = sigmoidf(ex[i]);
+    std::vector<float> d_scaled(d.size());                          // A * gate (channel broadcast)
+    for (G n = 0; n < N; ++n)
+        for (G c = 0; c < hidden; ++c)
+            for (G p = 0; p < H * W; ++p) {
+                const std::size_t idx = (static_cast<std::size_t>(n) * hidden + c) * H * W + p;
+                d_scaled[idx] = d[idx] * gate[n * hidden + c];
+            }
+    auto p = pw_conv_bn(d_scaled, wp, ccp, bnp, /*relu6*/false);
+    std::vector<float> oref = p;
+    for (std::size_t i = 0; i < oref.size(); ++i) oref[i] += x[i];   // residual
+
+    // --- DFG -----------------------------------------------------------------
+    KernelGraph g;
+    std::unordered_map<std::size_t, NodeData> nd;
+    auto ce = g.add_kernel(Kernel::create_conv2d(cce, false, ActivationType::NONE), "expand");
+    auto be = g.add_kernel(Kernel::create_batchnorm(N, hidden, H, W, bne.eps), "bn_e");
+    auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * H * W}), "relu6_e");
+    auto cd = g.add_kernel(Kernel::create_conv2d(ccd, false, ActivationType::NONE), "depthwise");
+    auto bd = g.add_kernel(Kernel::create_batchnorm(N, hidden, H, W, bnd.eps), "bn_d");
+    auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * H * W}), "relu6_d");
+    auto gp = g.add_kernel(Kernel::create_global_avg_pool2d(N, hidden, H, W), "se_gap");
+    auto fr = g.add_kernel(Kernel::create_matmul(N, se, hidden), "se_reduce");
+    auto fx = g.add_kernel(Kernel::create_matmul(N, hidden, se), "se_expand");
+    auto sg = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::SIGMOID, {hidden}), "se_sigmoid");
+    auto sc = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::MUL, {hidden * H * W}), "se_scale");
+    auto cp = g.add_kernel(Kernel::create_conv2d(ccp, false, ActivationType::NONE), "project");
+    auto bp = g.add_kernel(Kernel::create_batchnorm(N, C, H, W, bnp.eps), "bn_p");
+    auto ad = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::ADD, {C * H * W}), "add");
+
+    g.add_edge(ce, be); g.add_edge(be, re); g.add_edge(re, cd);
+    g.add_edge(cd, bd); g.add_edge(bd, rd);
+    g.add_edge(rd, gp); g.add_edge(gp, fr); g.add_edge(fr, fx); g.add_edge(fx, sg);
+    g.add_edge(rd, sc);                    // SE scale main branch = depthwise activation A
+    g.add_edge(sg, sc, "C", "B");          // SE scale gate branch
+    g.add_edge(sc, cp); g.add_edge(cp, bp);
+    // Residual: single block, so the identity skip is the block input (== the
+    // external network input x) - one edge + the bridge's external-input
+    // fallback supplies x as the ADD's second operand.
+    g.add_edge(bp, ad);
+
+    nd[ce].filter = we; set_bn(nd[be], bne);
+    nd[cd].filter = wd; set_bn(nd[bd], bnd);
+    nd[cp].filter = wp; set_bn(nd[bp], bnp);
+    nd[fr].fc_weight = wr; nd[fr].fc_bias = br; nd[fr].fc_M = N; nd[fr].fc_K = hidden; nd[fr].fc_N = se; nd[fr].fc_relu = true;
+    nd[fx].fc_weight = wx; nd[fx].fc_bias = bx; nd[fx].fc_M = N; nd[fx].fc_K = se; nd[fx].fc_N = hidden; nd[fx].fc_relu = false;
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, x, nd, /*T*/16);
+
+    REQUIRE(result.output.size() == oref.size());
+    INFO("max_err=" << maxerr(result.output, oref) << " ops=" << result.stats.ops);
+    REQUIRE(maxerr(result.output, oref) < 2e-3f);
+}


### PR DESCRIPTION
## Summary

M3 (#131), the remaining T3 half. The **EfficientNet MBConv bottleneck with squeeze-and-excitation** runs as a `KernelGraph` DFG on the CSP value path through `GraphCspExecutor`, validated against a composed host oracle (`test_m3_efficientnet_block`, max_err < 2e-3). Adds the SE gate — the one M3 op the MobileNetV2 work didn't need.

## New CSP runners (`csp_op_runners.hpp`)

- **`run_sigmoid`** — the Vector Engine has no sigmoid op, so `1/(1+e^-x)` is composed from four unary/scalar VE ops: `POW_S(ADD_S(EXP(NEG(x)),1),-1)`, via a new `run_ve_unary` helper (`Form::UNARY`).
- **`run_channel_broadcast_mul`** — the SE scale: a per-channel `[N,C]` gate × an `[N,C,H,W]` activation. Both row-major, so element `i`'s gate index is `i/(H·W)` with `H·W = activation.size()/gate.size()` — geometry-free. The gate is expanded host-side (like `run_relu`'s zeros) and the `C·H·W` multiplies run on the CSP data path.

## Bridge

`ElementwiseOp::SIGMOID` → `run_sigmoid`; an `ElementwiseOp::MUL` arm that routes to the channel-broadcast multiply when the two operands differ in size (SE scale: larger = activation, smaller = gate) and to a plain product when equal.

## The block

`expand 1×1 → BN → ReLU6 → 3×3 depthwise → BN → ReLU6 → SE → project 1×1 → BN → residual`, where **SE = `GAP → FC_reduce → ReLU → FC_expand → sigmoid → channel-broadcast-multiply`** (the gate scales the depthwise activation). Reuses GAP + matmul (with ReLU epilogue) + the new runners. SiLU/swish is approximated by ReLU6 for the M3 subset (per the design).

## Notes

- Corrected a stale `run_depthwise_conv` doc note (it still claimed a `C >= 32` deadlock from #210, which is fixed — C=48 passes).
- **Observation (not fixed here):** very large depthwise output-tile counts (~4000+, e.g. hidden=64 @ 8×8) trip the executor's livelock detector; hidden=64 @ 4×4 (1024 tiles, as in the M3-T4 model) and C=48 (768 tiles) pass. The SE test uses a demonstrative scale (hidden=32 @ 4×4). Larger-scale depthwise headroom is a separate follow-on.

## Test Results

| Target | build | test |
|--------|-------|------|
| test_m3_efficientnet_block | OK | PASS (max_err < 2e-3) |
| full timing suite | OK | 100% (54/54) |

Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the new TU.

## Scope

A full EfficientNet-B0 builder + demo (mirroring the M3-T4 MobileNetV2 artifact) and a dedicated SiLU activation are follow-ons.

Part of milestone #131.

Generated with [Claude Code](https://claude.com/claude-code)