### PR TITLE
feat(bench): buffer-occupancy timeline for the ResNet benchmark (item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Buffer-occupancy timeline for the ResNet benchmark (`m2_resnet --occupancy`).**
+  `run_conv2d_fused` gains an optional per-cycle `CycleObserver` (empty by default,
+  so the normal path is untouched); the demo drives a representative 1×1 projection
+  conv one cycle at a time and renders the `TileTracker` **L3 | L2 | L1/array**
+  occupancy bands plus **peak simultaneous occupancy per level** vs capacity. The
+  peaks sit far below capacity (L3 4/32, L2 2/64), so buffers are not the binding
+  resource at this scale — corroborating the DMA-bandwidth-bound finding from the
+  utilization and compute-efficiency views. `test_resnet_utilization.cpp` adds a
+  case asserting the observer fires and does not perturb the result.
+
 - **Compute FLOP efficiency / roofline for the ResNet benchmark.** During the graph
   walk `GraphCspExecutor` accumulates `RunStats::total_macs` from the GEMM ops
   (`conv.gemm_M·gemm_N·gemm_K`, which handles `groups`/depthwise, plus

--- a/docs/benchmarking/resnet-benchmarking-guide.md
+++ b/docs/benchmarking/resnet-benchmarking-guide.md
@@ -15,7 +15,8 @@ transfer occupied it) — not the earlier `cycles − stalls/N` heuristic — so
 cycles are excluded and the numbers are a true activity fraction. It also reports
 **compute FLOP efficiency** (GEMM MACs vs a 16×16 PE-array peak, arithmetic
 intensity, and roofline position — §6), which independently confirms the workload
-is memory-bound. The demo prints a "utilization" table and a "compute" table.
+is memory-bound. The demo prints a "utilization" table and a "compute" table, and
+`--occupancy` renders a `TileTracker` L3|L2|L1/array buffer-occupancy timeline.
 
 ---
 
@@ -157,6 +158,9 @@ cmake --build --preset release --target m2_resnet
 # Emit the KernelGraph for inspection
 ./build/examples/milestones/m2_resnet --dot resnet18.dot
 dot -Tpng resnet18.dot -o resnet18.png     # optional, needs graphviz
+
+# Buffer-occupancy timeline (L3|L2|L1/array bands + peak occupancy per level)
+./build/examples/milestones/m2_resnet --occupancy
 
 # CI smoke test
 ctest -R m2_resnet
@@ -326,6 +330,27 @@ Follow-ons: a full-resolution ResNet (higher AI, likely still memory-bound at th
 buffer sizing) and a per-layer AI breakdown to find which convs are compute- vs
 memory-bound.
 
+### Occupancy timeline — which buffer level saturates
+
+`m2_resnet --occupancy` runs a representative layer (a 1×1 projection conv) one
+executor cycle at a time and renders, via `TileTracker`, the horizontal
+**L3 | L2 | L1/array** occupancy bands — one row per occupancy *transition* (idle
+cycles are elided), `*` marking a tile in the compute array. You watch A/B tiles
+arrive at L3, move to L2, feed L1/array, the computes produce C tiles, and those
+drain back out to DRAM — all in credit-managed **buffers** (arrive / resident /
+credit-returned, never hit/miss/evict). It closes with a **peak simultaneous
+occupancy** line per level against that level's capacity:
+
+```text
+  peak simultaneous occupancy:  L3 4/32   L2 2/64   L1 6   array 6
+```
+
+The headline: **no buffer level saturates** — peak L3/L2 occupancy sits far below
+the credit counts. So buffers are *not* the binding resource at this scale; the
+constraint is DMA throughput, exactly the §5 diagnosis from the other two angles. A
+peak *at* capacity would flag that level as the binding buffer (the first place to
+add credits) — a check to re-run once the network is scaled up (task 4).
+
 ---
 
 ## 7. Research roadmap
@@ -340,11 +365,13 @@ Ordered by dependency:
 2. ~~**Compute FLOP efficiency / roofline position**~~ — **done** (§6): the demo
    prints MFLOP, GFLOP/s, peak efficiency, arithmetic intensity, and roofline
    position; the network is memory-bound (AI ≈ 5.2 < 8), corroborating §5.
-3. **Occupancy timeline** — wire `TileTracker` into the demo (behind a flag) to see
-   which buffer level saturates during the forward pass. **Now the top open task.**
+3. ~~**Occupancy timeline**~~ — **done** (§6): `m2_resnet --occupancy` renders the
+   `TileTracker` L3|L2|L1/array bands for a representative conv plus peak occupancy
+   per level. Peaks sit far below capacity (L3 4/32, L2 2/64) — buffers are **not**
+   the bottleneck, corroborating the DMA-bandwidth-bound finding.
 4. **Full-scale ResNet-18** — larger spatial dims + `[2,2,2,2]` + channel growth as
-   a benchmark spec (slow; run offline, not in CI). Needed before any number is
-   quoted as representative.
+   a benchmark spec (slow; run offline, not in CI). **Now the top open task** —
+   needed before any number is quoted as representative.
 5. **Concurrent branch scheduling** — the sequential-node assumption caps
    achievable utilization; overlapping execution-level-independent branches is the
    architectural lever the utilization study will eventually motivate.

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -118,5 +118,6 @@ reaching only ~22–29% of compute peak.
 cmake --build --preset release --target m2_resnet
 ./build/examples/milestones/m2_resnet            # benchmark table + validation
 ./build/examples/milestones/m2_resnet --dot resnet18.dot   # + KernelGraph
+./build/examples/milestones/m2_resnet --occupancy          # buffer-occupancy timeline
 ctest -R m2_resnet                               # CI smoke test
 ```

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -23,13 +23,15 @@
  * reflect within-op pipeline activity, not cross-branch overlap - a relative
  * metric for comparing configs. See docs/benchmarking/resnet-benchmarking-guide.md.
  *
- * Usage: m2_resnet [--dot FILE]
+ * Usage: m2_resnet [--dot FILE] [--occupancy]
  * Writeup: docs/milestones/M2_resnet.md
  */
 
 #include <sw/kpu/kernel_graph.hpp>
 #include <sw/kpu/timing/graph/resnet18.hpp>
+#include <sw/kpu/timing/tile_tracker.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -39,6 +41,7 @@
 #include <vector>
 
 using namespace sw::kpu::timing::graph;
+using namespace sw::kpu::timing;   // ConcurrentTimingExecutor, TileTracker, MemoryLevel
 
 namespace {
 
@@ -134,18 +137,78 @@ void print_compute_row(const Row& r) {
               << "\n" << std::defaultfloat;
 }
 
+// Occupancy timeline: run one representative ResNet conv (the stem im2col GEMM)
+// cycle-by-cycle and render the L3 | L2 | L1/array tile bands via TileTracker,
+// plus the peak simultaneous occupancy per level - i.e. which level saturates.
+int run_occupancy() {
+    // A small but representative ResNet layer: a 1x1 projection conv (batch 2,
+    // 32->16 channels, 4x4), im2col GEMM M=32 x N=16 x K=32, tiled 16^3 - few
+    // enough tiles to read the L3->L2->L1->array flow, while still exercising the
+    // full credit-managed hierarchy.
+    Conv2DGeometry geom;
+    geom.N = 2; geom.C_in = 32; geom.H_in = 4; geom.W_in = 4;
+    geom.C_out = 16; geom.Kh = 1; geom.Kw = 1;
+    geom.stride_h = geom.stride_w = 1; geom.pad_h = geom.pad_w = 0;
+    const Size T = 16;
+
+    // Values are irrelevant to occupancy; fill with constants.
+    std::vector<float> input(geom.input_elems(), 0.1f);
+    std::vector<float> filter(
+        static_cast<std::size_t>(geom.C_out) * geom.C_in * geom.Kh * geom.Kw, 0.01f);
+
+    TileTracker tracker;
+    std::size_t pk_l3 = 0, pk_l2 = 0, pk_l1 = 0, pk_arr = 0;
+    auto observe = [&](const ConcurrentTimingExecutor& e) {
+        tracker.observe(e);
+        pk_l3  = std::max(pk_l3,  e.tiles_at(MemoryLevel::L3).size());
+        pk_l2  = std::max(pk_l2,  e.tiles_at(MemoryLevel::L2).size());
+        pk_l1  = std::max(pk_l1,  e.tiles_at(MemoryLevel::L1).size());
+        pk_arr = std::max(pk_arr, e.tiles_at(MemoryLevel::COMPUTE).size());
+    };
+
+    RunStats stats;
+    (void)run_conv2d_fused(input, filter, geom, /*bn*/ nullptr, /*bias*/ {},
+                           /*relu*/ false, T, stats, observe);
+
+    const ConcurrentTimingExecutor::Config cap;   // capacities the runner used (defaults)
+    std::cout <<
+        "\n======================================================================\n"
+        "Occupancy timeline - 1x1 projection conv im2col GEMM (M=" << geom.M()
+        << " x N=" << geom.Ncols() << " x K=" << geom.K() << ", tile " << T << ")\n"
+        "L3 | L2 | L1/array tile bands, one row per occupancy transition ('*' = in\n"
+        "array). Credit-managed BUFFERS: tiles arrive, stay resident, return credit\n"
+        "- never hit/miss/evict.\n"
+        "======================================================================\n\n";
+    std::cout << tracker.log() << "\n";
+    std::cout << "  peak simultaneous occupancy:  L3 " << pk_l3 << "/" << cap.l3_buffer_count
+              << "   L2 " << pk_l2 << "/" << cap.l2_bank_count
+              << "   L1 " << pk_l1 << "   array " << pk_arr << "\n"
+              << "  (L3/L2 peaks are shown against their buffer/bank credit counts; a\n"
+              << "   peak at capacity means that level is the pipeline's binding buffer.)\n"
+              << "  total cycles " << stats.total_cycles << ", DMA util "
+              << std::fixed << std::setprecision(1) << 100.0 * stats.dma_utilization()
+              << "%\n" << std::defaultfloat;
+    return 0;
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {
     std::string dot_path;
+    bool occupancy = false;
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--dot") == 0 && i + 1 < argc) {
             dot_path = argv[++i];
+        } else if (std::strcmp(argv[i], "--occupancy") == 0) {
+            occupancy = true;
         } else {
-            std::cout << "Usage: " << argv[0] << " [--dot FILE]\n";
+            std::cout << "Usage: " << argv[0] << " [--dot FILE] [--occupancy]\n";
             return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
         }
     }
+
+    // Occupancy timeline is a focused debug view of the buffer hierarchy.
+    if (occupancy) return run_occupancy();
 
     std::cout << "\n"
         "======================================================================\n"

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -202,13 +202,20 @@ int main(int argc, char* argv[]) {
         } else if (std::strcmp(argv[i], "--occupancy") == 0) {
             occupancy = true;
         } else {
-            std::cout << "Usage: " << argv[0] << " [--dot FILE] [--occupancy]\n";
+            std::cout << "Usage: " << argv[0] << " [--dot FILE | --occupancy]\n";
             return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
         }
     }
 
-    // Occupancy timeline is a focused debug view of the buffer hierarchy.
-    if (occupancy) return run_occupancy();
+    // Occupancy timeline is a focused debug view of the buffer hierarchy; it does
+    // not build the whole-network graph, so --dot has nothing to emit alongside it.
+    if (occupancy) {
+        if (!dot_path.empty()) {
+            std::cerr << "error: --occupancy and --dot are mutually exclusive\n";
+            return 2;
+        }
+        return run_occupancy();
+    }
 
     std::cout << "\n"
         "======================================================================\n"

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -41,6 +42,11 @@ namespace sw::kpu::timing::graph {
 
 using schedule::Conv2DGeometry;
 using schedule::BatchNormAffine;
+
+/// Optional per-cycle observer, invoked with the live executor after each step()
+/// (and once before the first). Used to drive a TileTracker occupancy timeline;
+/// empty by default so the normal execution path pays nothing.
+using CycleObserver = std::function<void(const ConcurrentTimingExecutor&)>;
 
 /// Accumulated CSP-execution stats across the ops of a graph run.
 ///
@@ -199,7 +205,8 @@ inline void accumulate(RunStats& s, const ConcurrentTimingExecutor& exec) {
 [[nodiscard]] inline std::vector<float>
 run_conv2d_fused(const std::vector<float>& input, const std::vector<float>& filter,
                  const Conv2DGeometry& geom, const BatchNormAffine* bn,
-                 const std::vector<float>& bias, bool relu, Size T, RunStats& stats) {
+                 const std::vector<float>& bias, bool relu, Size T, RunStats& stats,
+                 const CycleObserver& on_cycle = {}) {
     using schedule::MatMulScheduleGenerator;
     using MatrixID = sw::kpu::isa::MatrixID;
 
@@ -277,8 +284,11 @@ run_conv2d_fused(const std::vector<float>& input, const std::vector<float>& filt
             }
         }
     }
-    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles)
+    if (on_cycle) on_cycle(exec);
+    while (!exec.is_complete() && exec.current_cycle() < exec.config().max_cycles) {
         exec.step();
+        if (on_cycle) on_cycle(exec);
+    }
     if (!exec.is_complete())
         throw std::runtime_error("run_conv2d_fused: schedule did not complete");
     detail::accumulate(stats, exec);

--- a/tests/timing/test_resnet_utilization.cpp
+++ b/tests/timing/test_resnet_utilization.cpp
@@ -103,6 +103,35 @@ TEST_CASE("ResNet RunStats utilization is directly measured and consistent",
     }
 }
 
+TEST_CASE("run_conv2d_fused cycle observer fires without perturbing results",
+          "[timing][resnet][occupancy]") {
+    // The observer backs the demo's --occupancy TileTracker timeline. It must be
+    // invoked each cycle and must not change execution (same output, same cycles).
+    sw::kpu::timing::schedule::Conv2DGeometry geom;
+    geom.N = 2; geom.C_in = 32; geom.H_in = 4; geom.W_in = 4;
+    geom.C_out = 16; geom.Kh = 1; geom.Kw = 1;
+    const std::vector<float> input(geom.input_elems(), 0.1f);
+    const std::vector<float> filter(
+        static_cast<std::size_t>(geom.C_out) * geom.C_in * geom.Kh * geom.Kw, 0.01f);
+
+    RunStats s_ref;
+    const auto y_ref = run_conv2d_fused(input, filter, geom, nullptr, {}, false, 16, s_ref);
+
+    std::size_t ticks = 0, peak_l3 = 0;
+    RunStats s_obs;
+    const auto y_obs = run_conv2d_fused(
+        input, filter, geom, nullptr, {}, false, 16, s_obs,
+        [&](const sw::kpu::timing::ConcurrentTimingExecutor& e) {
+            ++ticks;
+            peak_l3 = std::max(peak_l3, e.tiles_at(sw::kpu::timing::MemoryLevel::L3).size());
+        });
+
+    REQUIRE(ticks > 0);                      // observer actually ran
+    REQUIRE(peak_l3 > 0);                     // tiles were staged in L3
+    REQUIRE(y_obs == y_ref);                  // observation must not perturb results
+    REQUIRE(s_obs.total_cycles == s_ref.total_cycles);
+}
+
 TEST_CASE("GraphCspExecutor counts GEMM MACs from the FC matmul",
           "[timing][resnet][flops]") {
     // A single matmul node: MACs must equal M*N*K exactly (the FC hook), and the


### PR DESCRIPTION
## Summary

Item **3** of the benchmarking roadmap: `m2_resnet --occupancy` renders a `TileTracker` view of the credit-managed buffer hierarchy during a representative layer, answering "which buffer level saturates."

`run_conv2d_fused` gains an optional per-cycle `CycleObserver` (empty by default → `GraphCspExecutor` and the normal path are untouched). The demo drives a representative **1×1 projection conv** (batch 2, 32→16ch, 4×4 → im2col GEMM M=32 × N=16 × K=32) one executor cycle at a time and renders the horizontal **L3 | L2 | L1/array** occupancy bands (one row per occupancy transition, `*` = in the compute array), then a peak-occupancy line per level.

## Output

```text
cyc    | L3 buffers            | L2 banks      | L1 / array
36     | A[0,0,0]              | -             | -
...    (A tiles L3→L2→L1/array, computes produce C, C drains back to DRAM)
310    | -                     | -             | -

  peak simultaneous occupancy:  L3 4/32   L2 2/64   L1 6   array 6
```

## Finding — buffers are not the bottleneck

**Peak L3 4/32, L2 2/64** — occupancy sits far below the credit counts, so no buffer level saturates. Buffers are *not* the binding resource at this scale; the constraint is DMA throughput — the same conclusion as the utilization (DMA 78–92%) and compute-efficiency (memory-bound, AI ≈ 5.2) views. A peak *at* capacity would flag that level as the binding buffer; a check to re-run once the network is scaled up (roadmap item 4).

The timeline reads as **buffers** throughout (tile arrives / resident / credit-returned — never hit/miss/evict).

## Tests

`test_resnet_utilization.cpp` adds a case that runs `run_conv2d_fused` with and without an observer and asserts the observer fires (`ticks > 0`, `peak_l3 > 0`) **and does not perturb execution** (identical output, identical `total_cycles`).

## Test results

- All **58 timing tests pass**.
- `clang++ -Werror -Wall -Wextra -Wshorten-64-to-32 -fsyntax-only` OK on the demo and the test.

## Test plan

- [ ] Fast CI passes
- [ ] Resolve CodeRabbit review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--occupancy` mode to the ResNet benchmark.
  * Displays buffer-occupancy timelines and peak usage across L3, L2, L1, and compute resources.
  * Added optional per-cycle execution observation for benchmark instrumentation.

* **Documentation**
  * Updated benchmarking and milestone guides with occupancy instructions, examples, and interpretation guidance.

* **Tests**
  * Added coverage confirming occupancy observation does not affect benchmark results or timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->