### PR TITLE
docs(session): M3 milestone completion wrapup log

### DIFF
--- a/docs/sessions/2026-07-17_v0.9_m3-milestone-completion.md
+++ b/docs/sessions/2026-07-17_v0.9_m3-milestone-completion.md
@@ -1,0 +1,99 @@
+# Session Log — 2026-07-16/17 — M3 milestone completion (MobileNetV2 + EfficientNet-B0)
+
+**Milestone:** M3 (#131) — **achieved and closed.**
+**Tier:** CYCLE_ACCURATE (CSP timing executor, value path).
+**Scope:** eight PRs (all merged), two enabling bug fixes, both DNN models landed,
+milestone + all M2/M3 sub-issues closed.
+
+This is the session-level wrapup log; each PR below also has its own detailed
+session log in `docs/sessions/`.
+
+## Outcome
+
+Both M3 models now run **end-to-end as `KernelGraph` DFGs on the credit-based CSP
+value path**, validated elementwise against composed whole-network host oracles,
+each with a demonstrate / validate / benchmark demo and a writeup:
+
+- **MobileNetV2** — `build_mobilenetv2` + `m3_mobilenet` + `docs/milestones/M3_mobilenet.md`.
+- **EfficientNet-B0** — `build_efficientnet_b0` + `m3_efficientnet` + `docs/milestones/M3_efficientnet.md`.
+
+Timing suite ended at **57/57 green**.
+
+## PRs merged (in order)
+
+| PR | What | Note |
+|----|------|------|
+| #212 | compute-result-CAM cap fix (issue #210) | grow-only `TagCAM::set_capacity`; DRAIN no longer wedges at 255 |
+| #213 | MobileNetV2 inverted-residual block | depthwise + typed `ElementwiseOp::RELU6` bridge dispatch |
+| #214 | full MobileNetV2 model + demo | **MobileNetV2 achieved** |
+| #215 | EfficientNet MBConv+SE block | `run_sigmoid`, `run_channel_broadcast_mul` (SE scale) |
+| #216 | livelock-detector drain-progress fix | count backward-path + compute progress, not just forward |
+| #217 | full EfficientNet-B0 model + demo | **EfficientNet-B0 achieved** |
+| #218 | SiLU/swish activation on the CSP path | EfficientNet now architecturally faithful (was ReLU6-approx) |
+
+Plus the CI-resilience one-liner (sccache `continue-on-error`, folded into #212)
+that unblocked every PR during a GitHub Actions Cache incident.
+
+## The two enabling fixes (root-caused, not masked)
+
+- **#210 / #212** — the compute-result CAM was hardcoded to 256 entries and the
+  completion `insert()` ignored the full-CAM return, silently dropping results
+  past 256; the dropped result's DRAIN then head-of-line-blocked forever (wedged
+  at exactly 255 = 0xFF). Fixed by growing the ready-set (it models no fixed
+  hardware buffer). Unblocked depthwise/pooling at high channel counts.
+- **#216** — the livelock detector was fed only forward-path progress
+  (load/move/feed), so a large op's drain-back phase (COMPUTE → DRAIN → WRITEBACK
+  → STORE, all inputs already fed) plateaued the metric and false-tripped past the
+  10000-cycle threshold. Proved it was a false positive (completes with detection
+  off), then fixed the metric to count all stages + compute — cheaply, via
+  monotonic per-component counters (not a full event-history rescan). Unblocked
+  wide/deep depthwise (hidden=64 @ 8×8 = 4096 tiles).
+
+## Reusable CSP infrastructure now on main
+
+New value-path runners in `include/sw/kpu/timing/graph/csp_op_runners.hpp`, all
+reused across both models with no per-model kernel work: `run_depthwise_conv`
+(pooling-window unfold + per-channel filter reduce), `run_relu6`, `run_sigmoid`
+(composed from VE ops), `run_channel_broadcast_mul` (SE gate scale), `run_silu`
+(`x·sigmoid(x)`). Bridge (`graph_csp_executor.hpp`) dispatches depthwise
+(`groups == Cin`), `RELU6`, `SIGMOID`, `SILU`, and broadcast-`MUL`. Reusable
+builders: `mobilenetv2.hpp`, `efficientnet.hpp` (alongside `resnet18.hpp`).
+
+## Key decisions
+
+- **Depthwise = pooling-window + per-channel filter reduce**, not a grouped GEMM
+  (the M3 design's call) — reuses proven E7 movement.
+- **ReLU6 / SiLU as first-class typed activations** (kernels + dispatch across all
+  float formats), not FP32-only fallbacks — CodeRabbit flagged the silent-drop
+  risk on non-FP32 and it was fixed properly.
+- **SE channel-broadcast-multiply is geometry-free** (gate index = `i /
+  (act.size()/gate.size())`); the multiply runs on the CSP data path.
+- **Faithfulness fixes applied**: `t == 1` bottleneck omits expansion; identity
+  residuals are explicit graph edges (not the whole-network external-input
+  fallback — the ResNet-tower trap); real SiLU, not ReLU6.
+
+## Wrong decisions / lessons (documented across the per-PR logs)
+
+- Assumed appending an `ElementwiseOp` enumerator was switch-safe; two
+  compute-fabric switches were exhaustive with no default (`-Werror=switch`).
+  Lesson: verify every switch has a `default:` before adding an enumerator.
+- First livelock-metric draft used `get_statistics()`, which rescans the whole
+  event history every 100 cycles — corrected to cheap per-component counters.
+- Two recurring self-inflicted bugs across the model builders (both caught by
+  `-Werror=unused-parameter` / oracle mismatch): a depthwise oracle that dropped
+  its activation flag, and a residual skip wired to the wrong operand. Now a known
+  checklist for the next builder.
+
+## Issue hygiene
+
+Closed completed-but-orphaned sub-issues whose PRs referenced the *milestone*
+rather than the sub-issue (so GitHub never auto-closed them): **#201, #203, #206**
+(M2-T2/T3/T4) and **#209** (M3-T2), plus the milestone **#131** itself. Going
+forward, milestone PRs should use `Resolves #<sub-issue>` to auto-close.
+
+## Follow-ons (not blocking; M3 closed)
+
+- Faithful `Cin/4` SE reduction (needs larger tile-aligned widths).
+- Per-tile executor performance (a full forward pass is minutes at larger scale).
+- A native grouped/depthwise schedule generator (vs the pooling-window reuse).
+- Next rung: **M4 — attention head → flash attention (#132)**.


### PR DESCRIPTION
## Summary

Session-level wrapup decision log for the **M3 milestone completion** (MobileNetV2 + EfficientNet-B0 on the CSP executor). Docs-only.

Covers the full arc: 8 PRs merged (#212–#218), two root-caused enabling fixes (compute-result-CAM cap #210/#212, livelock-detector drain-progress #216), both DNN models landed end-to-end with demos + writeups, and the milestone #131 + orphaned M2/M3 sub-issues (#201/#203/#206/#209) closed.

Each PR already has its own detailed session log in `docs/sessions/`; this consolidates outcome, decisions, wrong-decisions/lessons, and follow-ons. The CHANGELOG is already complete on main (each PR carried its entry).

Generated with [Claude Code](https://claude.com/claude-code)