### PR TITLE
feat(m3): SiLU/swish activation on the CSP value path (EfficientNet faithful)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **SiLU/swish activation on the CSP value path — M3 polish (#131).** `run_silu`
+  (`csp_op_runners.hpp`) computes `x·sigmoid(x)` on the CSP executor (sigmoid via
+  the four-VE-op `run_sigmoid`, then a binary multiply), and `GraphCspExecutor`
+  dispatches `ElementwiseOp::SILU` to it (the fabric's typed `dispatch_silu`
+  already existed). `build_efficientnet_b0` now uses **real SiLU** for its stem /
+  expand / depthwise / head activations instead of the ReLU6 approximation, so
+  EfficientNet-B0 is architecturally faithful. `test_m3_efficientnet` adds a
+  `run_silu` unit test (matches `x·sigmoid(x)` to 1e-5) and the full network still
+  validates (`max_err < 5e-3`).
+
 - **Full EfficientNet-B0 network as a KernelGraph DFG on the CSP executor —
   M3 (#131), EfficientNet-B0 achieved.** `build_efficientnet_b0`
   (`include/sw/kpu/timing/graph/efficientnet.hpp`) assembles the whole network

--- a/docs/milestones/M3_efficientnet.md
+++ b/docs/milestones/M3_efficientnet.md
@@ -24,6 +24,9 @@ Beyond the MobileNetV2 milestone, EfficientNet-B0 adds:
   Vector Engine has no sigmoid, so `1/(1+e^-x)` is composed from four unary/scalar
   VE ops) and **`run_channel_broadcast_mul`** (the SE scale, a per-channel `[N,C]`
   gate × `[N,C,H,W]` activation).
+- **SiLU/swish activation** (`x·sigmoid(x)`) — the real EfficientNet activation,
+  on the CSP value path via `run_silu` (`run_sigmoid` then a binary multiply);
+  the bridge dispatches `ElementwiseOp::SILU`.
 - **Per-stage depthwise kernel sizes** (3×3 and 5×5) — `run_depthwise_conv`
   handles arbitrary `Kh×Kw`; the livelock-detector fix (counting backward-path +
   compute progress) lets wider/deeper depthwise run.
@@ -64,8 +67,8 @@ Dimensions are scaled for a fast CSP simulation (as the other milestones), with
 the tile-alignment discipline: batch and all channel counts — **including the SE
 reduce dim** — are multiples of the tile size, so the SE reduction uses a
 tile-aligned floor (16) rather than the real `Cin/4` at these small widths.
-**SiLU/swish is approximated by ReLU6** for the M3 subset (documented; a dedicated
-SiLU activation is a follow-on). The DFX tiling/dataflow compiler remains
+Activations are the real **SiLU/swish** (`x·sigmoid(x)`), not the earlier ReLU6
+approximation. The DFX tiling/dataflow compiler remains
 matmul-only — M3 tests operator-level fusions + the SE composition, not a full CNN
 compiler.
 

--- a/docs/milestones/M3_efficientnet.md
+++ b/docs/milestones/M3_efficientnet.md
@@ -37,26 +37,27 @@ EfficientNet-B0 is built by `build_efficientnet_b0`
 (`include/sw/kpu/timing/graph/efficientnet.hpp`) as a **`KernelGraph`** and
 executed by **`GraphCspExecutor`**, reusing the M2/M3 bridge:
 
-- **stem** — `3×3 s1 conv → BN → ReLU6`.
-- **MBConv+SE stack** — each block is `1×1 expand → BN → ReLU6 → k×k depthwise
-  (stride s) → BN → ReLU6 → SE gate → 1×1 project → BN`, with an **identity
+- **stem** — `3×3 s1 conv → BN → SiLU`.
+- **MBConv+SE stack** — each block is `1×1 expand → BN → SiLU → k×k depthwise
+  (stride s) → BN → SiLU → SE gate → 1×1 project → BN`, with an **identity
   residual** (an explicit graph edge) when `stride == 1 && Cin == Cout`. As in the
   real model, the `t == 1` stage omits the expansion, and the project is a linear
   bottleneck (no activation, none after the residual add).
-- **head** — `1×1 conv → BN → ReLU6 → global-average-pool → FC`.
+- **head** — `1×1 conv → BN → SiLU → global-average-pool → FC`.
 
 The bridge folds each BatchNorm into its conv, dispatches pointwise/expand/project
 `1×1` convs to im2col→GEMM and depthwise convs (`groups == Cin`) to the
 pooling-window path, runs the SE `sigmoid` and channel-broadcast `MUL` as VE ops,
 and joins the identity residuals. Because the SE `sigmoid` alone is four VE ops
-and each `ReLU6` is two, the CSP op count can exceed the graph node count.
+and each `SiLU` is five (sigmoid + multiply), the CSP op count can exceed the
+graph node count.
 
 ## Definition of done
 
 - **Demonstrate** — the whole network runs end-to-end on the CSP executor;
   `--dot FILE` emits the `KernelGraph`.
 - **Validate** — output compared elementwise against a composed whole-network host
-  oracle (pointwise / depthwise conv, BN, ReLU6, the SE gate, add, GAP, FC),
+  oracle (pointwise / depthwise conv, BN, SiLU, the SE gate, add, GAP, FC),
   `max_err < 5e-3` (observed ~6e-8).
 - **Benchmark** — cycles, CSP ops, cyc/op, and DMA/BM/STR stalls across a small
   sweep (compact base + a 5×5 MBConv variant).

--- a/docs/sessions/2026-07-17_v0.9_m3-silu-activation.md
+++ b/docs/sessions/2026-07-17_v0.9_m3-silu-activation.md
@@ -1,0 +1,63 @@
+# Session Log — 2026-07-17 — SiLU/swish activation on the CSP value path
+
+**Milestone:** M3 (#131) polish — EfficientNet-B0 faithfulness.
+**Branch:** `feat/m3-silu-activation`
+**Fidelity tier:** CYCLE_ACCURATE (CSP timing executor, value path).
+
+## Goal
+
+Replace the ReLU6 approximation of EfficientNet's SiLU/swish activation with the
+real thing on the CSP value path, so the EfficientNet-B0 model is architecturally
+faithful.
+
+## What was done
+
+The fabric layer already had SiLU end-to-end (`kernels::silu`,
+`execute_typed_silu`/`dispatch_silu` across all float formats, behavioral +
+transactional dispatch) and `ElementwiseOp::SILU` existed - only the CSP value
+path lacked it. Added:
+
+- **`run_silu`** (`csp_op_runners.hpp`) — `x·sigmoid(x)`: `run_sigmoid` (the four
+  VE-op composition) then a binary `MUL` against `x`, five VE ops total.
+- **Bridge** (`graph_csp_executor.hpp`) — `ElementwiseOp::SILU → run_silu`.
+- **`efficientnet.hpp`** — the stem / expand / depthwise / head activations are
+  now `ElementwiseOp::SILU` nodes (were `RELU6`), and the host oracle applies
+  `x·sigmoid(x)` (`ef_silu`). The SE internal reduce keeps ReLU and the SE gate
+  keeps sigmoid, as in the real model.
+- **`test_m3_efficientnet`** — a `run_silu` unit test (matches `x·sigmoid(x)` to
+  1e-5) alongside the full-network test.
+
+## Decisions
+
+- **SiLU composed from existing runners, not a new VE op.** `run_sigmoid` already
+  exists; SiLU is just `x * sigmoid(x)`, so `run_silu` is a five-op composition -
+  no `apply_ve_op`/fabric change needed. The fabric already computes SiLU for the
+  behavioral/transactional tiers.
+- **SiLU only for the main activations.** Stem, expand, depthwise, head use SiLU;
+  the SE reduce stays ReLU and the SE gate stays sigmoid, matching EfficientNet.
+
+## Wrong decisions
+
+None. The change was a clean composition + node-type swap; the full-network oracle
+matched on the first run after switching the oracle helper to `ef_silu`.
+
+## Validation
+
+- `test_m3_efficientnet`: `run_silu` unit test passes (1e-5); full EfficientNet-B0
+  network still validates vs the (now SiLU) oracle, `max_err < 5e-3`.
+- Full timing suite: **100% (57/57) passed**.
+- Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean.
+
+## Modified files
+
+- `include/sw/kpu/timing/graph/csp_op_runners.hpp` — `run_silu`.
+- `include/sw/kpu/timing/graph/graph_csp_executor.hpp` — SILU dispatch.
+- `include/sw/kpu/timing/graph/efficientnet.hpp` — SiLU activations + oracle.
+- `tests/timing/test_m3_efficientnet.cpp` — `run_silu` unit test.
+- `docs/milestones/M3_efficientnet.md` — SiLU (no longer ReLU6-approximated).
+- `CHANGELOG.md`, `docs/sessions/2026-07-17_v0.9_m3-silu-activation.md`.
+
+## Follow-on
+
+- Faithful `Cin/4` SE reduction (needs larger tile-aligned widths).
+- Per-tile executor performance.

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -278,6 +278,18 @@ run_sigmoid(const std::vector<float>& x, RunStats& stats) {
 }
 
 /**
+ * @brief SiLU / swish = x * sigmoid(x) on the CSP executor (EfficientNet activation).
+ *
+ * Composed on the value path: sigmoid(x) (four VE ops, run_sigmoid) then a binary
+ * multiply against x - five VE ops total.
+ */
+[[nodiscard]] inline std::vector<float>
+run_silu(const std::vector<float>& x, RunStats& stats) {
+    auto sig = run_sigmoid(x, stats);
+    return run_elementwise(sw::kpu::isa::VEOp::MUL, x, sig, stats);
+}
+
+/**
  * @brief Channel-broadcast multiply for the squeeze-and-excitation gate: scale
  *        an [N,C,H,W] activation by a per-channel [N,C] gate on the CSP executor.
  *

--- a/include/sw/kpu/timing/graph/efficientnet.hpp
+++ b/include/sw/kpu/timing/graph/efficientnet.hpp
@@ -8,9 +8,9 @@
 // Executed through GraphCspExecutor on the CSP value path. Beyond MobileNetV2 the
 // MBConv block adds a squeeze-and-excitation gate between the depthwise and the
 // project: GAP -> FC_reduce -> ReLU -> FC_expand -> sigmoid -> channel-broadcast
-// multiply. Depthwise convs use per-stage kernel sizes (3 or 5). SiLU/swish is
-// approximated by ReLU6 for the M3 subset (per the design). Dims are scaled for a
-// fast CSP demo; batch N keeps every conv GEMM's M = N*Hout*Wout tile-aligned.
+// multiply. Depthwise convs use per-stage kernel sizes (3 or 5). Activations are
+// SiLU/swish (x*sigmoid(x)) as in the real model. Dims are scaled for a fast CSP
+// demo; batch N keeps every conv GEMM's M = N*Hout*Wout tile-aligned.
 //
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
@@ -114,24 +114,23 @@ inline EfBN ef_bn(Size C, std::uint64_t seed, float eps) {
 inline void ef_set_bn(NodeData& nd, const EfBN& bn) {
     nd.gamma = bn.gamma; nd.beta = bn.beta; nd.mean = bn.mean; nd.var = bn.var; nd.eps = bn.eps;
 }
-inline void ef_relu6_ip(std::vector<float>& v) {
-    for (auto& x : v) x = std::min(std::max(0.0f, x), 6.0f);
-}
+inline float ef_silu(float x) { return x / (1.0f + std::exp(-x)); }   // x * sigmoid(x)
+inline void ef_silu_ip(std::vector<float>& v) { for (auto& x : v) x = ef_silu(x); }
 
-// Standard (pointwise) conv -> BN inference -> optional ReLU6. NCHW.
+// Standard (pointwise) conv -> BN inference -> optional SiLU. NCHW.
 inline std::vector<float> ef_pw_conv_bn(const std::vector<float>& x, const std::vector<float>& w,
-                                        const sw::kpu::Conv2DConfig& cc, const EfBN& bn, bool relu6) {
+                                        const sw::kpu::Conv2DConfig& cc, const EfBN& bn, bool silu) {
     const auto g = ef_geom(cc);
     auto z = schedule::conv2d_reference(x, w, {}, g, false);
     schedule::BatchNormGeometry bg; bg.N = g.N; bg.C = g.C_out; bg.H = g.H_out(); bg.W = g.W_out();
     auto y = schedule::batchnorm_reference(z, bn.gamma, bn.beta, bn.mean, bn.var, bn.eps, bg);
-    if (relu6) ef_relu6_ip(y);
+    if (silu) ef_silu_ip(y);
     return y;
 }
 
-// Per-channel depthwise conv (kxk) -> BN inference -> optional ReLU6. NCHW.
+// Per-channel depthwise conv (kxk) -> BN inference -> optional SiLU. NCHW.
 inline std::vector<float> ef_dw_conv_bn(const std::vector<float>& x, const std::vector<float>& filter,
-                                        const sw::kpu::Conv2DConfig& cc, const EfBN& bn, bool relu6) {
+                                        const sw::kpu::Conv2DConfig& cc, const EfBN& bn, bool silu) {
     const auto g = ef_geom(cc);
     const Size Hout = g.H_out(), Wout = g.W_out();
     std::vector<float> y(static_cast<std::size_t>(g.N) * g.C_out * Hout * Wout);
@@ -154,7 +153,7 @@ inline std::vector<float> ef_dw_conv_bn(const std::vector<float>& x, const std::
                         }
                     }
                     acc = acc * scale + shift;
-                    if (relu6) acc = std::min(std::max(0.0f, acc), 6.0f);
+                    if (silu) acc = ef_silu(acc);
                     y[((static_cast<std::size_t>(n) * g.C_out + c) * Hout + ho) * Wout + wo] = acc;
                 }
         }
@@ -225,7 +224,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
         auto bn = ef_bn(sp.stem_channels, seed, sp.eps);
         auto c = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "stem_conv");
         auto b = g.add_kernel(Kernel::create_batchnorm(N, sp.stem_channels, cur_H, cur_W, sp.eps), "stem_bn");
-        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {sp.stem_channels * cur_H * cur_W}), "stem_relu6");
+        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::SILU, {sp.stem_channels * cur_H * cur_W}), "stem_silu");
         g.add_edge(c, b); g.add_edge(b, r);
         nd[c].filter = w; ef_set_bn(nd[b], bn);
         ox = ef_pw_conv_bn(ox, w, cc, bn, true);
@@ -259,7 +258,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
                 auto bne = ef_bn(hidden, seed, sp.eps);
                 auto ce = g.add_kernel(Kernel::create_conv2d(cce, false, ActivationType::NONE), "expand");
                 auto be = g.add_kernel(Kernel::create_batchnorm(N, hidden, cur_H, cur_W, bne.eps), "bn_e");
-                auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * cur_H * cur_W}), "relu6_e");
+                auto re = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::SILU, {hidden * cur_H * cur_W}), "silu_e");
                 g.add_edge(in_node, ce); g.add_edge(ce, be); g.add_edge(be, re);
                 nd[ce].filter = we; ef_set_bn(nd[be], bne);
                 dw_in = ef_pw_conv_bn(ox, we, cce, bne, true);
@@ -269,7 +268,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
             // Depthwise -> BN -> ReLU6  => A
             auto cd = g.add_kernel(Kernel::create_conv2d(ccd, false, ActivationType::NONE), "depthwise");
             auto bd = g.add_kernel(Kernel::create_batchnorm(N, hidden, Hd, Wd, bnd.eps), "bn_d");
-            auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {hidden * Hd * Wd}), "relu6_d");
+            auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::SILU, {hidden * Hd * Wd}), "silu_d");
             g.add_edge(dw_in_node, cd); g.add_edge(cd, bd); g.add_edge(bd, rd);
             nd[cd].filter = wd; ef_set_bn(nd[bd], bnd);
             auto A = ef_dw_conv_bn(dw_in, wd, ccd, bnd, true);
@@ -339,7 +338,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
         auto bn = ef_bn(sp.head_channels, seed, sp.eps);
         auto c = g.add_kernel(Kernel::create_conv2d(cc, false, ActivationType::NONE), "head_conv");
         auto b = g.add_kernel(Kernel::create_batchnorm(N, sp.head_channels, cur_H, cur_W, sp.eps), "head_bn");
-        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::RELU6, {sp.head_channels * cur_H * cur_W}), "head_relu6");
+        auto r = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::SILU, {sp.head_channels * cur_H * cur_W}), "head_silu");
         g.add_edge(in_node, c); g.add_edge(c, b); g.add_edge(b, r);
         nd[c].filter = w; ef_set_bn(nd[b], bn);
         ox = ef_pw_conv_bn(ox, w, cc, bn, true);

--- a/include/sw/kpu/timing/graph/efficientnet.hpp
+++ b/include/sw/kpu/timing/graph/efficientnet.hpp
@@ -178,10 +178,10 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
 /**
  * @brief Build EfficientNet-B0 into `g`; return weights + input + oracle.
  *
- * Topology: stem (3x3 s1 conv -> BN -> ReLU6) + a stack of MBConv+SE bottlenecks
- * (1x1 expand -> BN -> ReLU6 -> kxk depthwise -> BN -> ReLU6 -> SE gate -> 1x1
+ * Topology: stem (3x3 s1 conv -> BN -> SiLU) + a stack of MBConv+SE bottlenecks
+ * (1x1 expand -> BN -> SiLU -> kxk depthwise -> BN -> SiLU -> SE gate -> 1x1
  * project -> BN, with an identity residual when stride==1 and Cin==Cout; the
- * t==1 stage omits the expansion) + a 1x1 head conv -> BN -> ReLU6 + global-
+ * t==1 stage omits the expansion) + a 1x1 head conv -> BN -> SiLU + global-
  * average-pool + FC. Execute the returned graph through GraphCspExecutor and
  * compare its output to `oracle` (tol ~5e-3).
  */
@@ -216,7 +216,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
     Size cur_ch = sp.in_channels, cur_H = sp.height, cur_W = sp.width;
     auto out_dim = [](Size in, Size K, Size stride, Size pad) { return (in + 2 * pad - K) / stride + 1; };
 
-    // ----- stem: 3x3 s1 conv -> BN -> ReLU6 -----------------------------------
+    // ----- stem: 3x3 s1 conv -> BN -> SiLU -----------------------------------
     std::size_t in_node;
     {
         auto cc = ef_conv_cfg(N, sp.in_channels, sp.stem_channels, cur_H, cur_W, 3, 1, 1);
@@ -249,7 +249,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
             auto wp = ef_synth(static_cast<std::size_t>(out_ch) * hidden, seed + 2, 0.12f);
             auto bnd = ef_bn(hidden, seed + 1, sp.eps), bnp = ef_bn(out_ch, seed + 2, sp.eps);
 
-            // Expansion (only t > 1): 1x1 -> BN -> ReLU6.
+            // Expansion (only t > 1): 1x1 -> BN -> SiLU.
             std::size_t dw_in_node = in_node;
             std::vector<float> dw_in = ox;
             if (expand) {
@@ -265,7 +265,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
                 dw_in_node = re;
             }
 
-            // Depthwise -> BN -> ReLU6  => A
+            // Depthwise -> BN -> SiLU  => A
             auto cd = g.add_kernel(Kernel::create_conv2d(ccd, false, ActivationType::NONE), "depthwise");
             auto bd = g.add_kernel(Kernel::create_batchnorm(N, hidden, Hd, Wd, bnd.eps), "bn_d");
             auto rd = g.add_kernel(Kernel::create_elementwise(ElementwiseOp::SILU, {hidden * Hd * Wd}), "silu_d");
@@ -331,7 +331,7 @@ inline std::vector<float> ef_matmul(const std::vector<float>& a, const std::vect
         }
     }
 
-    // ----- head: 1x1 conv -> BN -> ReLU6 --------------------------------------
+    // ----- head: 1x1 conv -> BN -> SiLU --------------------------------------
     {
         auto cc = ef_conv_cfg(N, cur_ch, sp.head_channels, cur_H, cur_W, 1, 1, 0);
         auto w  = ef_synth(static_cast<std::size_t>(sp.head_channels) * cur_ch, seed, 0.12f);

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -201,6 +201,9 @@ public:
                     } else if (op == ElementwiseOp::SIGMOID) {
                         // EfficientNet SE gate: 1/(1+e^-x) composed from VE ops.
                         out[id] = run_sigmoid(input_of(g, id, out, input), result.stats);
+                    } else if (op == ElementwiseOp::SILU) {
+                        // EfficientNet activation: x * sigmoid(x).
+                        out[id] = run_silu(input_of(g, id, out, input), result.stats);
                     } else if (op == ElementwiseOp::MUL) {
                         // Two operands: a full elementwise product when equal
                         // length, else the squeeze-and-excitation channel-

--- a/tests/timing/test_m3_efficientnet.cpp
+++ b/tests/timing/test_m3_efficientnet.cpp
@@ -11,14 +11,27 @@
 // ============================================================================
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <sw/kpu/kernel_graph.hpp>
 #include <sw/kpu/timing/graph/efficientnet.hpp>
 
 #include <algorithm>
 #include <cmath>
+#include <vector>
 
 using namespace sw::kpu::timing::graph;
+
+TEST_CASE("M3 run_silu matches x*sigmoid(x) on the CSP executor",
+          "[timing][m3][efficientnet]") {
+    RunStats st;
+    std::vector<float> x(64);
+    for (std::size_t i = 0; i < x.size(); ++i) x[i] = -4.0f + 0.125f * static_cast<float>(i);
+    auto y = run_silu(x, st);
+    REQUIRE(y.size() == x.size());
+    for (std::size_t i = 0; i < x.size(); ++i)
+        REQUIRE_THAT(y[i], Catch::Matchers::WithinAbs(x[i] / (1.0f + std::exp(-x[i])), 1e-5));
+}
 
 TEST_CASE("M3 EfficientNet-B0 full network on the CSP executor matches host oracle",
           "[timing][m3][efficientnet]") {


### PR DESCRIPTION
## Summary

M3 polish (#131): replaces the ReLU6 approximation of EfficientNet's activation with the **real SiLU/swish** (`x·sigmoid(x)`) on the CSP value path, making EfficientNet-B0 architecturally faithful.

The fabric layer already had SiLU end-to-end (`kernels::silu`, `dispatch_silu` across all float formats, behavioral + transactional) and `ElementwiseOp::SILU` existed — only the CSP value path lacked it.

## Changes

- **`run_silu`** (`csp_op_runners.hpp`) — `x·sigmoid(x)`: `run_sigmoid` (the four-VE-op composition) then a binary `MUL` against `x` (five VE ops).
- **`GraphCspExecutor`** — dispatches `ElementwiseOp::SILU` → `run_silu`.
- **`build_efficientnet_b0`** — stem / expand / depthwise / head activations are now SiLU nodes (were ReLU6); the oracle applies `x·sigmoid(x)`. The SE internal reduce keeps ReLU and the SE gate keeps sigmoid, as in the real model.
- **`test_m3_efficientnet`** — a `run_silu` unit test (matches `x·sigmoid(x)` to 1e-5) alongside the full-network test.

## Test Results

| Target | build | test |
|--------|-------|------|
| test_m3_efficientnet (run_silu + full net) | OK | PASS (max_err < 5e-3) |
| full timing suite | OK | 100% (57/57) |

Pre-push `clang -Wall -Wextra -Werror -Wshorten-64-to-32` clean.

## Follow-on

Faithful `Cin/4` SE reduction (needs larger tile-aligned widths) and a per-tile executor perf pass remain.

Part of milestone #131 (polish).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added true SiLU/swish activation support for EfficientNet-B0.
  - EfficientNet-B0 now uses SiLU activations across its stem, expansion, depthwise, and head stages.

- **Bug Fixes**
  - Replaced the previous ReLU6 activation approximation with mathematically accurate SiLU behavior.

- **Tests**
  - Added validation for SiLU calculations and full EfficientNet-B0 output correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->