### PR TITLE
feat(m3): full EfficientNet-B0 network as a KernelGraph DFG + demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Full EfficientNet-B0 network as a KernelGraph DFG on the CSP executor —
+  M3 (#131), EfficientNet-B0 achieved.** `build_efficientnet_b0`
+  (`include/sw/kpu/timing/graph/efficientnet.hpp`) assembles the whole network
+  (stem + MBConv+SE bottleneck stack + `1x1` head conv + global-average-pool +
+  FC) as a reusable `KernelGraph` builder with matching per-node weights and a
+  composed host oracle (including the SE gate), executed end-to-end through
+  `GraphCspExecutor`. Beyond MobileNetV2 each block adds a squeeze-and-excitation
+  gate (`GAP → FC_reduce → ReLU → FC_expand → sigmoid → channel-broadcast
+  multiply`) and per-stage depthwise kernel sizes (3x3 and 5x5). Delivered
+  demonstrate / validate / benchmark: `examples/milestones/m3_efficientnet.cpp`
+  (`--dot` + a base / +5x5 sweep), `test_m3_efficientnet` (full network vs oracle,
+  `max_err ~6e-8`, + tile-alignment guard including the SE reduce dim), and
+  writeup `docs/milestones/M3_efficientnet.md`. Reuses the `run_sigmoid` /
+  `run_channel_broadcast_mul` runners and the depthwise/livelock fixes; SiLU
+  approximated by ReLU6 for the M3 subset. Milestone M3 (#131).
+
 ### Fixed
 
 - **Livelock detector false-tripped on drain-heavy ops (large depthwise).** The

--- a/docs/milestones/M3_efficientnet.md
+++ b/docs/milestones/M3_efficientnet.md
@@ -1,0 +1,79 @@
+# DNN Milestone M3: EfficientNet-B0 on the CSP Executor
+
+**Status:** EfficientNet-B0 achieved (capability + demo). Issue #131.
+**Demo:** `examples/milestones/m3_efficientnet.cpp` (`ctest -R m3_efficientnet`).
+**Design:** `docs/plans/m3_mobilenet_dfg.md`. **Template:** M3 MobileNetV2
+(`docs/milestones/M3_mobilenet.md`).
+
+---
+
+## What this delivers
+
+**EfficientNet-B0** — the MBConv + squeeze-and-excitation CNN — expressed as a
+**dataflow graph (DFG)** and executed end-to-end on the credit-based CSP
+concurrent executor, with real fp32 values flowing DRAM → L3 → L2 → compute → …
+The whole network runs through one `KernelGraph`, and its classification output
+is validated elementwise against a composed host oracle.
+
+Beyond the MobileNetV2 milestone, EfficientNet-B0 adds:
+
+- **Squeeze-and-excitation** — a per-channel gate between the depthwise and the
+  project: `GAP → FC_reduce → ReLU → FC_expand → sigmoid → channel-broadcast
+  multiply` scales the block activation by its per-channel gate. This reuses GAP +
+  matmul (with a ReLU epilogue) + two new CSP runners: **`run_sigmoid`** (the
+  Vector Engine has no sigmoid, so `1/(1+e^-x)` is composed from four unary/scalar
+  VE ops) and **`run_channel_broadcast_mul`** (the SE scale, a per-channel `[N,C]`
+  gate × `[N,C,H,W]` activation).
+- **Per-stage depthwise kernel sizes** (3×3 and 5×5) — `run_depthwise_conv`
+  handles arbitrary `Kh×Kw`; the livelock-detector fix (counting backward-path +
+  compute progress) lets wider/deeper depthwise run.
+
+## Architecture: a KernelGraph DFG + the M2/M3 bridge
+
+EfficientNet-B0 is built by `build_efficientnet_b0`
+(`include/sw/kpu/timing/graph/efficientnet.hpp`) as a **`KernelGraph`** and
+executed by **`GraphCspExecutor`**, reusing the M2/M3 bridge:
+
+- **stem** — `3×3 s1 conv → BN → ReLU6`.
+- **MBConv+SE stack** — each block is `1×1 expand → BN → ReLU6 → k×k depthwise
+  (stride s) → BN → ReLU6 → SE gate → 1×1 project → BN`, with an **identity
+  residual** (an explicit graph edge) when `stride == 1 && Cin == Cout`. As in the
+  real model, the `t == 1` stage omits the expansion, and the project is a linear
+  bottleneck (no activation, none after the residual add).
+- **head** — `1×1 conv → BN → ReLU6 → global-average-pool → FC`.
+
+The bridge folds each BatchNorm into its conv, dispatches pointwise/expand/project
+`1×1` convs to im2col→GEMM and depthwise convs (`groups == Cin`) to the
+pooling-window path, runs the SE `sigmoid` and channel-broadcast `MUL` as VE ops,
+and joins the identity residuals. Because the SE `sigmoid` alone is four VE ops
+and each `ReLU6` is two, the CSP op count can exceed the graph node count.
+
+## Definition of done
+
+- **Demonstrate** — the whole network runs end-to-end on the CSP executor;
+  `--dot FILE` emits the `KernelGraph`.
+- **Validate** — output compared elementwise against a composed whole-network host
+  oracle (pointwise / depthwise conv, BN, ReLU6, the SE gate, add, GAP, FC),
+  `max_err < 5e-3` (observed ~6e-8).
+- **Benchmark** — cycles, CSP ops, cyc/op, and DMA/BM/STR stalls across a small
+  sweep (compact base + a 5×5 MBConv variant).
+
+## Honest scope
+
+Dimensions are scaled for a fast CSP simulation (as the other milestones), with
+the tile-alignment discipline: batch and all channel counts — **including the SE
+reduce dim** — are multiples of the tile size, so the SE reduction uses a
+tile-aligned floor (16) rather than the real `Cin/4` at these small widths.
+**SiLU/swish is approximated by ReLU6** for the M3 subset (documented; a dedicated
+SiLU activation is a follow-on). The DFX tiling/dataflow compiler remains
+matmul-only — M3 tests operator-level fusions + the SE composition, not a full CNN
+compiler.
+
+## Files
+
+- `include/sw/kpu/timing/graph/efficientnet.hpp` — reusable `build_efficientnet_b0`
+  builder + composed host oracle + `EfficientNetB0Spec`.
+- `examples/milestones/m3_efficientnet.cpp` — demonstrate / validate / benchmark
+  driver (`--dot`, spec sweep).
+- `tests/timing/test_m3_efficientnet.cpp` — full network vs oracle + spec guard.
+- `tests/timing/test_m3_efficientnet_block.cpp` — the MBConv+SE block.

--- a/docs/sessions/2026-07-17_v0.9_m3-efficientnet-b0-model.md
+++ b/docs/sessions/2026-07-17_v0.9_m3-efficientnet-b0-model.md
@@ -1,0 +1,77 @@
+# Session Log — 2026-07-17 — Full EfficientNet-B0 network + demo
+
+**Milestone:** M3 (#131) — EfficientNet-B0 (achieved)
+**Branch:** `feat/m3-efficientnet-b0-model`
+**Fidelity tier:** CYCLE_ACCURATE (CSP timing executor, value path)
+**Builds on:** MBConv+SE block (#215), livelock fix (#216), M3-T4 MobileNetV2 (#214).
+
+## Goal
+
+Assemble the full EfficientNet-B0 network as a `KernelGraph` DFG on the CSP value
+path and deliver the three-tier DoD + writeup, mirroring the M3-T4 MobileNetV2
+artifact and reusing the SE runners from #215. The livelock fix (#216) unblocked
+the wider/deeper depthwise EfficientNet needs.
+
+## What was done
+
+- **`include/sw/kpu/timing/graph/efficientnet.hpp`** — `EfficientNetB0Spec`
+  (per-stage `{t, c, n, s, k, se}`) + `build_efficientnet_b0` (stem + MBConv+SE
+  bottleneck stack + `1x1` head + GAP + FC), a reusable builder with per-node
+  weights and a composed host oracle including the SE gate. Generalizes the
+  MobileNetV2 builder: adds the SE branch (GAP → FC_reduce(ReLU) → FC_expand →
+  sigmoid → channel-broadcast scale) per block and per-stage depthwise kernel
+  size (3 or 5). No new runners - all dispatch through the M2/M3 bridge + the
+  #215 SE runners.
+- **`examples/milestones/m3_efficientnet.cpp`** — demonstrate/validate/benchmark
+  driver (`--dot`, base / +5x5 sweep), mirroring `m3_mobilenet.cpp`.
+- **`tests/timing/test_m3_efficientnet.cpp`** — full network vs oracle
+  (`max_err ~6e-8`) + a tile-alignment guard on the SE reduce dim.
+- Writeup `docs/milestones/M3_efficientnet.md`; CMake registration.
+
+## Decisions
+
+- **SE reduce dim uses a tile-aligned floor (16), not the real `Cin/4`.** At the
+  scaled-down demo widths, `Cin/4` is not a multiple of the tile, and the SE FCs
+  are GEMMs that must be tile-aligned. Documented as honest scope; the SE
+  composition and gate math are exact.
+- **Reused the block from #215 as-is.** The full model is the #215 MBConv+SE block
+  stacked, with the t==1-no-expansion and explicit-identity-skip rules already
+  established for MobileNetV2 - no new bridge or runner work.
+- **Compact demo sweep.** Per-spec cost is high (the SE FCs + depthwise +
+  optional 5x5), so the demo runs a compact base + a single 5x5 variant (~24s)
+  rather than a batch sweep; the fuller default spec is validated by the test.
+
+## Wrong decisions
+
+None this session - the MBConv+SE block, the t==1 rule, the explicit-skip rule,
+and the finite/eps guards were all carried over correctly from the MobileNetV2
+and SE-block work (each of which cost a fix earlier). The oracle matched on the
+first full run (max_err ~6e-8).
+
+## Validation
+
+- `test_m3_efficientnet`: full network `max_err < 5e-3` (observed ~6e-8), all
+  outputs finite, node/op counts sane (base 32 nodes -> 36 CSP ops - ops exceed
+  nodes because the SE sigmoid is 4 VE ops and each ReLU6 is 2); tile-alignment
+  guard throws on a non-aligned SE dim. ~18s.
+- Demo: base + 5x5 variant all PASS, max_err ~6e-8, ~24s.
+- Full timing suite: **100% (57/57) passed**.
+- Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the new TUs.
+
+## Modified files
+
+- `include/sw/kpu/timing/graph/efficientnet.hpp` — new reusable builder + oracle.
+- `examples/milestones/m3_efficientnet.cpp` — new demo driver.
+- `examples/milestones/CMakeLists.txt` — register `m3_efficientnet`.
+- `tests/timing/test_m3_efficientnet.cpp` — new full-network test.
+- `tests/timing/CMakeLists.txt` — register the test.
+- `docs/milestones/M3_efficientnet.md` — new writeup.
+- `CHANGELOG.md`, `docs/sessions/2026-07-17_v0.9_m3-efficientnet-b0-model.md`.
+
+## Follow-on
+
+- A dedicated SiLU/swish activation (currently approximated by ReLU6).
+- Faithful `Cin/4` SE reduction (needs larger tile-aligned widths, hence more
+  executor time) - or a smaller tile size.
+- Per-tile executor performance (a full EfficientNet forward is minutes at larger
+  scale) - a separate perf concern.

--- a/examples/milestones/CMakeLists.txt
+++ b/examples/milestones/CMakeLists.txt
@@ -43,3 +43,16 @@ if(KPU_BUILD_TESTS)
         LABELS "timing;mobilenet;milestone;v0.9"
     )
 endif()
+
+# M3: EfficientNet-B0 demo + benchmark (issue #131)
+add_executable(m3_efficientnet m3_efficientnet.cpp)
+target_link_libraries(m3_efficientnet PRIVATE kpu_simulator)
+set_target_properties(m3_efficientnet PROPERTIES
+    FOLDER "Examples/Milestones"
+)
+if(KPU_BUILD_TESTS)
+    add_test(NAME m3_efficientnet COMMAND m3_efficientnet)
+    set_tests_properties(m3_efficientnet PROPERTIES
+        LABELS "timing;efficientnet;milestone;v0.9"
+    )
+endif()

--- a/examples/milestones/m3_efficientnet.cpp
+++ b/examples/milestones/m3_efficientnet.cpp
@@ -1,0 +1,154 @@
+/**
+ * @file m3_efficientnet.cpp
+ * @brief DNN Milestone M3: EfficientNet-B0 as a dataflow graph on the CSP executor.
+ *
+ * The EfficientNet half of M3 (issue #131). The full EfficientNet-B0 (stem +
+ * MBConv+SE bottleneck stack + 1x1 head conv + global-average-pool + FC) is
+ * expressed as a KernelGraph DFG and executed end-to-end on the credit-based CSP
+ * value path through GraphCspExecutor. Beyond MobileNetV2 each block adds a
+ * squeeze-and-excitation gate (GAP -> FC_reduce -> ReLU -> FC_expand -> sigmoid
+ * -> channel-broadcast multiply) and per-stage depthwise kernel sizes (3 or 5).
+ *
+ * Three-tier definition of done:
+ *  - Demonstrate: the whole network runs end-to-end; `--dot FILE` emits the graph.
+ *  - Validate: output compared elementwise against a composed whole-network host
+ *    oracle (conv/depthwise/BN/ReLU6/SE/add/GAP/FC).
+ *  - Benchmark: cycles, CSP ops, cyc/op, and DMA/BM/STR stall breakdown.
+ *
+ * SiLU/swish is approximated by ReLU6 for the M3 subset (per the design).
+ *
+ * Usage: m3_efficientnet [--dot FILE]
+ * Writeup: docs/milestones/M3_efficientnet.md
+ */
+
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/efficientnet.hpp>
+
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace sw::kpu::timing::graph;
+
+namespace {
+
+struct Row {
+    std::string name;
+    std::size_t nodes = 0, ops = 0;
+    bool pass = false;
+    bool dot_ok = true;
+    float max_err = 0.0f;
+    RunStats stats;
+};
+
+Row run_spec(const std::string& name, const EfficientNetB0Spec& spec,
+             const std::string& dot_path) {
+    sw::kpu::KernelGraph g;
+    auto net = build_efficientnet_b0(g, spec);
+    bool dot_ok = true;
+    if (!dot_path.empty()) {
+        std::ofstream f(dot_path);
+        f << g.to_dot(true);
+        dot_ok = static_cast<bool>(f);
+    }
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, net.input, net.node_data, spec.tile);
+
+    Row r;
+    r.name = name;
+    r.nodes = net.num_nodes;
+    r.ops = result.stats.ops;
+    r.stats = result.stats;
+    r.dot_ok = dot_ok;
+    r.pass = result.output.size() == net.oracle.size();
+    bool finite = true;
+    for (std::size_t i = 0; i < result.output.size() && i < net.oracle.size(); ++i) {
+        const float d = std::abs(result.output[i] - net.oracle[i]);
+        if (!std::isfinite(result.output[i]) || !std::isfinite(d)) finite = false;
+        r.max_err = std::max(r.max_err, d);
+    }
+    r.pass = r.pass && finite && r.max_err < 5e-3f;
+    return r;
+}
+
+void print_row(const Row& r) {
+    double cyc_per_op = r.ops ? static_cast<double>(r.stats.total_cycles) / static_cast<double>(r.ops) : 0.0;
+    std::cout << "  " << std::left << std::setw(26) << r.name << std::right
+              << std::setw(7) << r.nodes
+              << std::setw(6) << r.ops
+              << std::setw(11) << r.stats.total_cycles
+              << std::setw(10) << std::fixed << std::setprecision(0) << cyc_per_op
+              << std::setw(9) << r.stats.dma_stalls
+              << std::setw(9) << r.stats.bm_stalls
+              << std::setw(9) << r.stats.str_stalls
+              << std::setw(11) << std::scientific << std::setprecision(1) << r.max_err
+              << std::setw(7) << (r.pass ? "PASS" : "FAIL") << "\n"
+              << std::defaultfloat;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    std::string dot_path;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--dot") == 0 && i + 1 < argc) {
+            dot_path = argv[++i];
+        } else {
+            std::cout << "Usage: " << argv[0] << " [--dot FILE]\n";
+            return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
+        }
+    }
+
+    std::cout << "\n"
+        "======================================================================\n"
+        "DNN Milestone M3: EfficientNet-B0 as a DFG on the CSP concurrent executor\n"
+        "The whole network runs through the credit-based dataflow (pointwise conv\n"
+        "im2col->GEMM, depthwise conv (3x3/5x5) via pooling-window unfold, folded\n"
+        "BN, ReLU6, squeeze-and-excitation gate, inverted-residual adds, global-\n"
+        "avg-pool, FC); outputs are validated against a whole-network host oracle.\n"
+        "======================================================================\n\n";
+
+    std::vector<Row> rows;
+
+    // Compact base (fast), plus a variant adding a 5x5 MBConv stage.
+    EfficientNetB0Spec base;
+    base.stages = { {1, 16, 1, 1, 3, 16}, {2, 32, 1, 2, 3, 16} };
+    rows.push_back(run_spec("efficientnet-b0 (base)", base, dot_path));
+
+    EfficientNetB0Spec k5 = base;
+    k5.stages.push_back({2, 32, 1, 1, 5, 16});   // extra 5x5 MBConv stage
+    rows.push_back(run_spec("efficientnet-b0 (+5x5)", k5, {}));
+
+    std::cout << "  " << std::left << std::setw(26) << "configuration" << std::right
+              << std::setw(7) << "nodes" << std::setw(6) << "ops"
+              << std::setw(11) << "cycles" << std::setw(10) << "cyc/op"
+              << std::setw(9) << "dmaStl" << std::setw(9) << "bmStl"
+              << std::setw(9) << "strStl" << std::setw(11) << "maxErr"
+              << std::setw(7) << "check" << "\n";
+    std::cout << "  " << std::string(103, '-') << "\n";
+
+    bool all_pass = true;
+    for (const auto& r : rows) { print_row(r); all_pass = all_pass && r.pass; }
+
+    std::cout << "\n  Fusion: BatchNorm folded into each conv; the base network's "
+              << rows.front().nodes << " graph nodes\n  execute as "
+              << rows.front().ops << " CSP ops (depthwise -> pooling-window path;"
+                 " SE gate = GAP/FC/sigmoid/broadcast-mul).\n";
+    std::cout << "  Validation: " << (all_pass ? "ALL PASS" : "FAILURES PRESENT")
+              << " (oracle: composed whole-network host reference, tol 5e-3)\n";
+    if (!dot_path.empty()) {
+        if (rows.front().dot_ok) {
+            std::cout << "  KernelGraph written to " << dot_path << " (Graphviz dot)\n";
+        } else {
+            std::cerr << "  error: could not write KernelGraph to " << dot_path << "\n";
+            all_pass = false;
+        }
+    }
+    std::cout << "\n";
+    return all_pass ? 0 : 1;
+}

--- a/include/sw/kpu/timing/graph/efficientnet.hpp
+++ b/include/sw/kpu/timing/graph/efficientnet.hpp
@@ -1,0 +1,376 @@
+// ============================================================================
+// include/sw/kpu/timing/graph/efficientnet.hpp
+// Reusable EfficientNet-B0 builder: constructs the network (stem + MBConv+SE
+// bottleneck stack + 1x1 head conv + global-average-pool + FC) as a KernelGraph
+// DFG, with matching per-node weights and a composed host oracle (M3, #131).
+// See docs/plans/m3_mobilenet_dfg.md and docs/milestones/M3_efficientnet.md.
+//
+// Executed through GraphCspExecutor on the CSP value path. Beyond MobileNetV2 the
+// MBConv block adds a squeeze-and-excitation gate between the depthwise and the
+// project: GAP -> FC_reduce -> ReLU -> FC_expand -> sigmoid -> channel-broadcast
+// multiply. Depthwise convs use per-stage kernel sizes (3 or 5). SiLU/swish is
+// approximated by ReLU6 for the M3 subset (per the design). Dims are scaled for a
+// fast CSP demo; batch N keeps every conv GEMM's M = N*Hout*Wout tile-aligned.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/kernel.hpp>
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/graph_csp_executor.hpp>
+#include <sw/kpu/timing/schedule/conv2d_im2col.hpp>
+#include <sw/kpu/timing/schedule/batchnorm_affine.hpp>
+#include <sw/kpu/timing/schedule/pooling_window.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+namespace sw::kpu::timing::graph {
+
+/// EfficientNet-B0 topology (scaled for the CSP demo). All channels and the SE
+/// reduce dim are tile-aligned; the batch keeps every conv GEMM's
+/// M = batch*Hout*Wout a multiple of the tile (the FC's M = batch, so batch >=
+/// tile). Each MBConv stage is {expansion t, out_channels c, repeats n, first-
+/// block stride s, depthwise kernel k, SE reduce dim se}: the first block of a
+/// stage strides by s and changes channels (no residual), the rest stride 1 with
+/// identity residuals.
+struct EfficientNetB0Spec {
+    struct Stage { Size t, c, n, s, k, se; };
+
+    Size batch = 16;
+    Size in_channels = 16, height = 8, width = 8;   // stem input
+    Size stem_channels = 16;                        // stem 3x3 conv output width
+    std::vector<Stage> stages = {
+        {1, 16, 1, 1, 3, 16},   // MBConv1, k3, no expansion, identity residual
+        {2, 32, 1, 2, 3, 16},   // MBConv2, k3, s2 downsample 8->4
+        {2, 32, 1, 1, 5, 16},   // MBConv2, k5, identity residual
+    };
+    Size head_channels = 16;   ///< final 1x1 conv width (scaled from 1280)
+    Size num_classes = 16;
+    Size tile = 16;   ///< GEMM tile; batch/channels/num_classes/se must be multiples
+    float eps = 1e-3f;
+    std::uint64_t seed = 3000;
+};
+
+struct EfficientNetB0 {
+    std::unordered_map<std::size_t, NodeData> node_data;
+    std::vector<float> input;
+    std::vector<float> oracle;   // [batch, num_classes]
+    std::size_t output_node = 0;
+    std::size_t num_nodes = 0;
+};
+
+namespace detail {
+
+inline std::vector<float> ef_synth(std::size_t n, std::uint64_t seed, float scale) {
+    std::vector<float> v(n);
+    std::uint64_t s = seed * 2654435761ULL + 12345ULL;
+    for (auto& x : v) {
+        s = s * 6364136223846793005ULL + 1442695040888963407ULL;
+        auto bits = static_cast<std::uint32_t>(s >> 33);
+        x = (2.0f * static_cast<float>(bits) / static_cast<float>(0x7FFFFFFF) - 1.0f) * scale;
+    }
+    return v;
+}
+
+inline sw::kpu::Conv2DConfig ef_conv_cfg(Size N, Size Cin, Size Cout, Size H, Size W,
+                                         Size K, Size stride, Size pad, Size groups = 1) {
+    sw::kpu::Conv2DConfig c;
+    c.batch_size = N; c.in_channels = Cin; c.out_channels = Cout;
+    c.input_height = H; c.input_width = W;
+    c.kernel_height = c.kernel_width = K;
+    c.stride_h = c.stride_w = stride; c.padding_h = c.padding_w = pad;
+    c.groups = groups;
+    return c;
+}
+inline schedule::Conv2DGeometry ef_geom(const sw::kpu::Conv2DConfig& c) {
+    schedule::Conv2DGeometry g;
+    g.N = static_cast<Size>(c.batch_size); g.C_in = static_cast<Size>(c.in_channels);
+    g.H_in = static_cast<Size>(c.input_height); g.W_in = static_cast<Size>(c.input_width);
+    g.C_out = static_cast<Size>(c.out_channels); g.Kh = static_cast<Size>(c.kernel_height);
+    g.Kw = static_cast<Size>(c.kernel_width); g.stride_h = static_cast<Size>(c.stride_h);
+    g.stride_w = static_cast<Size>(c.stride_w); g.pad_h = static_cast<Size>(c.padding_h);
+    g.pad_w = static_cast<Size>(c.padding_w);
+    return g;
+}
+
+struct EfBN { std::vector<float> gamma, beta, mean, var; float eps; };
+inline EfBN ef_bn(Size C, std::uint64_t seed, float eps) {
+    EfBN b; b.eps = eps;
+    b.gamma = ef_synth(C, seed * 4 + 1, 0.4f); for (auto& g : b.gamma) g += 1.0f;
+    b.beta  = ef_synth(C, seed * 4 + 2, 0.2f);
+    b.mean  = ef_synth(C, seed * 4 + 3, 0.3f);
+    b.var   = ef_synth(C, seed * 4 + 4, 0.2f); for (auto& v : b.var) v = std::abs(v) + 0.5f;
+    return b;
+}
+inline void ef_set_bn(NodeData& nd, const EfBN& bn) {
+    nd.gamma = bn.gamma; nd.beta = bn.beta; nd.mean = bn.mean; nd.var = bn.var; nd.eps = bn.eps;
+}
+inline void ef_relu6_ip(std::vector<float>& v) {
+    for (auto& x : v) x = std::min(std::max(0.0f, x), 6.0f);
+}
+
+// Standard (pointwise) conv -> BN inference -> optional ReLU6. NCHW.
+inline std::vector<float> ef_pw_conv_bn(const std::vector<float>& x, const std::vector<float>& w,
+                                        const sw::kpu::Conv2DConfig& cc, const EfBN& bn, bool relu6) {
+    const auto g = ef_geom(cc);
+    auto z = schedule::conv2d_reference(x, w, {}, g, false);
+    schedule::BatchNormGeometry bg; bg.N = g.N; bg.C = g.C_out; bg.H = g.H_out(); bg.W = g.W_out();
+    auto y = schedule::batchnorm_reference(z, bn.gamma, bn.beta, bn.mean, bn.var, bn.eps, bg);
+    if (relu6) ef_relu6_ip(y);
+    return y;
+}
+
+// Per-channel depthwise conv (kxk) -> BN inference -> optional ReLU6. NCHW.
+inline std::vector<float> ef_dw_conv_bn(const std::vector<float>& x, const std::vector<float>& filter,
+                                        const sw::kpu::Conv2DConfig& cc, const EfBN& bn, bool relu6) {
+    const auto g = ef_geom(cc);
+    const Size Hout = g.H_out(), Wout = g.W_out();
+    std::vector<float> y(static_cast<std::size_t>(g.N) * g.C_out * Hout * Wout);
+    for (Size n = 0; n < g.N; ++n)
+        for (Size c = 0; c < g.C_out; ++c) {
+            const std::size_t plane = (static_cast<std::size_t>(n) * g.C_in + c) * g.H_in * g.W_in;
+            const float scale = bn.gamma[c] / std::sqrt(bn.var[c] + bn.eps);
+            const float shift = bn.beta[c] - bn.mean[c] * scale;
+            for (Size ho = 0; ho < Hout; ++ho)
+                for (Size wo = 0; wo < Wout; ++wo) {
+                    float acc = 0.0f;
+                    for (Size kh = 0; kh < g.Kh; ++kh) {
+                        const long ih = static_cast<long>(ho * g.stride_h + kh) - static_cast<long>(g.pad_h);
+                        if (ih < 0 || ih >= static_cast<long>(g.H_in)) continue;
+                        for (Size kw = 0; kw < g.Kw; ++kw) {
+                            const long iw = static_cast<long>(wo * g.stride_w + kw) - static_cast<long>(g.pad_w);
+                            if (iw < 0 || iw >= static_cast<long>(g.W_in)) continue;
+                            acc += x[plane + static_cast<std::size_t>(ih) * g.W_in + iw] *
+                                   filter[(static_cast<std::size_t>(c) * g.Kh + kh) * g.Kw + kw];
+                        }
+                    }
+                    acc = acc * scale + shift;
+                    if (relu6) acc = std::min(std::max(0.0f, acc), 6.0f);
+                    y[((static_cast<std::size_t>(n) * g.C_out + c) * Hout + ho) * Wout + wo] = acc;
+                }
+        }
+    return y;
+}
+
+// Host matmul C[M,N] = A[M,K] @ W[K,N] + bias, optional ReLU.
+inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vector<float>& w,
+                                    const std::vector<float>& bias, Size M, Size Kd, Size Nd, bool relu) {
+    std::vector<float> c(static_cast<std::size_t>(M) * Nd);
+    for (Size m = 0; m < M; ++m)
+        for (Size n = 0; n < Nd; ++n) {
+            float acc = bias.empty() ? 0.0f : bias[n];
+            for (Size k = 0; k < Kd; ++k) acc += a[m * Kd + k] * w[k * Nd + n];
+            c[m * Nd + n] = relu ? std::max(0.0f, acc) : acc;
+        }
+    return c;
+}
+
+} // namespace detail
+
+/**
+ * @brief Build EfficientNet-B0 into `g`; return weights + input + oracle.
+ *
+ * Topology: stem (3x3 s1 conv -> BN -> ReLU6) + a stack of MBConv+SE bottlenecks
+ * (1x1 expand -> BN -> ReLU6 -> kxk depthwise -> BN -> ReLU6 -> SE gate -> 1x1
+ * project -> BN, with an identity residual when stride==1 and Cin==Cout; the
+ * t==1 stage omits the expansion) + a 1x1 head conv -> BN -> ReLU6 + global-
+ * average-pool + FC. Execute the returned graph through GraphCspExecutor and
+ * compare its output to `oracle` (tol ~5e-3).
+ */
+[[nodiscard]] inline EfficientNetB0 build_efficientnet_b0(KernelGraph& g, const EfficientNetB0Spec& sp) {
+    using namespace detail;
+    using sw::kpu::Kernel;
+    using sw::kpu::ElementwiseOp;
+    using sw::kpu::ActivationType;
+
+    auto aligned = [&](Size v) { return v != 0 && v % sp.tile == 0; };
+    if (sp.tile == 0 || !aligned(sp.batch))
+        throw std::invalid_argument("build_efficientnet_b0: batch must be a nonzero multiple of tile");
+    if (!aligned(sp.in_channels) || !aligned(sp.stem_channels) ||
+        !aligned(sp.head_channels) || !aligned(sp.num_classes))
+        throw std::invalid_argument("build_efficientnet_b0: in/stem/head/class channels must be multiples of tile");
+    if (sp.height == 0 || sp.width == 0 || sp.stages.empty())
+        throw std::invalid_argument("build_efficientnet_b0: invalid geometry");
+    if (!std::isfinite(sp.eps) || sp.eps <= 0.0f)
+        throw std::invalid_argument("build_efficientnet_b0: eps must be finite and positive");
+    for (const auto& st : sp.stages)
+        if (st.t == 0 || !aligned(st.c) || st.n == 0 || (st.s != 1 && st.s != 2) ||
+            (st.k != 3 && st.k != 5) || !aligned(st.se))
+            throw std::invalid_argument("build_efficientnet_b0: invalid stage");
+
+    EfficientNetB0 net;
+    auto& nd = net.node_data;
+    const Size N = sp.batch;
+    std::uint64_t seed = sp.seed;
+
+    net.input = ef_synth(static_cast<std::size_t>(N) * sp.in_channels * sp.height * sp.width, seed, 1.0f);
+    std::vector<float> ox = net.input;
+    Size cur_ch = sp.in_channels, cur_H = sp.height, cur_W = sp.width;
+    auto out_dim = [](Size in, Size K, Size stride, Size pad) { return (in + 2 * pad - K) / stride + 1; };
+
+    // ----- stem: 3x3 s1 conv -> BN -> ReLU6 -----------------------------------
+    std::size_t in_node;
+    {
+        auto cc = ef_conv_cfg(N, sp.in_channels, sp.stem_channels, cur_H, cur_W, 3, 1, 1);
+        auto w  = ef_synth(static_cast<std::size_t>(sp.stem_channels) * sp.in_channels * 9, seed, 0.1f);
+        auto bn = ef_bn(sp.stem_channels, seed, sp.eps);
+        auto c = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "stem_conv");
+        auto b = g.add_kernel(Kernel::create_batchnorm(N, sp.stem_channels, cur_H, cur_W, sp.eps), "stem_bn");
+        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {sp.stem_channels * cur_H * cur_W}), "stem_relu6");
+        g.add_edge(c, b); g.add_edge(b, r);
+        nd[c].filter = w; ef_set_bn(nd[b], bn);
+        ox = ef_pw_conv_bn(ox, w, cc, bn, true);
+        in_node = r; cur_ch = sp.stem_channels;
+        ++seed;
+    }
+
+    // ----- MBConv+SE bottleneck stack -----------------------------------------
+    for (const auto& st : sp.stages) {
+        for (Size blk = 0; blk < st.n; ++blk) {
+            const Size stride = (blk == 0) ? st.s : 1;
+            const Size in_ch = cur_ch, out_ch = st.c;
+            const Size hidden = st.t * in_ch;
+            const Size pad = st.k / 2;
+            const bool expand = (st.t > 1);
+            const bool residual = (stride == 1 && in_ch == out_ch);
+            const Size Hd = out_dim(cur_H, st.k, stride, pad), Wd = out_dim(cur_W, st.k, stride, pad);
+
+            auto ccd = ef_conv_cfg(N, hidden, hidden, cur_H, cur_W, st.k, stride, pad, hidden); // depthwise
+            auto ccp = ef_conv_cfg(N, hidden, out_ch, Hd, Wd, 1, 1, 0);                          // project 1x1
+            auto wd = ef_synth(static_cast<std::size_t>(hidden) * st.k * st.k, seed + 1, 0.25f);
+            auto wp = ef_synth(static_cast<std::size_t>(out_ch) * hidden, seed + 2, 0.12f);
+            auto bnd = ef_bn(hidden, seed + 1, sp.eps), bnp = ef_bn(out_ch, seed + 2, sp.eps);
+
+            // Expansion (only t > 1): 1x1 -> BN -> ReLU6.
+            std::size_t dw_in_node = in_node;
+            std::vector<float> dw_in = ox;
+            if (expand) {
+                auto cce = ef_conv_cfg(N, in_ch, hidden, cur_H, cur_W, 1, 1, 0);
+                auto we  = ef_synth(static_cast<std::size_t>(hidden) * in_ch, seed, 0.12f);
+                auto bne = ef_bn(hidden, seed, sp.eps);
+                auto ce = g.add_kernel(Kernel::create_conv2d(cce, false, ActivationType::NONE), "expand");
+                auto be = g.add_kernel(Kernel::create_batchnorm(N, hidden, cur_H, cur_W, bne.eps), "bn_e");
+                auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * cur_H * cur_W}), "relu6_e");
+                g.add_edge(in_node, ce); g.add_edge(ce, be); g.add_edge(be, re);
+                nd[ce].filter = we; ef_set_bn(nd[be], bne);
+                dw_in = ef_pw_conv_bn(ox, we, cce, bne, true);
+                dw_in_node = re;
+            }
+
+            // Depthwise -> BN -> ReLU6  => A
+            auto cd = g.add_kernel(Kernel::create_conv2d(ccd, false, ActivationType::NONE), "depthwise");
+            auto bd = g.add_kernel(Kernel::create_batchnorm(N, hidden, Hd, Wd, bnd.eps), "bn_d");
+            auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * Hd * Wd}), "relu6_d");
+            g.add_edge(dw_in_node, cd); g.add_edge(cd, bd); g.add_edge(bd, rd);
+            nd[cd].filter = wd; ef_set_bn(nd[bd], bnd);
+            auto A = ef_dw_conv_bn(dw_in, wd, ccd, bnd, true);
+
+            // Squeeze-and-excitation: GAP -> FC_reduce(ReLU) -> FC_expand -> sigmoid -> scale
+            auto wr = ef_synth(static_cast<std::size_t>(hidden) * st.se, seed + 3, 0.15f);
+            auto br = ef_synth(st.se, seed + 4, 0.1f);
+            auto wx = ef_synth(static_cast<std::size_t>(st.se) * hidden, seed + 5, 0.15f);
+            auto bx = ef_synth(hidden, seed + 6, 0.1f);
+            auto gp = g.add_kernel(Kernel::create_global_avg_pool2d(N, hidden, Hd, Wd), "se_gap");
+            auto fr = g.add_kernel(Kernel::create_matmul(N, st.se, hidden), "se_reduce");
+            auto fx = g.add_kernel(Kernel::create_matmul(N, hidden, st.se), "se_expand");
+            auto sg = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::SIGMOID, {hidden}), "se_sigmoid");
+            auto sc = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::MUL, {hidden * Hd * Wd}), "se_scale");
+            g.add_edge(rd, gp); g.add_edge(gp, fr); g.add_edge(fr, fx); g.add_edge(fx, sg);
+            g.add_edge(rd, sc);              // scale main branch = A
+            g.add_edge(sg, sc, "C", "B");    // scale gate branch
+            nd[fr].fc_weight = wr; nd[fr].fc_bias = br; nd[fr].fc_M = N; nd[fr].fc_K = hidden; nd[fr].fc_N = st.se; nd[fr].fc_relu = true;
+            nd[fx].fc_weight = wx; nd[fx].fc_bias = bx; nd[fx].fc_M = N; nd[fx].fc_K = st.se; nd[fx].fc_N = hidden; nd[fx].fc_relu = false;
+
+            // SE oracle
+            std::vector<float> sq(static_cast<std::size_t>(N) * hidden, 0.0f);
+            for (Size n = 0; n < N; ++n)
+                for (Size c = 0; c < hidden; ++c) {
+                    float s = 0.0f;
+                    for (Size p = 0; p < Hd * Wd; ++p)
+                        s += A[(static_cast<std::size_t>(n) * hidden + c) * Hd * Wd + p];
+                    sq[n * hidden + c] = s / static_cast<float>(Hd * Wd);
+                }
+            auto red = ef_matmul(sq, wr, br, N, hidden, st.se, true);
+            auto exv = ef_matmul(red, wx, bx, N, st.se, hidden, false);
+            std::vector<float> A_scaled(A.size());
+            for (Size n = 0; n < N; ++n)
+                for (Size c = 0; c < hidden; ++c) {
+                    const float gate = 1.0f / (1.0f + std::exp(-exv[n * hidden + c]));
+                    for (Size p = 0; p < Hd * Wd; ++p) {
+                        const std::size_t idx = (static_cast<std::size_t>(n) * hidden + c) * Hd * Wd + p;
+                        A_scaled[idx] = A[idx] * gate;
+                    }
+                }
+
+            // Project 1x1 -> BN (linear bottleneck)
+            auto cp = g.add_kernel(Kernel::create_conv2d(ccp, false, ActivationType::NONE), "project");
+            auto bp = g.add_kernel(Kernel::create_batchnorm(N, out_ch, Hd, Wd, bnp.eps), "bn_p");
+            g.add_edge(sc, cp); g.add_edge(cp, bp);
+            nd[cp].filter = wp; ef_set_bn(nd[bp], bnp);
+            auto p = ef_pw_conv_bn(A_scaled, wp, ccp, bnp, false);
+
+            std::size_t sink = bp;
+            if (residual) {
+                auto ad = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::ADD, {out_ch * Hd * Wd}), "add");
+                g.add_edge(bp, ad);                  // main branch
+                g.add_edge(in_node, ad, "C", "B");   // explicit identity skip = block input
+                for (std::size_t i = 0; i < p.size(); ++i) p[i] += ox[i];
+                sink = ad;
+            }
+            ox = std::move(p);
+            in_node = sink; cur_ch = out_ch; cur_H = Hd; cur_W = Wd;
+            seed += 7;
+        }
+    }
+
+    // ----- head: 1x1 conv -> BN -> ReLU6 --------------------------------------
+    {
+        auto cc = ef_conv_cfg(N, cur_ch, sp.head_channels, cur_H, cur_W, 1, 1, 0);
+        auto w  = ef_synth(static_cast<std::size_t>(sp.head_channels) * cur_ch, seed, 0.12f);
+        auto bn = ef_bn(sp.head_channels, seed, sp.eps);
+        auto c = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "head_conv");
+        auto b = g.add_kernel(Kernel::create_batchnorm(N, sp.head_channels, cur_H, cur_W, sp.eps), "head_bn");
+        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {sp.head_channels * cur_H * cur_W}), "head_relu6");
+        g.add_edge(in_node, c); g.add_edge(c, b); g.add_edge(b, r);
+        nd[c].filter = w; ef_set_bn(nd[b], bn);
+        ox = ef_pw_conv_bn(ox, w, cc, bn, true);
+        in_node = r; cur_ch = sp.head_channels;
+        ++seed;
+    }
+
+    // ----- head: global-average-pool -> FC ------------------------------------
+    auto gp = g.add_kernel(Kernel::create_global_avg_pool2d(N, cur_ch, cur_H, cur_W), "gap");
+    auto fc = g.add_kernel(Kernel::create_matmul(N, sp.num_classes, cur_ch), "fc");
+    g.add_edge(in_node, gp); g.add_edge(gp, fc);
+
+    auto wfc = ef_synth(static_cast<std::size_t>(cur_ch) * sp.num_classes, seed, 0.1f);
+    auto bfc = ef_synth(sp.num_classes, seed + 1, 0.2f);
+    nd[fc].fc_weight = wfc; nd[fc].fc_bias = bfc;
+    nd[fc].fc_M = N; nd[fc].fc_K = cur_ch; nd[fc].fc_N = sp.num_classes;
+
+    schedule::Pool2DGeometry pg; pg.N = N; pg.C = cur_ch; pg.H = cur_H; pg.W = cur_W;
+    auto gap = schedule::global_avg_pool_reference(ox, pg);
+    net.oracle.assign(static_cast<std::size_t>(N) * sp.num_classes, 0.0f);
+    for (Size m = 0; m < N; ++m)
+        for (Size n = 0; n < sp.num_classes; ++n) {
+            float acc = bfc[n];
+            for (Size k = 0; k < cur_ch; ++k)
+                acc += gap[m * cur_ch + k] * wfc[k * sp.num_classes + n];
+            net.oracle[m * sp.num_classes + n] = acc;
+        }
+
+    net.output_node = fc;
+    net.num_nodes = g.num_nodes();
+    return net;
+}
+
+} // namespace sw::kpu::timing::graph

--- a/tests/timing/CMakeLists.txt
+++ b/tests/timing/CMakeLists.txt
@@ -343,6 +343,16 @@ set_tests_properties(test_m3_efficientnet_block PROPERTIES
     LABELS "timing;m3;efficientnet;v0.9"
 )
 
+# M3 full EfficientNet-B0 network (milestone M3, #131): whole network (MBConv+SE)
+# as a KernelGraph DFG on the CSP value path vs a composed host oracle.
+kpu_add_component_test(test_m3_efficientnet "timing"
+    test_m3_efficientnet.cpp
+)
+
+set_tests_properties(test_m3_efficientnet PROPERTIES
+    LABELS "timing;m3;efficientnet;v0.9"
+)
+
 # Livelock detector progress regression: backward-path + compute progress must
 # count, so drain-heavy ops (large depthwise) do not false-trip the detector.
 kpu_add_component_test(test_livelock_progress "timing"

--- a/tests/timing/test_m3_efficientnet.cpp
+++ b/tests/timing/test_m3_efficientnet.cpp
@@ -1,0 +1,56 @@
+// ============================================================================
+// tests/timing/test_m3_efficientnet.cpp
+// M3 (#131): the full EfficientNet-B0 network (stem + MBConv+SE bottleneck stack
+// + 1x1 head conv + global-average-pool + FC) built as a KernelGraph DFG and
+// executed end-to-end on the CSP value path through GraphCspExecutor, validated
+// against a composed whole-network host oracle (including the SE gate). See
+// docs/plans/m3_mobilenet_dfg.md and docs/milestones/M3_efficientnet.md.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/kernel_graph.hpp>
+#include <sw/kpu/timing/graph/efficientnet.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+using namespace sw::kpu::timing::graph;
+
+TEST_CASE("M3 EfficientNet-B0 full network on the CSP executor matches host oracle",
+          "[timing][m3][efficientnet]") {
+    sw::kpu::KernelGraph g;
+    EfficientNetB0Spec sp;                     // default fast scaled topology
+    auto net = build_efficientnet_b0(g, sp);
+
+    REQUIRE(g.num_nodes() == net.num_nodes);
+    REQUIRE(g.get_execution_order().size() == net.num_nodes);
+
+    GraphCspExecutor exec;
+    auto result = exec.run(g, net.input, net.node_data, /*T*/16);
+
+    REQUIRE(result.output.size() == net.oracle.size());
+    REQUIRE(result.output.size() == static_cast<std::size_t>(sp.batch) * sp.num_classes);
+
+    float max_err = 0.0f;
+    for (std::size_t i = 0; i < net.oracle.size(); ++i) {
+        REQUIRE(std::isfinite(result.output[i]));
+        REQUIRE(std::isfinite(net.oracle[i]));
+        max_err = std::max(max_err, std::abs(result.output[i] - net.oracle[i]));
+    }
+    INFO("max_err=" << max_err << " nodes=" << net.num_nodes
+         << " ops=" << result.stats.ops << " cycles=" << result.stats.total_cycles);
+    REQUIRE(max_err < 5e-3f);
+    REQUIRE(result.stats.ops > 0);
+}
+
+TEST_CASE("M3 EfficientNet-B0 builder rejects non-tile-aligned specs",
+          "[timing][m3][efficientnet]") {
+    sw::kpu::KernelGraph g;
+    EfficientNetB0Spec sp;
+    sp.stages[0].se = 20;   // SE reduce dim not a multiple of tile (16)
+    REQUIRE_THROWS_AS(build_efficientnet_b0(g, sp), std::invalid_argument);
+}


### PR DESCRIPTION
## Summary

M3 (milestone #131), **EfficientNet-B0 achieved**. The full EfficientNet-B0 runs end-to-end as a `KernelGraph` DFG on the credit-based CSP value path, validated against a composed whole-network host oracle. Completes the M3 EfficientNet story, mirroring the M3-T4 MobileNetV2 artifact; reuses the M2/M3 bridge and the SE runners from #215 with **no new runners**.

## What's delivered

- **`include/sw/kpu/timing/graph/efficientnet.hpp`** — reusable `build_efficientnet_b0` (stem + MBConv+SE bottleneck stack + `1×1` head → GAP → FC) with per-node weights + a composed host oracle including the SE gate, plus `EfficientNetB0Spec` (per-stage `{t, c, n, s, k, se}`).
- **`examples/milestones/m3_efficientnet.cpp`** — demonstrate / validate / benchmark (`--dot` + base / +5×5 sweep).
- **`tests/timing/test_m3_efficientnet.cpp`** — full network vs oracle (`max_err ~6e-8`), all-finite + tile-alignment guard (incl. the SE reduce dim).
- **`docs/milestones/M3_efficientnet.md`** — writeup.

## Beyond MobileNetV2

- **Squeeze-and-excitation** per block: `GAP → FC_reduce → ReLU → FC_expand → sigmoid → channel-broadcast multiply`, reusing GAP + matmul (ReLU epilogue) + `run_sigmoid` / `run_channel_broadcast_mul` (#215).
- **Per-stage depthwise kernel sizes** (3×3 and 5×5) — `run_depthwise_conv` handles arbitrary K; the livelock fix (#216) lets wider/deeper depthwise run.

The `t==1` stage omits the expansion; identity residuals are explicit graph edges. Because the SE `sigmoid` is 4 VE ops and each `ReLU6` is 2, the CSP op count can exceed the graph node count (base: 32 nodes → 36 ops).

## Honest scope

Dims are scaled for a fast CSP simulation with the tile-alignment discipline — including the **SE reduce dim**, which uses a tile-aligned floor (16) rather than the real `Cin/4` at these small widths. **SiLU/swish is approximated by ReLU6** (documented; a dedicated SiLU is a follow-on).

## Test Results

| Target | build | test |
|--------|-------|------|
| test_m3_efficientnet | OK | PASS (max_err ~6e-8) |
| m3_efficientnet demo | OK | PASS (base / +5×5) |
| full timing suite | OK | 100% (57/57) |

Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean on the new TUs.

Part of milestone #131.

Generated with [Claude Code](https://claude.com/claude-code)