### PR TITLE
feat(bench): compute FLOP efficiency + roofline for the ResNet benchmark (item 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Compute FLOP efficiency / roofline for the ResNet benchmark.** During the graph
+  walk `GraphCspExecutor` accumulates `RunStats::total_macs` from the GEMM ops
+  (`conv.gemm_M·gemm_N·gemm_K`, which handles `groups`/depthwise, plus
+  `fc_M·fc_N·fc_K`); fused BN/ReLU, residual adds, and pooling carry no GEMM.
+  `RunStats` exposes `total_flops()` (2/MAC), `achieved_gflops(clock)`,
+  `arithmetic_intensity()` (FLOPs/DRAM byte), `compute_efficiency(peak_flops/cycle)`,
+  and `roofline_efficiency(peak_gflops, ext_bw, clock)`, using the matmul harness's
+  16×16-PE / 512-GFLOP-@1GHz / 64-GB/s convention. The `m2_resnet` demo prints a
+  compute table (MFLOP, GFLOP/s, peak%, arithmetic intensity, roofline%, mem/cmp
+  bound). Result: ResNet is **memory-bound** (AI ≈ 5.2 < 8 ridge, ~22–29% of peak),
+  independently corroborating the DRAM-saturated movement-fabric finding.
+  `test_resnet_utilization.cpp` adds a precise single-matmul MAC anchor
+  (`total_macs == M·N·K`) and bounded-efficiency asserts.
+
 - **Movement-fabric utilization surfaced in the ResNet benchmark.** `RunStats`
   (`csp_op_runners.hpp`) now aggregates the executor's per-op
   `ConcurrentTimingExecutor::get_statistics()` — `{dma,bm,str}_busy_cycles`,

--- a/docs/benchmarking/resnet-benchmarking-guide.md
+++ b/docs/benchmarking/resnet-benchmarking-guide.md
@@ -12,9 +12,10 @@ reports **cycles / ops / stall-cycles** plus **movement-fabric utilization**
 (DMA/BlockMover/Streamer busy%, tiles, effective DRAM bandwidth). Utilization is a
 **directly measured** active-cycle count (each component counts the cycles a
 transfer occupied it) — not the earlier `cycles − stalls/N` heuristic — so idle
-cycles are excluded and the numbers are a true activity fraction. The demo prints a
-second "utilization" table. What is *not* yet available is compute-fabric FLOP
-efficiency (§6 caveat) — that is the next research task.
+cycles are excluded and the numbers are a true activity fraction. It also reports
+**compute FLOP efficiency** (GEMM MACs vs a 16×16 PE-array peak, arithmetic
+intensity, and roofline position — §6), which independently confirms the workload
+is memory-bound. The demo prints a "utilization" table and a "compute" table.
 
 ---
 
@@ -180,6 +181,11 @@ directly. Any new spec must keep batch/channels/classes as `tile` multiples.
   resnet18 (base)           84.6    14.1    10.7     1805     1438     1438      18.5       2.9
   resnet18 [2,2,2,2]        77.9    18.4    13.9     2773     2318     2318      25.4       4.0
   resnet18 (batch 32)       92.3    14.9    11.8     3610     2876     2876      19.3       3.2
+
+  compute                    MFLOP   GFLOP/s  peakEff%   AI(F/B)  roofEff%   bound
+  resnet18 (base)             4.48     112.4      21.9      5.25      33.4     mem
+  resnet18 [2,2,2,2]          7.73     150.1      29.3      5.11      45.9     mem
+  resnet18 (batch 32)         8.96     124.2      24.3      5.54      35.1     mem
 ```
 
 Reading it:
@@ -198,6 +204,9 @@ Reading it:
 - **`ldGB/s`/`stGB/s`** are at an assumed 1.0 GHz clock (so GB/s == bytes/cycle);
   the unit is a knob, the *ratio* between configs is the signal.
 - **cyc/op is not efficiency** — it is total cycles / op count, inflated by stalls.
+- **Compute confirms it from the other side:** arithmetic intensity ≈ 5.2 FLOP/byte
+  is below the 8 FLOP/byte ridge, so every config is **memory-bound** (`bound=mem`),
+  reaching only ~22–29% of the 16×16 array's peak. Full detail in §6.
 
 One accounting note so the columns are not misread:
 - **Stall columns are summed across all parallel components and all ops**, so a
@@ -273,16 +282,49 @@ Practical guidance:
 - The signal is the **DMA near-saturation (78–92%) vs. starved on-chip movers
   (11–18%)**: the workload is DRAM-bandwidth-bound at this scale.
 
-### Caveat: compute-fabric utilization is not in this path
+### Compute FLOP efficiency (roofline position)
 
-`Statistics` covers the **movement** fabric (DMA / BlockMover / Streamer) and DRAM
-bandwidth. It does **not** carry a compute-fabric FLOP-efficiency number the way
-the standalone `kpu-benchmark` matmul harness does (`tools/benchmark/`, whose
-`baseline.json` has `utilization.compute` and `gflops`/`efficiency`). If the study
-needs "what fraction of peak MACs are we hitting on ResNet's convs," that is a
-separate metric: compute the network's total MACs (known from the graph) and divide
-by `total_cycles × peak_MACs_per_cycle`. That is research task #2, and it belongs
-either in the demo or in a ResNet row added to the `kpu-benchmark` harness.
+`RunStats` now also carries the **compute** side. During the graph walk the GEMM
+ops accumulate `total_macs` (`conv.gemm_M·gemm_N·gemm_K`, which handles `groups`,
+plus `fc_M·fc_N·fc_K`); fused BatchNorm, ReLU epilogues, residual adds, and pooling
+carry no GEMM and contribute nothing. From that:
+
+```cpp
+r.stats.total_flops();                       // 2 * total_macs
+r.stats.achieved_gflops(clock_ghz);          // FLOP/cycle * clock
+r.stats.arithmetic_intensity();              // FLOPs per DRAM byte
+r.stats.compute_efficiency(512.0);           // achieved / peak FLOP/cycle
+r.stats.roofline_efficiency(512.0, 64.0, 1.0); // achieved / min(AI*bw, peak)
+```
+
+Conventions match the matmul `kpu-benchmark` harness (`sw::benchmark::HardwareSpec`):
+a **16×16 PE array, 2 FLOP/MAC → 512 GFLOP/s peak at 1 GHz**, **64 GB/s** external
+DRAM, ridge point `512/64 = 8` FLOP/byte. The demo prints a compute table:
+
+```text
+  compute                    MFLOP   GFLOP/s  peakEff%   AI(F/B)  roofEff%   bound
+  resnet18 (base)             4.48     112.4      21.9      5.25      33.4     mem
+  resnet18 [2,2,2,2]          7.73     150.1      29.3      5.11      45.9     mem
+  resnet18 (batch 32)         8.96     124.2      24.3      5.54      35.1     mem
+```
+
+Reading it, and how it corroborates the movement story:
+- **Arithmetic intensity ≈ 5.2 FLOP/byte < the 8 ridge → memory-bound.** This is the
+  *same* conclusion the movement fabric gave (DMA at 78–92%), now from the compute
+  side: the scaled network does too little arithmetic per DRAM byte to saturate the
+  PE array.
+- **peakEff 22–29%** — only about a quarter of the 16×16 array's peak is reached,
+  because compute is starved behind DRAM.
+- **roofEff 33–46%** — even against the *memory* ceiling (AI·64) there is headroom:
+  movement stalls and the sequential-node walk keep it below the attainable limit.
+- **Deeper `[2,2,2,2]` is best** on both (29% / 46%): more arithmetic amortizes each
+  load, nudging toward the ridge.
+- These are **relative** numbers on a scaled topology (§3) — the *shape* (memory-
+  bound, quarter-peak) is the signal, not the absolute GFLOP/s.
+
+Follow-ons: a full-resolution ResNet (higher AI, likely still memory-bound at this
+buffer sizing) and a per-layer AI breakdown to find which convs are compute- vs
+memory-bound.
 
 ---
 
@@ -295,12 +337,11 @@ Ordered by dependency:
 1b. ~~**Refine `busy` to a directly-measured active-cycle count**~~ — **done**:
    each component now counts, in its `tick()`, the cycles a transfer occupied it, so
    utilization excludes idle cycles and is a measured activity fraction (§6).
-2. **Compute utilization / FLOP efficiency** — MACs / (`total_cycles` × peak). Lets
-   you say "roofline position" for each config. **Now the top open task** — the
-   movement fabric being DRAM-bound (§5) makes the compute-side story the next
-   question.
+2. ~~**Compute FLOP efficiency / roofline position**~~ — **done** (§6): the demo
+   prints MFLOP, GFLOP/s, peak efficiency, arithmetic intensity, and roofline
+   position; the network is memory-bound (AI ≈ 5.2 < 8), corroborating §5.
 3. **Occupancy timeline** — wire `TileTracker` into the demo (behind a flag) to see
-   which buffer level saturates during the forward pass.
+   which buffer level saturates during the forward pass. **Now the top open task.**
 4. **Full-scale ResNet-18** — larger spatial dims + `[2,2,2,2]` + channel growth as
    a benchmark spec (slow; run offline, not in CI). Needed before any number is
    quoted as representative.

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -67,6 +67,11 @@ utilization              dmaU%    bmU%   strU%  tilesLd  tilesMv  tilesFd    ldG
 resnet18 (base)           84.6    14.1    10.7     1805     1438     1438      18.5
 resnet18 [2,2,2,2]        77.9    18.4    13.9     2773     2318     2318      25.4
 resnet18 (batch 32)       92.3    14.9    11.8     3610     2876     2876      19.3
+
+compute                    MFLOP   GFLOP/s  peakEff%   AI(F/B)  roofEff%   bound
+resnet18 (base)             4.48     112.4      21.9      5.25      33.4     mem
+resnet18 [2,2,2,2]          7.73     150.1      29.3      5.11      45.9     mem
+resnet18 (batch 32)         8.96     124.2      24.3      5.54      35.1     mem
 ```
 
 **Fusion payoff:** the `[2,2,2,2]` network's 67 graph nodes execute as **38 CSP
@@ -79,6 +84,11 @@ the **DRAM→L3 DMA as the near-saturated bottleneck** (78–92% active, 92% at 
 it**: the scaled network is DRAM-bandwidth-bound. Stall columns are summed across
 all parallel components (so they can exceed `cycles`); see
 `docs/benchmarking/resnet-benchmarking-guide.md` for the full metric definitions.
+
+**Compute FLOP efficiency** confirms the same story from the arithmetic side:
+arithmetic intensity ≈ 5.2 FLOP/byte is below the 8 FLOP/byte ridge of a 16×16 PE
+array (512 GFLOP/s @ 1 GHz) with 64 GB/s DRAM, so every config is **memory-bound**,
+reaching only ~22–29% of compute peak.
 
 ## Scope & scaling notes
 

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -82,6 +82,14 @@ Row run_spec(const std::string& name, const ResNet18Spec& spec,
 // at 1.0 GHz, GB/s == bytes/cycle, so this only sets the reported unit.
 constexpr double kAssumedClockGHz = 1.0;
 
+// Compute-roofline hardware constants (sw::benchmark::HardwareSpec convention):
+// a 16x16 systolic array at 2 FLOP/MAC gives 512 FLOP/cycle = 512 GFLOP/s @ 1 GHz;
+// external DRAM bandwidth 64 GB/s. Ridge point = 512/64 = 8 FLOP/byte.
+constexpr double kPeakFlopsPerCycle = 512.0;   // 16*16*2
+constexpr double kPeakGflops        = 512.0;   // at kAssumedClockGHz
+constexpr double kExtBwGbs          = 64.0;
+constexpr double kRidgeAI           = kPeakGflops / kExtBwGbs;   // 8 FLOP/byte
+
 void print_row(const Row& r) {
     double cyc_per_op = r.ops ? static_cast<double>(r.stats.total_cycles) / static_cast<double>(r.ops) : 0.0;
     std::cout << "  " << std::left << std::setw(22) << r.name << std::right
@@ -109,6 +117,20 @@ void print_util_row(const Row& r) {
               << std::setw(9) << r.stats.tiles_fed
               << std::setw(10) << std::setprecision(1) << r.stats.effective_load_bandwidth(kAssumedClockGHz)
               << std::setw(10) << r.stats.effective_store_bandwidth(kAssumedClockGHz)
+              << "\n" << std::defaultfloat;
+}
+
+void print_compute_row(const Row& r) {
+    const double ai = r.stats.arithmetic_intensity();
+    std::cout << "  " << std::left << std::setw(22) << r.name << std::right
+              << std::fixed
+              << std::setw(10) << std::setprecision(2) << r.stats.total_flops() / 1e6   // MFLOP
+              << std::setw(10) << std::setprecision(1) << r.stats.achieved_gflops(kAssumedClockGHz)
+              << std::setw(10) << std::setprecision(1) << 100.0 * r.stats.compute_efficiency(kPeakFlopsPerCycle)
+              << std::setw(10) << std::setprecision(2) << ai
+              << std::setw(10) << std::setprecision(1)
+              << 100.0 * r.stats.roofline_efficiency(kPeakGflops, kExtBwGbs, kAssumedClockGHz)
+              << std::setw(8) << (ai < kRidgeAI ? "mem" : "cmp")
               << "\n" << std::defaultfloat;
 }
 
@@ -170,6 +192,22 @@ int main(int argc, char* argv[]) {
               << std::fixed << std::setprecision(1) << kAssumedClockGHz
               << " GHz assumed clock. See\n"
                  "  docs/benchmarking/resnet-benchmarking-guide.md.\n"
+              << std::defaultfloat;
+
+    // Compute FLOP efficiency (roofline position).
+    std::cout << "\n  " << std::left << std::setw(22) << "compute" << std::right
+              << std::setw(10) << "MFLOP" << std::setw(10) << "GFLOP/s"
+              << std::setw(10) << "peakEff%" << std::setw(10) << "AI(F/B)"
+              << std::setw(10) << "roofEff%" << std::setw(8) << "bound" << "\n";
+    std::cout << "  " << std::string(80, '-') << "\n";
+    for (const auto& r : rows) print_compute_row(r);
+    std::cout << "\n  GEMM FLOPs (conv im2col + FC, 2/MAC) vs a "
+              << std::fixed << std::setprecision(0) << kPeakGflops
+              << " GFLOP/s peak (16x16 PE @ "
+              << std::setprecision(1) << kAssumedClockGHz << " GHz) and "
+              << std::setprecision(0) << kExtBwGbs << " GB/s DRAM. peakEff = achieved/peak;\n"
+                 "  roofEff = achieved/min(AI*bw, peak); bound = mem below the "
+              << std::setprecision(0) << kRidgeAI << " FLOP/byte ridge, else cmp.\n"
               << std::defaultfloat;
 
     std::cout << "\n  Fusion: BatchNorm folded into conv, ReLU fused as the conv"

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -30,7 +30,9 @@
 #include <sw/kpu/timing/schedule/pooling_schedule_generator.hpp>
 #include <sw/kpu/timing/schedule/schedule_executor.hpp>
 
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -72,6 +74,11 @@ struct RunStats {
     std::size_t bytes_loaded = 0;
     std::size_t bytes_stored = 0;
 
+    // Multiply-accumulates performed by the GEMM ops (conv im2col + FC matmul),
+    // accumulated during the graph walk. Fused BatchNorm, ReLU epilogues, residual
+    // adds, and pooling are not GEMMs and contribute no MACs.
+    std::uint64_t total_macs = 0;
+
     // Utilization (0.0 - 1.0) = busy / total_cycles, over the whole run.
     [[nodiscard]] double dma_utilization() const {
         return total_cycles ? static_cast<double>(dma_busy) / static_cast<double>(total_cycles) : 0.0;
@@ -94,6 +101,41 @@ struct RunStats {
         if (clock_ghz <= 0.0 || total_cycles == 0) return 0.0;
         const double seconds = static_cast<double>(total_cycles) / (clock_ghz * 1e9);
         return static_cast<double>(bytes_stored) / (seconds * 1e9);
+    }
+
+    // ---- Compute FLOP efficiency (roofline) ---------------------------------
+    // Conventions match the matmul benchmark harness (sw::benchmark::HardwareSpec):
+    // 2 FLOPs per MAC, achieved GFLOP/s = FLOP/cycle * clock, peak/bandwidth
+    // supplied by the caller (no PE-array peak lives in the timing config).
+
+    /// Total floating-point operations (2 per MAC).
+    [[nodiscard]] double total_flops() const { return 2.0 * static_cast<double>(total_macs); }
+
+    /// Achieved compute throughput (GFLOP/s) at the given clock.
+    [[nodiscard]] double achieved_gflops(double clock_ghz) const {
+        return total_cycles ? total_flops() / static_cast<double>(total_cycles) * clock_ghz : 0.0;
+    }
+
+    /// Arithmetic intensity: FLOPs per byte of external (DRAM) traffic.
+    [[nodiscard]] double arithmetic_intensity() const {
+        const std::size_t bytes = bytes_loaded + bytes_stored;
+        return bytes ? total_flops() / static_cast<double>(bytes) : 0.0;
+    }
+
+    /// Fraction of the compute fabric's peak (clock-independent): achieved
+    /// FLOP/cycle divided by peak FLOP/cycle (e.g. 16*16*2 = 512 for a 16x16 PE).
+    [[nodiscard]] double compute_efficiency(double peak_flops_per_cycle) const {
+        return (total_cycles && peak_flops_per_cycle > 0.0)
+            ? total_flops() / (static_cast<double>(total_cycles) * peak_flops_per_cycle)
+            : 0.0;
+    }
+
+    /// Fraction of the roofline ceiling min(AI * bandwidth, peak) at the given
+    /// clock - i.e. how close to the attainable (memory- or compute-bound) limit.
+    [[nodiscard]] double roofline_efficiency(double peak_gflops, double ext_bw_gbs,
+                                             double clock_ghz) const {
+        const double roof = std::min(arithmetic_intensity() * ext_bw_gbs, peak_gflops);
+        return roof > 0.0 ? achieved_gflops(clock_ghz) / roof : 0.0;
     }
 };
 

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -128,6 +128,10 @@ public:
                     const auto& cc = k.conv2d_config();
                     if (!nd) throw std::runtime_error("GraphCspExecutor: missing NodeData for conv node");
                     Conv2DGeometry geom = conv_geom(cc);
+                    // MACs = gemm_M * gemm_N * gemm_K; gemm_K = (Cin/groups)*Kh*Kw
+                    // so this is correct for grouped/depthwise convs too.
+                    result.stats.total_macs += static_cast<std::uint64_t>(cc.gemm_M())
+                                             * cc.gemm_N() * cc.gemm_K();
                     // input: this conv's graph predecessor output, else external input.
                     const std::vector<float>& x = input_of(g, id, out, input);
 
@@ -242,6 +246,8 @@ public:
                 }
                 case KernelOpType::MATMUL: {
                     if (!nd) throw std::runtime_error("GraphCspExecutor: missing NodeData for matmul node");
+                    result.stats.total_macs += static_cast<std::uint64_t>(nd->fc_M)
+                                             * nd->fc_N * nd->fc_K;
                     out[id] = run_matmul(input_of(g, id, out, input), nd->fc_weight,
                                          nd->fc_M, nd->fc_N, nd->fc_K, nd->fc_bias,
                                          nd->fc_relu, T, result.stats);

--- a/tests/timing/test_resnet_utilization.cpp
+++ b/tests/timing/test_resnet_utilization.cpp
@@ -24,12 +24,16 @@
 // ============================================================================
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <sw/kpu/kernel_graph.hpp>
 #include <sw/kpu/timing/graph/resnet18.hpp>
 
 #include <cmath>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
 
 using namespace sw::kpu::timing::graph;
 using sw::kpu::timing::Cycle;
@@ -82,7 +86,43 @@ TEST_CASE("ResNet RunStats utilization is directly measured and consistent",
         REQUIRE(st.tiles_loaded > 0);
         REQUIRE(st.tiles_moved > 0);
         REQUIRE(st.bytes_loaded > 0);
+
+        // Compute FLOP efficiency (roofline). GEMM MACs are counted, FLOPs = 2*MACs,
+        // and the efficiencies are bounded fractions.
+        REQUIRE(st.total_macs > 0);
+        REQUIRE(st.total_flops() == Catch::Approx(2.0 * static_cast<double>(st.total_macs)));
+        REQUIRE(st.arithmetic_intensity() > 0.0);
+        REQUIRE(st.achieved_gflops(1.0) > 0.0);
+        const double peak_eff = st.compute_efficiency(/*peak_flops_per_cycle*/ 512.0);
+        REQUIRE(peak_eff > 0.0);
+        REQUIRE(peak_eff <= 1.0);                     // cannot exceed the array peak
+        const double roof_eff = st.roofline_efficiency(512.0, 64.0, 1.0);
+        REQUIRE(roof_eff > 0.0);
+        REQUIRE(std::isfinite(roof_eff));
+        REQUIRE(roof_eff <= 1.0 + 1e-9);              // cannot beat the roofline
     }
+}
+
+TEST_CASE("GraphCspExecutor counts GEMM MACs from the FC matmul",
+          "[timing][resnet][flops]") {
+    // A single matmul node: MACs must equal M*N*K exactly (the FC hook), and the
+    // fused/pool/elementwise ops that carry no GEMM contribute nothing.
+    const sw::kpu::Size M = 32, N = 16, K = 48;   // tile-aligned (T = 16)
+    sw::kpu::KernelGraph g;
+    const auto mm = g.add_kernel(sw::kpu::Kernel::create_matmul(M, N, K), "mm");
+
+    std::unordered_map<std::size_t, NodeData> nd;
+    nd[mm].fc_M = M; nd[mm].fc_N = N; nd[mm].fc_K = K;
+    nd[mm].fc_weight.assign(static_cast<std::size_t>(K) * N, 0.1f);
+    nd[mm].fc_bias.assign(N, 0.0f);
+    const std::vector<float> input(static_cast<std::size_t>(M) * K, 0.5f);
+
+    GraphCspExecutor exec;
+    const auto result = exec.run(g, input, nd, /*T*/ 16);
+
+    const std::uint64_t expected = static_cast<std::uint64_t>(M) * N * K;   // 24576
+    REQUIRE(result.stats.total_macs == expected);
+    REQUIRE(result.stats.total_flops() == Catch::Approx(2.0 * static_cast<double>(expected)));
 }
 
 TEST_CASE("RunStats effective bandwidth guards the clock argument",


### PR DESCRIPTION
## Summary

Item **2** of the benchmarking roadmap: add the **compute side** of the ResNet-on-CSP benchmark — GEMM FLOPs, arithmetic intensity, and roofline position — so the DRAM-bound movement finding can be confirmed from the compute side.

During the graph walk `GraphCspExecutor` accumulates `RunStats::total_macs` from the GEMM ops only: `conv.gemm_M·gemm_N·gemm_K` (which handles `groups`/depthwise via `gemm_K = (Cin/groups)·Kh·Kw`) plus `fc_M·fc_N·fc_K`. Fused BN/ReLU, residual adds, and pooling carry no GEMM and contribute nothing.

`RunStats` exposes: `total_flops()` (2/MAC), `achieved_gflops(clock)`, `arithmetic_intensity()` (FLOPs/DRAM byte), `compute_efficiency(peak_flops_per_cycle)`, `roofline_efficiency(peak_gflops, ext_bw, clock)`. Conventions match the matmul `kpu-benchmark` harness (`sw::benchmark::HardwareSpec`): **16×16 PE → 512 GFLOP/s @ 1 GHz, 64 GB/s DRAM, ridge 8 FLOP/byte**.

## Demo output

```
  compute                    MFLOP   GFLOP/s  peakEff%   AI(F/B)  roofEff%   bound
  resnet18 (base)             4.48     112.4      21.9      5.25      33.4     mem
  resnet18 [2,2,2,2]          7.73     150.1      29.3      5.11      45.9     mem
  resnet18 (batch 32)         8.96     124.2      24.3      5.54      35.1     mem
```

## Finding — memory-bound, corroborating the movement fabric

- **Arithmetic intensity ≈ 5.2 FLOP/byte < the 8 ridge → memory-bound** (`bound=mem`). Same conclusion the utilization work reached (DMA 78–92%), now from the compute side.
- **peakEff 22–29%** — only ~a quarter of the 16×16 array's peak, because compute is starved behind DRAM.
- **roofEff 33–46%** — headroom even against the memory ceiling (movement stalls + sequential-node walk).
- **Deeper `[2,2,2,2]` best** on both (more arithmetic per load).
- AI cross-checks against the measured bandwidth (5.25 = 4.48 MFLOP / 853 KB DRAM).

## Tests

`test_resnet_utilization.cpp` adds:
- A precise single-matmul MAC anchor: a one-node matmul graph must report `total_macs == M·N·K` (32·16·48 = 24576).
- ResNet FLOP asserts: `total_flops == 2·macs`, `AI > 0`, `achieved_gflops > 0`, and `compute_efficiency`/`roofline_efficiency` in `(0, 1]` (cannot exceed peak or beat the roofline).

## Test results

- All **58 timing tests pass**.
- `clang++ -Werror -Wall -Wextra -Wshorten-64-to-32 -fsyntax-only` OK on the demo and the test (which include both changed headers).

## Test plan

- [ ] Fast CI passes
- [ ] Resolve CodeRabbit review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)