### PR TITLE
feat(timing): directly measured active-cycle counter for utilization (1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `run_channel_broadcast_mul` runners and the depthwise/livelock fixes; SiLU
   approximated by ReLU6 for the M3 subset. Milestone M3 (#131).
 
+### Changed
+
+- **Movement-fabric utilization is now directly measured (follow-on 1b).** Each CSP
+  component (`DMAEngineProcess`, `BlockMoverProcess`, `StreamerProcess`) counts, in
+  its `tick()`, the cycles a transfer actually occupied it (DMA: a `SUBMITTED`
+  request; BM/STR: an in-flight transfer — dedup moves and the drain compute-wait
+  excluded), exposed via `active_cycles()`. `collect_statistics` now populates
+  `{dma,bm,str}_busy_cycles` from this measured count (averaged per component)
+  instead of the `total_cycles − stalls/N` heuristic, so utilization excludes idle
+  cycles and is a true activity fraction. The corrected reading flips the ResNet
+  bottleneck story: the **DRAM→L3 DMA is near-saturated (78–92%)** while the on-chip
+  BlockMover (14–18%) and Streamer (11–14%) starve behind it — the scaled network is
+  DRAM-bandwidth-bound (the former heuristic mis-ranked the L3→L2 mover as the
+  bottleneck by counting its idle cycles as busy).
+  `tests/timing/test_resnet_utilization.cpp` updated to the direct-counting
+  invariants (`0 < busy ≤ cycles`, not all movers pinned at 100%); demo,
+  `M2_resnet.md`, and the benchmarking guide regenerated.
+
 ### Fixed
 
 - **ResNet utilization was understated by inconsistent instrumentation.** Four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `effective_{load,store}_bandwidth(clock_ghz)` (guarded to return 0.0 for a
   non-positive clock). The `m2_resnet` demo prints a new utilization table
   (dmaU%/bmU%/strU%, tiles moved/fed/loaded, effective GB/s at an assumed 1.0 GHz
-  clock). The corrected numbers localize the **L3→L2 BlockMover as the bottleneck**
-  (32–47% busy vs. 77–85% for DMA/Streamer). New research guide
-  `docs/benchmarking/resnet-benchmarking-guide.md` documents the assets,
-  assumptions, howto, results, and the utilization derivation + limits.
+  clock). New research guide `docs/benchmarking/resnet-benchmarking-guide.md`
+  documents the assets, assumptions, howto, results, and the utilization
+  derivation + limits. (The bottleneck reading from this entry's stall-derived
+  `busy` was **superseded** by the directly-measured counter in the "Changed"
+  entry below, which identifies the DMA — not the BlockMover — as the bottleneck.)
 
 - **SiLU/swish activation on the CSP value path — M3 polish (#131).** `run_silu`
   (`csp_op_runners.hpp`) computes `x·sigmoid(x)` on the CSP executor (sigmoid via
@@ -61,10 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bottleneck story: the **DRAM→L3 DMA is near-saturated (78–92%)** while the on-chip
   BlockMover (14–18%) and Streamer (11–14%) starve behind it — the scaled network is
   DRAM-bandwidth-bound (the former heuristic mis-ranked the L3→L2 mover as the
-  bottleneck by counting its idle cycles as busy).
-  `tests/timing/test_resnet_utilization.cpp` updated to the direct-counting
-  invariants (`0 < busy ≤ cycles`, not all movers pinned at 100%); demo,
-  `M2_resnet.md`, and the benchmarking guide regenerated.
+  bottleneck by counting its idle cycles as busy). The per-component mean is kept in
+  floating point (`busy_cycles` is now `double`) so it is exact rather than
+  integer-floored — a floor would systematically undercount whenever N does not
+  divide the active sum. `tests/timing/test_resnet_utilization.cpp` updated to the
+  direct-counting invariants (`0 < busy ≤ cycles`, not all movers pinned at 100%),
+  and `test_concurrent_timing_executor.cpp` adds a non-divisible component-count
+  regression (`busy(3 movers)·3 == busy(1 mover)`); demo, `M2_resnet.md`, and the
+  benchmarking guide regenerated.
 
 ### Fixed
 

--- a/docs/benchmarking/resnet-benchmarking-guide.md
+++ b/docs/benchmarking/resnet-benchmarking-guide.md
@@ -9,10 +9,12 @@ milestone writeup. For the milestone framing see
 
 **TL;DR of the current state:** ResNet-18 runs end-to-end, oracle-validated, and
 reports **cycles / ops / stall-cycles** plus **movement-fabric utilization**
-(DMA/BlockMover/Streamer busy%, tiles, effective DRAM bandwidth). The utilization
-plumbing described in §6 is **implemented** — the demo prints a second
-"utilization" table. What is *not* yet available is compute-fabric FLOP efficiency
-(§6 caveat) — that is the next research task.
+(DMA/BlockMover/Streamer busy%, tiles, effective DRAM bandwidth). Utilization is a
+**directly measured** active-cycle count (each component counts the cycles a
+transfer occupied it) — not the earlier `cycles − stalls/N` heuristic — so idle
+cycles are excluded and the numbers are a true activity fraction. The demo prints a
+second "utilization" table. What is *not* yet available is compute-fabric FLOP
+efficiency (§6 caveat) — that is the next research task.
 
 ---
 
@@ -175,32 +177,34 @@ directly. Any new spec must keep batch/channels/classes as `tile` multiples.
   resnet18 (batch 32)        39    22      72169      3280    16430   196470    49551    6.0e-08   PASS
 
   utilization              dmaU%    bmU%   strU%  tilesLd  tilesMv  tilesFd    ldGB/s    stGB/s
-  resnet18 (base)           82.4    37.5    83.4     1805     1438     1438      18.5       2.9
-  resnet18 [2,2,2,2]        80.6    47.3    85.5     2773     2318     2318      25.4       4.0
-  resnet18 (batch 32)       77.2    32.0    82.9     3610     2876     2876      19.3       3.2
+  resnet18 (base)           84.6    14.1    10.7     1805     1438     1438      18.5       2.9
+  resnet18 [2,2,2,2]        77.9    18.4    13.9     2773     2318     2318      25.4       4.0
+  resnet18 (batch 32)       92.3    14.9    11.8     3610     2876     2876      19.3       3.2
 ```
 
 Reading it:
 - **Fusion payoff:** `[2,2,2,2]` runs 67 graph nodes as **38 CSP ops** (every BN
   folded, every block-internal ReLU fused). Base `[1,1,1,1]` = 39 nodes → 22 ops.
-- **BlockMover (L3→L2) is the bottleneck stage.** It carries by far the most stall
-  cycles (`bmStl` ≫ `strStl` > `dmaStl`) *and* the lowest utilization (32–47% vs.
-  77–85% for DMA and Streamer) — the two views agree: the L3→L2 move is where the
-  pipeline waits. It is the first place to add buffering / rebalance credits.
-- **DMA and Streamer run 77–85% busy;** deeper (`[2,2,2,2]`) lifts BlockMover
-  utilization (47%) as more work amortizes the moves, while batch 32 pushes it
-  *down* (32%) — more per-move DRAM traffic, more waiting.
+- **DMA (DRAM→L3) is the near-saturated bottleneck** — 78–92% active, and **batch
+  32 drives it to 92%** (the most DRAM-bound config). At this scale the network is
+  bandwidth-bound on the DRAM load path.
+- **The on-chip movers starve behind it:** BlockMover 14–18%, Streamer 11–14%
+  active. They are not the throughput limiter — they spend most cycles waiting for
+  the DMA to deliver tiles (note `bmStl`/`strStl` are large: much *waiting*, little
+  *transferring*). Widening DRAM bandwidth / adding DMA engines is the lever, not
+  more on-chip buffering.
+- **Deeper (`[2,2,2,2]`)** lifts on-chip utilization slightly (more work amortizes
+  each load) and eases DMA to 78%.
 - **`ldGB/s`/`stGB/s`** are at an assumed 1.0 GHz clock (so GB/s == bytes/cycle);
   the unit is a knob, the *ratio* between configs is the signal.
 - **cyc/op is not efficiency** — it is total cycles / op count, inflated by stalls.
 
-Two accounting notes so the columns are not misread:
+One accounting note so the columns are not misread:
 - **Stall columns are summed across all parallel components and all ops**, so a
   value can exceed `cycles` (e.g. `bmStl` 99797 > 39881 with ~4 BlockMovers). They
-  are a workload stall total, not a per-component fraction.
-- **Utilization normalizes per component** (`busy = cycles − stalls/N`), so it is
-  *not* `1 − stall/cycles` on the raw columns. The two are consistent once you
-  divide the stall column by the component count (see §6).
+  are a workload stall total, not a per-component fraction — high `bmStl` with low
+  `bmU%` means the BlockMovers *wait* a lot but rarely *transfer*, consistent with
+  starving behind the DMA.
 
 ---
 
@@ -223,32 +227,44 @@ The demo prints these as the "utilization" table. Because nodes run sequentially
 a fresh `ConcurrentTimingExecutor` per op, the per-op `Statistics` are additive and
 the whole-network ratio is `Σ busy / Σ total_cycles`.
 
-### How `busy` is derived — and why utilization ≠ 1 − stall/total
+### How `busy` is measured — directly, not derived
 
-`busy` is **not** `cycles − stall column`. The executor derives it inside
-`collect_statistics` (`concurrent_timing_executor.hpp`): per component type it
-averages stalls across the **N parallel components**, subtracts that from the op's
-`total_cycles`, and clamps to zero if the averaged stall exceeds the op span. So
-`busy = cycles − stalls/N`, and the printed stall column is the *un-normalized*
-`stalls` (summed over all N and all ops) — which is why `bmStl` (99797, ~4
-movers) dwarfs `cycles` (39881) while `bmU` is a sane 37.5%. Divide the stall
-column by the component count before comparing it to a utilization.
+`busy` is a **directly measured active-cycle count**. Every cycle, in each
+component's `tick()`, the component increments an `active_cycles_` counter iff a
+transfer actually occupied it that cycle:
 
-**Consistency invariant (regression-checked):** because `busy ≥ cycles − stalls`
-per op, the aggregate satisfies `busy + stalls ≥ cycles` for every mover. This is
-exactly what the earlier, buggy version violated — some ops added `cycles` to the
-denominator without adding their `busy`/`stalls`, understating utilization to
-≈12–39%. `tests/timing/test_resnet_utilization.cpp` asserts the invariant so that
-regression cannot return.
+- **DMA** — a request is `SUBMITTED` (the memory controller is transferring on its
+  behalf).
+- **BlockMover / Streamer** — an `InFlightTransfer` occupies the cycle
+  (`in_flight_.has_value()`). Zero-latency dedup moves and the drain compute-wait do
+  **not** count.
+
+`collect_statistics` sums these across the N parallel components and divides by N,
+so `busy` is the mean active cycles per component and `utilization = busy /
+total_cycles ∈ [0,1]` is the mean fraction of time a component of that type was
+transferring. This is a genuine activity measurement — the three per-cycle outcomes
+(WORKING / STALLED / IDLE) are distinguished, and only WORKING counts. (The former
+`cycles − stalls/N` heuristic counted IDLE as busy, inflating and mis-ranking the
+movers; a directly-measured counter was follow-on 1b, now done.)
+
+**Stall columns are still un-normalized** (summed over all N and all ops), which is
+why `bmStl` (99797, ~4 movers) exceeds `cycles` (39881). Utilization normalizes;
+the stall column does not. High `bmStl` **with** low `bmU%` is the signature of a
+stage that waits a lot but rarely transfers — i.e. starves behind an upstream
+bottleneck (here the DMA).
+
+**Regression check:** `tests/timing/test_resnet_utilization.cpp` asserts, per mover,
+`0 < busy ≤ total_cycles` (util in `(0,1]`), that not every mover is pinned at 100%
+(idle is genuinely excluded), and accessor consistency `util == busy/total`. A
+component whose counter was never wired into its `tick()` would read a flat `busy=0`
+and fail.
 
 Practical guidance:
-- Treat utilization as the **executor's own relative metric**, good for A/B
-  comparison across configs and before/after a scheduler change — **not** a
-  validated absolute "fraction of peak." Refining `busy` to a directly-measured
-  active-cycle count (instead of `cycles − stalls/N`) is follow-on §7 item 1b.
-- The signal in the current numbers is the **spread between movers** (BlockMover
-  32–47% vs. DMA/Streamer 77–85%), which localizes the L3→L2 bottleneck — not the
-  absolute level.
+- Utilization is now a **measured activity fraction**, usable as an absolute (with
+  the caveat that it is a per-component mean and, under the sequential-node walk,
+  excludes cross-branch overlap — see §3).
+- The signal is the **DMA near-saturation (78–92%) vs. starved on-chip movers
+  (11–18%)**: the workload is DRAM-bandwidth-bound at this scale.
 
 ### Caveat: compute-fabric utilization is not in this path
 
@@ -269,12 +285,13 @@ Ordered by dependency:
 
 1. ~~**Surface movement utilization**~~ — **done** (§6): the demo prints per-mover
    `busy/total`, tiles, and effective bandwidth.
-1b. **Validate/refine the `busy` derivation** — the current busy is
-   `total − avg_stall` with clamping (§6), which is not a measured active-cycle
-   count. Add a direct active-cycle counter per component so utilization becomes a
-   defensible absolute, not just a relative metric.
+1b. ~~**Refine `busy` to a directly-measured active-cycle count**~~ — **done**:
+   each component now counts, in its `tick()`, the cycles a transfer occupied it, so
+   utilization excludes idle cycles and is a measured activity fraction (§6).
 2. **Compute utilization / FLOP efficiency** — MACs / (`total_cycles` × peak). Lets
-   you say "roofline position" for each config.
+   you say "roofline position" for each config. **Now the top open task** — the
+   movement fabric being DRAM-bound (§5) makes the compute-side story the next
+   question.
 3. **Occupancy timeline** — wire `TileTracker` into the demo (behind a flag) to see
    which buffer level saturates during the forward pass.
 4. **Full-scale ResNet-18** — larger spatial dims + `[2,2,2,2]` + channel growth as

--- a/docs/benchmarking/resnet-benchmarking-guide.md
+++ b/docs/benchmarking/resnet-benchmarking-guide.md
@@ -239,13 +239,20 @@ transfer actually occupied it that cycle:
   (`in_flight_.has_value()`). Zero-latency dedup moves and the drain compute-wait do
   **not** count.
 
-`collect_statistics` sums these across the N parallel components and divides by N,
-so `busy` is the mean active cycles per component and `utilization = busy /
+`collect_statistics` sums these across the N parallel components and divides by N
+(in floating point, so the per-component mean is exact — not integer-floored), so
+`busy` is the mean active cycles per component and `utilization = busy /
 total_cycles ∈ [0,1]` is the mean fraction of time a component of that type was
-transferring. This is a genuine activity measurement — the three per-cycle outcomes
-(WORKING / STALLED / IDLE) are distinguished, and only WORKING counts. (The former
-`cycles − stalls/N` heuristic counted IDLE as busy, inflating and mis-ranking the
-movers; a directly-measured counter was follow-on 1b, now done.)
+transferring. Only WORKING cycles count — the former `cycles − stalls/N` heuristic
+counted IDLE as busy, inflating and mis-ranking the movers; a directly-measured
+counter was follow-on 1b, now done.
+
+For the single-transfer **BlockMover/Streamer** the per-cycle outcome is exactly one
+of WORKING / STALLED / IDLE (`active` and `stall` cannot both fire in a tick). The
+**DMA holds multiple requests**, so a tick can *both* count active (one request
+`SUBMITTED`) *and* record a stall (another request waiting on an L3 credit) — for
+the DMA, `active` and `stall` may overlap in a cycle. `active` still never exceeds
+`total_cycles` (one increment per tick), so utilization stays in `[0,1]`.
 
 **Stall columns are still un-normalized** (summed over all N and all ops), which is
 why `bmStl` (99797, ~4 movers) exceeds `cycles` (39881). Utilization normalizes;

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -64,21 +64,21 @@ resnet18 [2,2,2,2]         67    38      51469      1354     9984   108557    29
 resnet18 (batch 32)        39    22      72169      3280    16430   196470    49551
 
 utilization              dmaU%    bmU%   strU%  tilesLd  tilesMv  tilesFd    ldGB/s
-resnet18 (base)           82.4    37.5    83.4     1805     1438     1438      18.5
-resnet18 [2,2,2,2]        80.6    47.3    85.5     2773     2318     2318      25.4
-resnet18 (batch 32)       77.2    32.0    82.9     3610     2876     2876      19.3
+resnet18 (base)           84.6    14.1    10.7     1805     1438     1438      18.5
+resnet18 [2,2,2,2]        77.9    18.4    13.9     2773     2318     2318      25.4
+resnet18 (batch 32)       92.3    14.9    11.8     3610     2876     2876      19.3
 ```
 
 **Fusion payoff:** the `[2,2,2,2]` network's 67 graph nodes execute as **38 CSP
 ops** — every BatchNorm folded into its conv, every block-internal ReLU fused as
 an epilogue. The base `[1,1,1,1]` scale runs 39 nodes as 22 ops.
 
-**Movement-fabric utilization** (busy/total per mover, summed over ops) shows the
-**L3→L2 BlockMover as the bottleneck** — 32–47% busy and by far the most stall
-cycles, vs. 77–85% for DMA and the Streamer. Stall columns are summed across all
-parallel components (so they can exceed `cycles`); see
-`docs/benchmarking/resnet-benchmarking-guide.md` for the full metric definitions
-and the utilization consistency invariant.
+**Movement-fabric utilization** — directly measured active cycles per mover — shows
+the **DRAM→L3 DMA as the near-saturated bottleneck** (78–92% active, 92% at batch
+32), with the on-chip BlockMover (14–18%) and Streamer (11–14%) **starving behind
+it**: the scaled network is DRAM-bandwidth-bound. Stall columns are summed across
+all parallel components (so they can exceed `cycles`); see
+`docs/benchmarking/resnet-benchmarking-guide.md` for the full metric definitions.
 
 ## Scope & scaling notes
 

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -163,12 +163,13 @@ int main(int argc, char* argv[]) {
               << std::setw(10) << "ldGB/s" << std::setw(10) << "stGB/s" << "\n";
     std::cout << "  " << std::string(93, '-') << "\n";
     for (const auto& r : rows) print_util_row(r);
-    std::cout << "\n  Utilization = Sum(busy)/Sum(total) per mover, the executor's"
-                 " reported ratio\n  (get_statistics), summed over the sequentially"
-                 " executed ops; GB/s at "
+    std::cout << "\n  Utilization = Sum(active)/Sum(total) per mover: directly"
+                 " measured cycles a\n  transfer occupied each component (excludes"
+                 " stalled + idle), summed over the\n  sequentially executed ops;"
+                 " GB/s at "
               << std::fixed << std::setprecision(1) << kAssumedClockGHz
-              << " GHz\n  assumed clock. Relative metric - see"
-                 " docs/benchmarking/resnet-benchmarking-guide.md.\n"
+              << " GHz assumed clock. See\n"
+                 "  docs/benchmarking/resnet-benchmarking-guide.md.\n"
               << std::defaultfloat;
 
     std::cout << "\n  Fusion: BatchNorm folded into conv, ReLU fused as the conv"

--- a/include/sw/kpu/timing/block_mover_process.hpp
+++ b/include/sw/kpu/timing/block_mover_process.hpp
@@ -136,6 +136,12 @@ public:
             }
         }
 
+        // Direct active-cycle measurement (follow-on 1b): this cycle counts as
+        // active iff a transfer (move or writeback) occupies it. Measured, not
+        // derived from total - stalls, so idle cycles are excluded. Zero-latency
+        // dedup moves (step 2) do not occupy the bus and are not counted.
+        if (in_flight_.has_value()) ++active_cycles_;
+
         return events;
     }
 
@@ -163,6 +169,7 @@ public:
         next_l2_slot_ = 0;
         stall_cycles_tag_ = 0;
         stall_cycles_credit_ = 0;
+        active_cycles_ = 0;
         total_tiles_moved_ = 0;
         total_tiles_writeback_ = 0;
     }
@@ -185,6 +192,12 @@ public:
 
     [[nodiscard]] Cycle stall_cycles_credit() const {
         return stall_cycles_credit_;
+    }
+
+    /// Directly measured cycles a transfer (move or writeback) occupied the mover.
+    /// Excludes stalled and idle cycles, and zero-latency dedup moves.
+    [[nodiscard]] Cycle active_cycles() const {
+        return active_cycles_;
     }
 
     [[nodiscard]] size_t total_tiles_moved() const {
@@ -222,6 +235,7 @@ private:
     // Statistics
     Cycle stall_cycles_tag_ = 0;
     Cycle stall_cycles_credit_ = 0;
+    Cycle active_cycles_ = 0;
     size_t total_tiles_moved_ = 0;
     size_t total_tiles_writeback_ = 0;
 

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -172,10 +172,12 @@ public:
 
         // Component busy cycles: directly measured active (transferring) cycles,
         // averaged per component. Measured per cycle in each component's tick(),
-        // NOT derived from total - stalls, so idle cycles are excluded.
-        Cycle dma_busy_cycles = 0;
-        Cycle bm_busy_cycles = 0;
-        Cycle str_busy_cycles = 0;
+        // NOT derived from total - stalls, so idle cycles are excluded. Fractional
+        // (double) so the per-component mean is exact rather than integer-floored
+        // (which would systematically undercount when N does not divide the sum).
+        double dma_busy_cycles = 0.0;
+        double bm_busy_cycles = 0.0;
+        double str_busy_cycles = 0.0;
 
         // Stall breakdown
         Cycle dma_credit_stalls = 0;
@@ -1452,19 +1454,20 @@ inline void ConcurrentTimingExecutor::collect_statistics(Statistics& stats) cons
     }
 
     // Normalize the directly measured active cycles to a per-component average
-    // (follow-on 1b). busy_cycles now holds the raw sum of measured active cycles
-    // across the N parallel components of each type; dividing by N gives the
-    // average active cycles per component, so utilization = busy/total_cycles is
-    // the mean fraction of time a component of that type was transferring. Unlike
-    // the former total - avg_stall heuristic, this excludes idle cycles (a
-    // component with nothing queued) rather than counting them as busy.
+    // (follow-on 1b). busy_cycles holds the raw sum of measured active cycles
+    // across the N parallel components of each type; dividing by N (in floating
+    // point, so no integer floor / systematic undercount) gives the average active
+    // cycles per component, so utilization = busy/total_cycles is the mean fraction
+    // of time a component of that type was transferring. Unlike the former
+    // total - avg_stall heuristic, this excludes idle cycles (a component with
+    // nothing queued) rather than counting them as busy.
     size_t n_dma = dma_engines_.size();
     size_t n_bm = block_movers_.size();
     size_t n_str = row_streamers_.size() + col_streamers_.size();
 
-    if (n_dma > 0) stats.dma_busy_cycles /= n_dma; else stats.dma_busy_cycles = 0;
-    if (n_bm > 0)  stats.bm_busy_cycles  /= n_bm;  else stats.bm_busy_cycles = 0;
-    if (n_str > 0) stats.str_busy_cycles /= n_str; else stats.str_busy_cycles = 0;
+    stats.dma_busy_cycles = n_dma > 0 ? stats.dma_busy_cycles / static_cast<double>(n_dma) : 0.0;
+    stats.bm_busy_cycles  = n_bm > 0  ? stats.bm_busy_cycles  / static_cast<double>(n_bm)  : 0.0;
+    stats.str_busy_cycles = n_str > 0 ? stats.str_busy_cycles / static_cast<double>(n_str) : 0.0;
 }
 
 inline size_t ConcurrentTimingExecutor::count_completed_tiles() const {

--- a/include/sw/kpu/timing/concurrent_timing_executor.hpp
+++ b/include/sw/kpu/timing/concurrent_timing_executor.hpp
@@ -170,7 +170,9 @@ public:
     struct Statistics {
         Cycle total_cycles = 0;
 
-        // Component busy cycles
+        // Component busy cycles: directly measured active (transferring) cycles,
+        // averaged per component. Measured per cycle in each component's tick(),
+        // NOT derived from total - stalls, so idle cycles are excluded.
         Cycle dma_busy_cycles = 0;
         Cycle bm_busy_cycles = 0;
         Cycle str_busy_cycles = 0;
@@ -1407,9 +1409,11 @@ inline ConcurrentTimingExecutor::Statistics ConcurrentTimingExecutor::get_statis
 }
 
 inline void ConcurrentTimingExecutor::collect_statistics(Statistics& stats) const {
-    // Aggregate from DMA Engines
+    // Aggregate from DMA Engines. dma_busy_cycles accumulates the raw sum of
+    // directly measured active cycles here, then is normalized per component below.
     for (const auto& dma : dma_engines_) {
         stats.dma_credit_stalls += dma->stall_cycles_credit();
+        stats.dma_busy_cycles += dma->active_cycles();
         stats.bytes_loaded += dma->total_bytes_loaded();
         stats.bytes_stored += dma->total_bytes_stored();
     }
@@ -1418,6 +1422,7 @@ inline void ConcurrentTimingExecutor::collect_statistics(Statistics& stats) cons
     for (const auto& mover : block_movers_) {
         stats.bm_tag_stalls += mover->stall_cycles_tag();
         stats.bm_credit_stalls += mover->stall_cycles_credit();
+        stats.bm_busy_cycles += mover->active_cycles();
         stats.tiles_moved += mover->total_tiles_moved();
         stats.tiles_writeback += mover->total_tiles_writeback();
     }
@@ -1426,12 +1431,14 @@ inline void ConcurrentTimingExecutor::collect_statistics(Statistics& stats) cons
     for (const auto& streamer : row_streamers_) {
         stats.str_tag_stalls += streamer->stall_cycles_tag();
         stats.str_credit_stalls += streamer->stall_cycles_credit();
+        stats.str_busy_cycles += streamer->active_cycles();
         stats.tiles_fed += streamer->total_tiles_fed();
         stats.tiles_drained += streamer->total_tiles_drained();
     }
     for (const auto& streamer : col_streamers_) {
         stats.str_tag_stalls += streamer->stall_cycles_tag();
         stats.str_credit_stalls += streamer->stall_cycles_credit();
+        stats.str_busy_cycles += streamer->active_cycles();
         stats.tiles_fed += streamer->total_tiles_fed();
     }
 
@@ -1444,23 +1451,20 @@ inline void ConcurrentTimingExecutor::collect_statistics(Statistics& stats) cons
         }
     }
 
-    // Compute average busy cycles per component type
-    // Stalls are aggregated across N parallel components, so divide by N to get
-    // average stalls per component, then subtract from total_cycles.
-    // This gives utilization as average activity across all components of that type.
+    // Normalize the directly measured active cycles to a per-component average
+    // (follow-on 1b). busy_cycles now holds the raw sum of measured active cycles
+    // across the N parallel components of each type; dividing by N gives the
+    // average active cycles per component, so utilization = busy/total_cycles is
+    // the mean fraction of time a component of that type was transferring. Unlike
+    // the former total - avg_stall heuristic, this excludes idle cycles (a
+    // component with nothing queued) rather than counting them as busy.
     size_t n_dma = dma_engines_.size();
     size_t n_bm = block_movers_.size();
     size_t n_str = row_streamers_.size() + col_streamers_.size();
 
-    // Compute average stalls per component, capped to prevent underflow
-    Cycle avg_dma_stalls = n_dma > 0 ? stats.dma_credit_stalls / n_dma : 0;
-    Cycle avg_bm_stalls = n_bm > 0 ? (stats.bm_tag_stalls + stats.bm_credit_stalls) / n_bm : 0;
-    Cycle avg_str_stalls = n_str > 0 ? (stats.str_tag_stalls + stats.str_credit_stalls) / n_str : 0;
-
-    // Busy = total - average stalls, capped at 0 to prevent underflow
-    stats.dma_busy_cycles = avg_dma_stalls < stats.total_cycles ? stats.total_cycles - avg_dma_stalls : 0;
-    stats.bm_busy_cycles = avg_bm_stalls < stats.total_cycles ? stats.total_cycles - avg_bm_stalls : 0;
-    stats.str_busy_cycles = avg_str_stalls < stats.total_cycles ? stats.total_cycles - avg_str_stalls : 0;
+    if (n_dma > 0) stats.dma_busy_cycles /= n_dma; else stats.dma_busy_cycles = 0;
+    if (n_bm > 0)  stats.bm_busy_cycles  /= n_bm;  else stats.bm_busy_cycles = 0;
+    if (n_str > 0) stats.str_busy_cycles /= n_str; else stats.str_busy_cycles = 0;
 }
 
 inline size_t ConcurrentTimingExecutor::count_completed_tiles() const {

--- a/include/sw/kpu/timing/dma_engine_process.hpp
+++ b/include/sw/kpu/timing/dma_engine_process.hpp
@@ -164,6 +164,12 @@ public:
         // Step 4: Remove completed requests
         remove_completed_requests();
 
+        // Direct active-cycle measurement (follow-on 1b): this cycle counts as
+        // active iff the MC is transferring on our behalf (>=1 SUBMITTED request).
+        // This is measured, not derived from total - stalls, so idle cycles (no
+        // request queued) are correctly excluded from utilization.
+        if (!is_idle()) ++active_cycles_;
+
         return events;
     }
 
@@ -204,6 +210,7 @@ public:
         next_slot_id_ = 0;
         stall_cycles_credit_ = 0;
         stall_cycles_tag_ = 0;
+        active_cycles_ = 0;
         total_bytes_loaded_ = 0;
         total_bytes_stored_ = 0;
     }
@@ -236,6 +243,12 @@ public:
         return stall_cycles_credit_ + stall_cycles_tag_;
     }
 
+    /// Directly measured cycles the engine was actively transferring (a request
+    /// SUBMITTED to the MC). Excludes both stalled and idle cycles.
+    [[nodiscard]] Cycle active_cycles() const {
+        return active_cycles_;
+    }
+
     [[nodiscard]] size_t total_bytes_loaded() const {
         return total_bytes_loaded_;
     }
@@ -263,6 +276,7 @@ private:
     // Statistics
     Cycle stall_cycles_credit_ = 0;
     Cycle stall_cycles_tag_ = 0;
+    Cycle active_cycles_ = 0;
     size_t total_bytes_loaded_ = 0;
     size_t total_bytes_stored_ = 0;
 

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -46,11 +46,11 @@ using schedule::BatchNormAffine;
 /// on a fresh ConcurrentTimingExecutor and its per-op Statistics are additive. The
 /// movement-fabric activity below is summed the same way as the stall/cycle totals.
 ///
-/// Utilization is the executor's own busy/total ratio, aggregated as
-/// Sum(busy) / Sum(total_cycles). busy is derived by the executor from its
-/// per-component stall accounting (ConcurrentTimingExecutor::collect_statistics);
-/// because nodes run sequentially, treat these as a relative activity metric for
-/// comparing configurations, not a validated absolute
+/// Utilization is Sum(busy) / Sum(total_cycles) per mover. busy is the executor's
+/// DIRECTLY MEASURED active-cycle count (each component counts, in its tick(), the
+/// cycles a transfer actually occupied it) averaged per component — not derived
+/// from total - stalls, so idle cycles are excluded. Because nodes run
+/// sequentially this captures within-op activity, not cross-branch overlap
 /// (see docs/benchmarking/resnet-benchmarking-guide.md, section 6).
 struct RunStats {
     Cycle total_cycles = 0;

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -59,10 +59,12 @@ struct RunStats {
     Cycle str_stalls = 0;
     std::size_t ops = 0;
 
-    // Movement-fabric activity (summed per-op).
-    Cycle dma_busy = 0;
-    Cycle bm_busy = 0;
-    Cycle str_busy = 0;
+    // Movement-fabric activity (summed per-op). busy is fractional: each op's
+    // per-component mean active cycles is exact (not integer-floored), so the
+    // whole-network sum carries that precision.
+    double dma_busy = 0.0;
+    double bm_busy = 0.0;
+    double str_busy = 0.0;
     std::size_t tiles_loaded = 0;
     std::size_t tiles_stored = 0;
     std::size_t tiles_moved = 0;

--- a/include/sw/kpu/timing/streamer_process.hpp
+++ b/include/sw/kpu/timing/streamer_process.hpp
@@ -132,6 +132,12 @@ public:
             }
         }
 
+        // Direct active-cycle measurement (follow-on 1b): this cycle counts as
+        // active iff a transfer (feed or drain) occupies it. Measured, not derived
+        // from total - stalls, so idle cycles and the drain compute-wait are
+        // excluded from utilization.
+        if (in_flight_.has_value()) ++active_cycles_;
+
         return events;
     }
 
@@ -159,6 +165,7 @@ public:
         stall_cycles_tag_ = 0;
         stall_cycles_credit_ = 0;
         stall_cycles_compute_ = 0;
+        active_cycles_ = 0;
         total_tiles_fed_ = 0;
         total_tiles_drained_ = 0;
     }
@@ -185,6 +192,12 @@ public:
 
     [[nodiscard]] Cycle stall_cycles_compute() const {
         return stall_cycles_compute_;
+    }
+
+    /// Directly measured cycles a transfer (feed or drain) occupied the streamer.
+    /// Excludes stalled (incl. drain compute-wait) and idle cycles.
+    [[nodiscard]] Cycle active_cycles() const {
+        return active_cycles_;
     }
 
     [[nodiscard]] size_t total_tiles_fed() const {
@@ -225,6 +238,7 @@ private:
     Cycle stall_cycles_tag_ = 0;
     Cycle stall_cycles_credit_ = 0;
     Cycle stall_cycles_compute_ = 0;
+    Cycle active_cycles_ = 0;
     size_t total_tiles_fed_ = 0;
     size_t total_tiles_drained_ = 0;
 

--- a/tests/timing/test_concurrent_timing_executor.cpp
+++ b/tests/timing/test_concurrent_timing_executor.cpp
@@ -664,6 +664,38 @@ TEST_CASE("ConcurrentTimingExecutor utilization", "[timing][executor]") {
     REQUIRE(stats.str_utilization() <= 1.0);
 }
 
+TEST_CASE("ConcurrentTimingExecutor busy cycles are a fractional (unfloored) mean",
+          "[timing][executor][utilization]") {
+    // A single move routes to exactly one BlockMover for L cycles. With one mover
+    // the reported per-component-mean busy IS L; with three movers the other two
+    // are idle, so the raw active sum is still L and the mean must be the EXACT
+    // L / 3. Hence busy(3 movers) * 3 == busy(1 mover). A regression to integer
+    // per-component division would floor L/3 and break this whenever 3 does not
+    // divide L (the exact case the fractional-precision fix protects against).
+    auto busy_for = [](size_t n_bm) {
+        auto cfg = default_config();
+        cfg.num_block_movers = n_bm;
+        ConcurrentTimingExecutor exec(cfg);
+        // 512-byte tile -> L = 14 move cycles, deliberately NOT divisible by 3 so
+        // the fractional mean L/3 differs from floor(L/3).
+        auto tile = make_tile(MatrixID::A, 0, 0, /*tk*/ 0, /*size_bytes*/ 512);
+        exec.schedule_load(tile);
+        exec.schedule_move(tile);
+        exec.schedule_feed(tile);
+        exec.run();
+        return exec.get_statistics().bm_busy_cycles;  // per-component mean (double)
+    };
+
+    const double busy1 = busy_for(1);   // == L (single mover, no division)
+    const double busy3 = busy_for(3);   // == L / 3, exact fractional mean
+    REQUIRE(busy1 > 0.0);
+    // Guard the test itself: L must not be divisible by 3, or floor == exact and
+    // the check below could not distinguish a regression.
+    REQUIRE(static_cast<long>(busy1) % 3 != 0);
+    REQUIRE(busy1 == Catch::Approx(static_cast<double>(static_cast<long>(busy1))));  // integer
+    REQUIRE(busy3 * 3.0 == Catch::Approx(busy1));   // exact mean, not floor(L/3)
+}
+
 // ============================================================================
 // Step-by-Step Execution Tests
 // ============================================================================

--- a/tests/timing/test_resnet_utilization.cpp
+++ b/tests/timing/test_resnet_utilization.cpp
@@ -1,18 +1,23 @@
 // ============================================================================
 // tests/timing/test_resnet_utilization.cpp
-// Regression guard for the ResNet movement-fabric utilization metric (PR #220).
+// Regression guard for the ResNet movement-fabric utilization metric.
 //
 // RunStats aggregates the executor's per-op Statistics so the m2_resnet demo can
-// report DMA/BlockMover/Streamer utilization. Every RunStats-producing runner must
-// contribute BOTH its busy cycles (numerator) AND its total_cycles (denominator);
-// an earlier version instrumented total_cycles for some ops (elementwise,
-// depthwise, global-avg-pool) without their busy cycles, understating utilization.
+// report DMA/BlockMover/Streamer utilization. busy_cycles is now a DIRECTLY
+// MEASURED active-cycle count (follow-on 1b): each component increments a counter
+// in its tick() on every cycle a transfer occupies it, so busy excludes both
+// stalled and idle cycles (the former total - stalls/N heuristic counted idle as
+// busy). Utilization = busy / total_cycles is therefore a true activity fraction.
 //
-// The consistency invariant that catches that bug: because the executor derives
-// busy = cycles - stalls/N (clamped >= 0) per op, the aggregate satisfies
-//   busy + stalls >= total_cycles      for each mover.
-// An op that adds cycles without its busy/stalls breaks it. This test asserts the
-// invariant (and util in [0,1], and the bandwidth clock guard) on a full network.
+// Invariants asserted here (on a full network, two shapes):
+//   - 0 <= busy <= total_cycles for every mover (util in [0,1]) -- guards
+//     over-counting / bad per-component normalization.
+//   - busy > 0 for every mover -- guards a component whose active counter was
+//     never wired into its tick() (would read a flat 0).
+//   - not every mover pinned at 100% -- guards an unconditional per-cycle
+//     increment that ignores whether a transfer actually occupied the cycle.
+//   - util == busy / total (accessor consistency), tiles/bytes > 0.
+//   - effective bandwidth guards a non-positive clock.
 //
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024-2026 Stillwater Supercomputing, Inc.
@@ -38,12 +43,11 @@ RunStats run_resnet(const ResNet18Spec& sp) {
     return exec.run(g, net.input, net.node_data, /*T*/16).stats;
 }
 
-// busy + stalls >= cycles, and busy <= cycles (util in [0,1]), per mover.
-void check_mover(const char* who, Cycle busy, Cycle stalls, Cycle total, double util) {
-    INFO(who << ": busy=" << busy << " stalls=" << stalls << " total=" << total
-             << " util=" << util);
-    REQUIRE(busy <= total);                    // utilization <= 1
-    REQUIRE(busy + stalls >= total);           // instrumentation-consistency invariant
+// Directly measured active cycles: 0 < busy <= cycles (util in (0,1]), per mover.
+void check_mover(const char* who, Cycle busy, Cycle total, double util) {
+    INFO(who << ": busy=" << busy << " total=" << total << " util=" << util);
+    REQUIRE(busy > 0);                         // active counter wired into tick()
+    REQUIRE(busy <= total);                    // utilization <= 1 (no over-count)
     REQUIRE(util >= 0.0);
     REQUIRE(util <= 1.0);
     REQUIRE_THAT(util, Catch::Matchers::WithinAbs(
@@ -52,9 +56,9 @@ void check_mover(const char* who, Cycle busy, Cycle stalls, Cycle total, double 
 
 } // namespace
 
-TEST_CASE("ResNet RunStats utilization is instrumentation-consistent",
+TEST_CASE("ResNet RunStats utilization is directly measured and consistent",
           "[timing][resnet][utilization]") {
-    // Two shapes so the invariant is exercised across op mixes (the base and the
+    // Two shapes so the invariants are exercised across op mixes (the base and the
     // wider-batch sweep the demo publishes).
     for (const auto& sp : {ResNet18Spec{}, [] { ResNet18Spec s; s.batch = 32; return s; }()}) {
         RunStats st = run_resnet(sp);
@@ -62,12 +66,18 @@ TEST_CASE("ResNet RunStats utilization is instrumentation-consistent",
         REQUIRE(st.ops > 0);
         REQUIRE(st.total_cycles > 0);
 
-        check_mover("dma", st.dma_busy, st.dma_stalls, st.total_cycles, st.dma_utilization());
-        check_mover("bm",  st.bm_busy,  st.bm_stalls,  st.total_cycles, st.bm_utilization());
-        check_mover("str", st.str_busy, st.str_stalls, st.total_cycles, st.str_utilization());
+        check_mover("dma", st.dma_busy, st.total_cycles, st.dma_utilization());
+        check_mover("bm",  st.bm_busy,  st.total_cycles, st.bm_utilization());
+        check_mover("str", st.str_busy, st.total_cycles, st.str_utilization());
 
-        // Real fp32 moved through the fabric: tiles and bytes are non-zero, and
-        // every op contributed to ops (so the denominator is not diluted).
+        // Not every mover pinned at 100%: direct measurement must exclude idle
+        // cycles, so at least one stage shows headroom (on ResNet the on-chip
+        // movers starve behind the DRAM-bound DMA).
+        REQUIRE((st.dma_busy < st.total_cycles ||
+                 st.bm_busy  < st.total_cycles ||
+                 st.str_busy < st.total_cycles));
+
+        // Real fp32 moved through the fabric.
         REQUIRE(st.tiles_loaded > 0);
         REQUIRE(st.tiles_moved > 0);
         REQUIRE(st.bytes_loaded > 0);

--- a/tests/timing/test_resnet_utilization.cpp
+++ b/tests/timing/test_resnet_utilization.cpp
@@ -43,15 +43,16 @@ RunStats run_resnet(const ResNet18Spec& sp) {
     return exec.run(g, net.input, net.node_data, /*T*/16).stats;
 }
 
-// Directly measured active cycles: 0 < busy <= cycles (util in (0,1]), per mover.
-void check_mover(const char* who, Cycle busy, Cycle total, double util) {
+// Directly measured active cycles (fractional per-component mean): 0 < busy <=
+// cycles (util in (0,1]), per mover.
+void check_mover(const char* who, double busy, Cycle total, double util) {
     INFO(who << ": busy=" << busy << " total=" << total << " util=" << util);
-    REQUIRE(busy > 0);                         // active counter wired into tick()
-    REQUIRE(busy <= total);                    // utilization <= 1 (no over-count)
+    REQUIRE(busy > 0.0);                        // active counter wired into tick()
+    REQUIRE(busy <= static_cast<double>(total)); // utilization <= 1 (no over-count)
     REQUIRE(util >= 0.0);
     REQUIRE(util <= 1.0);
     REQUIRE_THAT(util, Catch::Matchers::WithinAbs(
-        total > 0 ? static_cast<double>(busy) / static_cast<double>(total) : 0.0, 1e-12));
+        total > 0 ? busy / static_cast<double>(total) : 0.0, 1e-12));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Follow-on **1b** from #220: replace the derived `busy = total_cycles − stalls/N` utilization heuristic with a **directly measured active-cycle counter**, so utilization is a true activity fraction that excludes idle cycles.

Each CSP component increments an `active_cycles_` counter in its `tick()` on every cycle a transfer actually occupies it:
- **DMAEngineProcess** — a request is `SUBMITTED` (MC transferring on its behalf).
- **BlockMoverProcess / StreamerProcess** — an `InFlightTransfer` occupies the cycle. Zero-latency dedup moves and the drain compute-wait are excluded.

`collect_statistics` sums these across the N parallel components and divides by N; `{dma,bm,str}_busy_cycles` becomes the mean active cycles per component and `utilization = busy/total ∈ [0,1]` is the mean fraction of time a component was transferring.

## The measured picture flips the bottleneck diagnosis

```
  utilization              dmaU%    bmU%   strU%
  resnet18 (base)           84.6    14.1    10.7
  resnet18 [2,2,2,2]        77.9    18.4    13.9
  resnet18 (batch 32)       92.3    14.9    11.8
```

- **DRAM→L3 DMA is the near-saturated bottleneck** (78–92%, 92% at batch 32).
- **On-chip BlockMover (14–18%) and Streamer (11–14%) starve behind it** — the scaled network is DRAM-bandwidth-bound.

The former heuristic reported BM at 32–47% and mis-ranked it as the bottleneck by counting its idle cycles as busy. High `bmStl` **with** low `bmU%` is exactly the signature of a stage that waits a lot but rarely transfers.

## Test changes

`test_resnet_utilization.cpp` moves off the derived-formula invariant (`busy + stalls ≥ cycles`, which was a property of `total − stall` and no longer holds once idle is excluded) to the direct-counting invariants:
- `0 < busy ≤ total_cycles` per mover (util in `(0,1]`) — guards over-count / bad normalization.
- `busy > 0` per mover — guards a counter never wired into `tick()`.
- not all movers pinned at 100% — guards an unconditional per-cycle increment (proves idle is genuinely excluded).
- accessor consistency, tiles/bytes > 0.

## Changes

- `dma_engine_process.hpp`, `block_mover_process.hpp`, `streamer_process.hpp` — `active_cycles_` counter + `active_cycles()` accessor + reset.
- `concurrent_timing_executor.hpp` — aggregate active cycles, per-component average; `Statistics` doc updated.
- `csp_op_runners.hpp` — `RunStats` doc updated (busy is measured, not derived).
- `examples/milestones/m2_resnet.cpp` — footnote regenerated.
- `docs/benchmarking/resnet-benchmarking-guide.md`, `docs/milestones/M2_resnet.md` — numbers + narrative regenerated; roadmap 1b marked done.
- `CHANGELOG.md` — Changed entry.

## Test results

- All **58 timing tests pass** (no other test asserts a CSP utilization threshold beyond `[0,1]` bounds, which still hold).
- `clang++ -Werror -Wall -Wextra -Wshorten-64-to-32 -fsyntax-only` OK on the demo, the test, and `test_concurrent_timing_executor.cpp` (MSVC C4267 proxy).

## Test plan

- [ ] Fast CI passes
- [ ] Resolve CodeRabbit review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Utilization metrics now use directly measured active transfer cycles, excluding idle and stalled time.
  * ResNet benchmark results now identify DRAM-to-L3 DMA as the primary near-saturated bottleneck, with BlockMover and Streamer activity constrained behind it.
  * Component utilization statistics and displayed benchmark output have been updated to reflect the improved measurement accuracy.

* **Documentation**
  * Updated benchmarking guidance, milestone documentation, changelog details, and demo explanations for the revised utilization metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->