### PR TITLE
fix(timing): livelock detector must count backward-path + compute progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Livelock detector false-tripped on drain-heavy ops (large depthwise).** The
+  `ConcurrentTimingExecutor`'s livelock detector was fed only forward-path
+  progress (DMA bytes *loaded*, `BlockMover` forward moves, streamer feeds), so
+  once a large operation had fed all its inputs, the remaining COMPUTE → DRAIN →
+  WRITEBACK → STORE phase showed no tracked progress; if that phase exceeded the
+  10000-cycle stall threshold the detector aborted a *progressing* run
+  (`run_depthwise_conv: execution failed: Livelock detected` at e.g. hidden=64 @
+  8x8, ~4096 output tiles). The metrics now count all pipeline stages - forward
+  (load/move/feed), backward (store/writeback/drain) via the full `get_statistics`,
+  and compute (`next_compute_slot_`) - so a genuine livelock (no progress in *any*
+  stage) is still caught while a compute/drain-heavy schedule is not.
+  `test_livelock_progress` locks it in (a windowed pool with a low stall threshold
+  completes without a false trip; fails before the fix). Depthwise now runs to
+  65536 outputs (4096 tiles) with detection on. `run_depthwise_conv` note updated.
+
 ### Added
 
 - **EfficientNet MBConv block with squeeze-and-excitation on the CSP executor —

--- a/docs/sessions/2026-07-17_v0.9_livelock-detector-drain-progress.md
+++ b/docs/sessions/2026-07-17_v0.9_livelock-detector-drain-progress.md
@@ -1,0 +1,81 @@
+# Session Log — 2026-07-17 — Livelock detector: count backward-path progress
+
+**Milestone:** M3 (#131) enabler — unblocks large depthwise / faithful scaling.
+**Branch:** `fix/depthwise-large-tile-livelock`
+**Fidelity tier:** CYCLE_ACCURATE (CSP timing executor).
+
+## Problem
+
+While building the EfficientNet MBConv+SE block (#215) the depthwise runner
+threw `run_depthwise_conv: execution failed: Livelock detected` at hidden=64 @
+8x8 (~4096 output tiles), while hidden=64 @ 4x4 (1024 tiles) and C=48 (768 tiles)
+passed. Since the #210 compute-result-CAM cap was already fixed, this was a
+*new*, separate limit.
+
+## Diagnosis
+
+A scratch probe ran the failing depthwise with `enable_livelock_detection =
+false`: it **completed** correctly (65536 outputs, 45635 cycles). So the schedule
+is not deadlocked - the detector false-tripped.
+
+Root cause: `ConcurrentTimingExecutor` fed the `LivelockDetector` only
+forward-path progress metrics - DMA bytes *loaded*, `BlockMover` forward moves,
+streamer feeds. `ProgressMetrics::total()` also sums a `compute_ops_completed`
+field, but the executor never set it, and stores/writebacks/drains were not
+counted at all. Once a large op has fed every input, the remaining COMPUTE →
+DRAIN → WRITEBACK → STORE phase shows no tracked progress; when that phase
+exceeds the 10000-cycle stall threshold the detector aborts a run that is in fact
+draining thousands of result tiles steadily.
+
+## Fix
+
+Populate the detector metrics from the full pipeline every 100 cycles:
+
+```cpp
+const Statistics st = get_statistics();
+metrics.tiles_dma_completed = st.tiles_loaded + st.tiles_stored;
+metrics.tiles_moved         = st.tiles_moved  + st.tiles_writeback;
+metrics.tiles_streamed      = st.tiles_fed    + st.tiles_drained;
+metrics.compute_ops_completed = next_compute_slot_;
+```
+
+A genuine livelock - no progress in *any* stage for the threshold window - still
+trips (`total()` stays flat). Only false positives, where some stage is
+progressing, are eliminated.
+
+## Validation
+
+- Scratch probe: hidden=64 @ 8x8 depthwise now completes with detection ON
+  (65536 outputs, 45635 cycles).
+- `test_livelock_progress` (new): a windowed pool (16ch @ 8x8, 1024 output tiles)
+  run with detection ON and a deliberately low `livelock_threshold = 500`
+  completes without a false trip (`REQUIRE_FALSE(result.livelock_detected)`) and
+  stores every output tile. Confirmed it FAILS with the fix reverted (git stash)
+  and PASSES with it - a real regression, ~1.05s.
+- Full timing suite: **100% (55/55) passed** - including the multi-tile tests
+  that catch *real* livelocks, so detection is not weakened.
+- Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean.
+
+## Decisions
+
+- **Fix the metric, not disable detection.** The alternative - disabling livelock
+  detection in the value-path runners (they already bound with `max_cycles`) -
+  would lose real-livelock protection for those runners. Correcting the progress
+  signal keeps protection everywhere and fixes the class of false positive, not
+  just depthwise.
+
+## Modified files
+
+- `include/sw/kpu/timing/concurrent_timing_executor.hpp` — detector metrics count
+  all pipeline stages + compute.
+- `include/sw/kpu/timing/graph/csp_op_runners.hpp` — updated the (now-inaccurate)
+  `run_depthwise_conv` livelock note.
+- `tests/timing/test_livelock_progress.cpp` — new regression.
+- `tests/timing/CMakeLists.txt` — register it.
+- `CHANGELOG.md`, `docs/sessions/2026-07-17_v0.9_livelock-detector-drain-progress.md`.
+
+## Follow-on
+
+- With large depthwise unblocked, a more faithful-scale EfficientNet-B0 / larger
+  MobileNetV2 config is possible (though the per-tile executor cost is still high
+  - hidden=64 @ 8x8 was ~27s wall-clock; a perf pass is a separate concern).

--- a/docs/sessions/2026-07-17_v0.9_livelock-detector-drain-progress.md
+++ b/docs/sessions/2026-07-17_v0.9_livelock-detector-drain-progress.md
@@ -64,6 +64,21 @@ progressing, are eliminated.
   signal keeps protection everywhere and fixes the class of false positive, not
   just depthwise.
 
+## Wrong decisions
+
+- **First draft read the metrics via `get_statistics()`.** Convenient, but
+  `collect_statistics()` rescans the entire `events_` history on every call, and
+  the check runs every 100 cycles - so detection cost would grow with
+  duration x event volume, precisely on the large workloads this fix targets
+  (CodeRabbit caught this). Corrected to read the cheap monotonic per-component
+  counters (`total_bytes_loaded/stored`, `total_tiles_moved/writeback`,
+  `total_tiles_fed/drained`, `next_compute_slot_`) directly - O(components) per
+  check, no history scan.
+- **Considered disabling livelock detection in the value-path runners** (they
+  already bound with `max_cycles`). Rejected: it would drop real-livelock
+  protection for those runners and only paper over this specific false positive;
+  fixing the progress signal keeps protection everywhere.
+
 ## Modified files
 
 - `include/sw/kpu/timing/concurrent_timing_executor.hpp` — detector metrics count

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -978,19 +978,18 @@ inline bool ConcurrentTimingExecutor::run() {
 
         // Check for livelock (every 100 cycles to avoid overhead)
         if (livelock_detector_ && (current_cycle_ % 100 == 0)) {
+            // Count progress across ALL pipeline stages - forward (load/move/
+            // feed) AND backward (store/writeback/drain) AND compute. A large op
+            // spends a long phase draining results to DRAM after every input has
+            // been fed; tracking only the forward path plateaus there and
+            // false-trips the detector on a compute/drain-heavy-but-progressing
+            // schedule (e.g. depthwise with thousands of output tiles).
+            const Statistics st = get_statistics();
             LivelockDetector::ProgressMetrics metrics;
-            metrics.tiles_dma_completed = 0;
-            metrics.tiles_moved = 0;
-            metrics.tiles_streamed = 0;
-            for (const auto& dma : dma_engines_) {
-                metrics.tiles_dma_completed += dma->total_bytes_loaded() / 1024;
-            }
-            for (const auto& mover : block_movers_) {
-                metrics.tiles_moved += mover->total_tiles_moved();
-            }
-            for (const auto& streamer : row_streamers_) {
-                metrics.tiles_streamed += streamer->total_tiles_fed();
-            }
+            metrics.tiles_dma_completed = st.tiles_loaded + st.tiles_stored;
+            metrics.tiles_moved = st.tiles_moved + st.tiles_writeback;
+            metrics.tiles_streamed = st.tiles_fed + st.tiles_drained;
+            metrics.compute_ops_completed = next_compute_slot_;
             auto result = livelock_detector_->check(current_cycle_, metrics);
             if (result.livelock_detected) {
                 // Livelock detected - could log or throw

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -983,12 +983,24 @@ inline bool ConcurrentTimingExecutor::run() {
             // spends a long phase draining results to DRAM after every input has
             // been fed; tracking only the forward path plateaus there and
             // false-trips the detector on a compute/drain-heavy-but-progressing
-            // schedule (e.g. depthwise with thousands of output tiles).
-            const Statistics st = get_statistics();
+            // schedule (e.g. depthwise with thousands of output tiles). Read the
+            // cheap monotonic component counters directly (NOT get_statistics(),
+            // which rescans the whole event history on every 100-cycle check).
             LivelockDetector::ProgressMetrics metrics;
-            metrics.tiles_dma_completed = st.tiles_loaded + st.tiles_stored;
-            metrics.tiles_moved = st.tiles_moved + st.tiles_writeback;
-            metrics.tiles_streamed = st.tiles_fed + st.tiles_drained;
+            metrics.tiles_dma_completed = 0;
+            metrics.tiles_moved = 0;
+            metrics.tiles_streamed = 0;
+            for (const auto& dma : dma_engines_)
+                metrics.tiles_dma_completed +=
+                    (dma->total_bytes_loaded() + dma->total_bytes_stored()) / 1024;
+            for (const auto& mover : block_movers_)
+                metrics.tiles_moved +=
+                    mover->total_tiles_moved() + mover->total_tiles_writeback();
+            for (const auto& streamer : row_streamers_)
+                metrics.tiles_streamed +=
+                    streamer->total_tiles_fed() + streamer->total_tiles_drained();
+            for (const auto& streamer : col_streamers_)
+                metrics.tiles_streamed += streamer->total_tiles_fed();
             metrics.compute_ops_completed = next_compute_slot_;
             auto result = livelock_detector_->check(current_cycle_, metrics);
             if (result.livelock_detected) {

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -402,9 +402,9 @@ run_matmul(const std::vector<float>& a, const std::vector<float>& w,
  * @param T      tile size (must divide N*Hout*Wout)
  *
  * @note The #210 compute-result-CAM cap is fixed, so high channel counts work
- *       (validated to C=48, 768 output tiles). Very large output-tile counts
- *       (roughly a few thousand, e.g. hidden=64 at 8x8 spatial) can still trip
- *       the executor's livelock detector; keep per-op tile counts modest.
+ *       (validated to C=48, and hidden=64 at 8x8 = 65536 outputs / 4096 output
+ *       tiles once the livelock detector was taught to count backward-path and
+ *       compute progress, not just load/move/feed).
  */
 [[nodiscard]] inline std::vector<float>
 run_depthwise_conv(const std::vector<float>& input,

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -343,6 +343,16 @@ set_tests_properties(test_m3_efficientnet_block PROPERTIES
     LABELS "timing;m3;efficientnet;v0.9"
 )
 
+# Livelock detector progress regression: backward-path + compute progress must
+# count, so drain-heavy ops (large depthwise) do not false-trip the detector.
+kpu_add_component_test(test_livelock_progress "timing"
+    test_livelock_progress.cpp
+)
+
+set_tests_properties(test_livelock_progress PROPERTIES
+    LABELS "timing;livelock;regression;v0.9"
+)
+
 # Functional elementwise execution with host oracle (issue #102, epic E2):
 # value-producing elementwise/broadcast on the CSP data path
 kpu_add_component_test(test_functional_elementwise "timing"

--- a/tests/timing/test_livelock_progress.cpp
+++ b/tests/timing/test_livelock_progress.cpp
@@ -1,0 +1,84 @@
+// ============================================================================
+// tests/timing/test_livelock_progress.cpp
+// Regression: the livelock detector must count progress across ALL pipeline
+// stages - forward (load/move/feed), backward (store/writeback/drain), and
+// compute - not just the forward path. A large op spends a long phase draining
+// results to DRAM after every input has been fed; counting only load/move/feed
+// plateaus there and false-trips the detector on a progressing schedule (the
+// depthwise-with-thousands-of-output-tiles case).
+//
+// This drives a windowed pooling schedule with a deliberately LOW stall
+// threshold so its drain-back phase exceeds the threshold quickly: before the
+// fix the detector false-tripped, now it completes.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/timing/concurrent_timing_executor.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+#include <sw/kpu/timing/schedule/pooling_schedule_generator.hpp>
+#include <sw/kpu/timing/schedule/schedule_executor.hpp>
+
+#include <limits>
+#include <optional>
+#include <vector>
+
+using namespace sw::kpu::timing;
+using namespace sw::kpu::timing::schedule;
+
+TEST_CASE("Livelock detector counts backward-path progress (no false trip on drain)",
+          "[timing][livelock][regression]") {
+    // Windowed pooling over 16 channels @ 8x8: 16 * (16*8*8 / 16) = 1024 output
+    // tiles, so the drain-back phase (all inputs fed, results still draining)
+    // comfortably exceeds the low stall threshold below.
+    PoolingScheduleGenerator::Config cfg;
+    cfg.geom.N = 16; cfg.geom.C = 16; cfg.geom.H = 8; cfg.geom.W = 8;
+    cfg.geom.Kh = cfg.geom.Kw = 3;
+    cfg.geom.stride_h = cfg.geom.stride_w = 1;
+    cfg.geom.pad_h = cfg.geom.pad_w = 1;
+    cfg.mode = PoolingScheduleGenerator::Mode::WINDOWED; cfg.Ti = 16;
+    cfg.l3_buffer_count = 128; cfg.l2_bank_count = 128;
+    auto sch = PoolingScheduleGenerator(cfg).generate();
+    REQUIRE(sch.valid);
+
+    ConcurrentTimingExecutor::Config ec;
+    ec.enable_livelock_detection = true;   // detection ON
+    ec.livelock_threshold = 500;           // low: the drain-back phase exceeds it
+    ec.l3_buffer_count = 128; ec.l2_bank_count = 128;
+    ec.max_cycles = 3'000'000;
+    ConcurrentTimingExecutor exec(ec);
+
+    const Size K = cfg.geom.window();
+    for (const auto& op : sch.operations) {
+        if (op.type != ScheduleOpType::LOAD) continue;
+        exec.set_tile_payload(op.tile.tile_id,
+                              TilePayload{16, K, std::vector<float>(16 * K, 1.0f)});
+    }
+
+    ScheduleExecutor se(exec);
+    se.set_functional_compute_binder(
+        [K](const ScheduleOperation& op)
+            -> std::optional<ConcurrentTimingExecutor::FunctionalComputeSpec> {
+            ConcurrentTimingExecutor::FunctionalComputeSpec spec;
+            spec.input_tiles = op.dependency_tiles;
+            spec.operation = [K](const std::vector<TilePayload>& in) {
+                const auto& x = in.at(0);
+                TilePayload out{x.rows, 1, std::vector<float>(x.rows)};
+                for (Size r = 0; r < x.rows; ++r) {
+                    float m = -std::numeric_limits<float>::infinity();
+                    for (Size k = 0; k < K; ++k) m = std::max(m, x.values[r * K + k]);
+                    out.values[r] = m;
+                }
+                return out;
+            };
+            return spec;
+        });
+
+    auto result = se.execute(sch);
+    REQUIRE(result.success);
+    REQUIRE_FALSE(result.livelock_detected);
+    REQUIRE(exec.get_statistics().tiles_stored == sch.count_ops(ScheduleOpType::STORE));
+}

--- a/tests/timing/test_livelock_progress.cpp
+++ b/tests/timing/test_livelock_progress.cpp
@@ -78,6 +78,10 @@ TEST_CASE("Livelock detector counts backward-path progress (no false trip on dra
         });
 
     auto result = se.execute(sch);
+    // The run must actually last longer than the stall threshold, otherwise the
+    // drain-back phase is never long enough to exercise the detector and the
+    // regression would pass vacuously.
+    REQUIRE(result.total_cycles > ec.livelock_threshold);
     REQUIRE(result.success);
     REQUIRE_FALSE(result.livelock_detected);
     REQUIRE(exec.get_statistics().tiles_stored == sch.count_ops(ScheduleOpType::STORE));


### PR DESCRIPTION
## Summary

Fixes a livelock-detector **false positive** on drain-heavy operations, surfaced while building the EfficientNet MBConv+SE block: `run_depthwise_conv: execution failed: Livelock detected` at hidden=64 @ 8×8 (~4096 output tiles), while smaller depthwise (1024 / 768 tiles) passed. The #210 compute-result-CAM cap was already fixed — this is a separate limit.

## Root cause

The `ConcurrentTimingExecutor` fed the `LivelockDetector` only **forward-path** progress: DMA bytes *loaded*, `BlockMover` forward moves, streamer feeds. `ProgressMetrics::total()` also sums a `compute_ops_completed` field, but the executor never set it, and stores/writebacks/drains weren't counted. Once a large op has fed every input, the remaining COMPUTE → DRAIN → WRITEBACK → STORE phase shows **no tracked progress**; when it exceeds the 10000-cycle stall threshold the detector aborts a run that is in fact draining thousands of result tiles steadily.

A scratch probe with `enable_livelock_detection = false` proved the schedule **completes correctly** (65536 outputs, 45635 cycles) — a false positive, not a deadlock.

## Fix

Populate the detector metrics from all pipeline stages every 100 cycles:

```cpp
const Statistics st = get_statistics();
metrics.tiles_dma_completed   = st.tiles_loaded + st.tiles_stored;
metrics.tiles_moved           = st.tiles_moved  + st.tiles_writeback;
metrics.tiles_streamed        = st.tiles_fed    + st.tiles_drained;
metrics.compute_ops_completed = next_compute_slot_;
```

A genuine livelock — no progress in **any** stage for the threshold window — still trips (`total()` stays flat). Only false positives, where some stage is progressing, are removed.

## Validation

- `test_livelock_progress` (new): a windowed pool (16ch @ 8×8, 1024 output tiles) run with detection ON and a deliberately low `livelock_threshold = 500` completes without a false trip and stores every output tile. **Confirmed it FAILS with the fix reverted and PASSES with it** — a real regression (~1.05s).
- Depthwise hidden=64 @ 8×8 now completes with detection on (65536 outputs).
- **Full timing suite 100% (55/55)** — including the multi-tile tests that catch *real* livelocks, so detection is not weakened.

Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean.

## Follow-on

Large depthwise is now unblocked, enabling a more faithful-scale EfficientNet-B0 / larger MobileNetV2. (Per-tile executor cost is still high — hidden=64 @ 8×8 was ~27s wall-clock — a perf pass is a separate concern.)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved livelock detection to recognize progress across compute, forward, and drain stages.
  * Prevented false livelock alerts during drain-heavy operations, including depthwise workloads, while preserving genuine livelock detection.

* **Tests**
  * Added regression coverage for pipeline progress during drain-heavy execution.

* **Documentation**
  * Updated depthwise convolution guidance with the latest livelock-detection behavior and validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->