### PR TITLE
feat(bench): representative-scale offline ResNet run --full (item 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Representative-scale offline ResNet run (`m2_resnet --full`).** Runs one
+  channel-growing config — batch 16, stem 16ch 8×8, stages `{16,32,64,128}×2` (true
+  `[2,2,2,2]` depth with stride-2 downsampling + 1×1 projections) — through the same
+  benchmark / utilization / compute tables in ~50 s (offline; not in the CI smoke
+  test, which keeps the default scaled sweep). It confirms the findings survive
+  realistic proportions: arithmetic intensity rises 5.2 → 7.6 FLOP/byte (toward the
+  8 ridge) and compute efficiency 22–29% → 37%, but the network stays memory-bound
+  and DMA-saturated (84.5%) — the diagnosis holds at scale. `--full`/`--occupancy`
+  are rejected in combination with `--dot`. Table-printing refactored into a shared
+  `print_all_tables` helper (no output change on the default path).
+
 - **Buffer-occupancy timeline for the ResNet benchmark (`m2_resnet --occupancy`).**
   `run_conv2d_fused` gains an optional per-cycle `CycleObserver` (empty by default,
   so the normal path is untouched); the demo drives a representative 1×1 projection

--- a/docs/benchmarking/resnet-benchmarking-guide.md
+++ b/docs/benchmarking/resnet-benchmarking-guide.md
@@ -15,8 +15,10 @@ transfer occupied it) — not the earlier `cycles − stalls/N` heuristic — so
 cycles are excluded and the numbers are a true activity fraction. It also reports
 **compute FLOP efficiency** (GEMM MACs vs a 16×16 PE-array peak, arithmetic
 intensity, and roofline position — §6), which independently confirms the workload
-is memory-bound. The demo prints a "utilization" table and a "compute" table, and
-`--occupancy` renders a `TileTracker` L3|L2|L1/array buffer-occupancy timeline.
+is memory-bound. The demo prints a "utilization" table and a "compute" table,
+`--occupancy` renders a `TileTracker` L3|L2|L1/array buffer-occupancy timeline, and
+`--full` runs a channel-growing `[2,2,2,2]` config offline to confirm the findings
+survive realistic scale (§6).
 
 ---
 
@@ -162,7 +164,10 @@ dot -Tpng resnet18.dot -o resnet18.png     # optional, needs graphviz
 # Buffer-occupancy timeline (L3|L2|L1/array bands + peak occupancy per level)
 ./build/examples/milestones/m2_resnet --occupancy
 
-# CI smoke test
+# Representative-scale offline run: channel growth + [2,2,2,2] depth (~50 s)
+./build/examples/milestones/m2_resnet --full
+
+# CI smoke test (default scaled sweep only; --full/--occupancy are not in CI)
 ctest -R m2_resnet
 ```
 
@@ -351,6 +356,34 @@ constraint is DMA throughput, exactly the §5 diagnosis from the other two angle
 peak *at* capacity would flag that level as the binding buffer (the first place to
 add credits) — a check to re-run once the network is scaled up (task 4).
 
+### Representative-scale offline run (`--occupancy`'s bigger sibling, `--full`)
+
+The §5 tables use a deliberately tiny topology (4×4, uniform 16 channels) so the
+demo is CI-fast. Before quoting any number as representative you must check the
+findings survive **channel growth and real depth**. `m2_resnet --full` runs one
+offline config — batch 16, stem 16ch 8×8, stages **{16, 32, 64, 128} ×2** (the true
+`[2,2,2,2]` depth with stride-2 downsampling + 1×1 projections) — in ≈ 50 s:
+
+```text
+  configuration       nodes  ops   cycles    cyc/op   dmaStl    bmStl   strStl    maxErr  check
+  resnet18 (full)        67   38   393927    10366   161274  1019258   244014   1.1e-06  PASS
+  utilization          dmaU%  bmU%  strU%  ...  ldGB/s  stGB/s
+  resnet18 (full)       84.5  15.7  16.1   ...   21.8    2.8
+  compute              MFLOP  GFLOP/s  peakEff%  AI(F/B)  roofEff%  bound
+  resnet18 (full)      73.99   187.8    36.7     7.62     38.5     mem
+```
+
+What scaling up changes — and what it doesn't:
+- **Arithmetic intensity rises 5.2 → 7.6 FLOP/byte**, right up against the 8 ridge:
+  more channels means more FLOPs reused per DRAM byte. **Compute efficiency climbs
+  too, 22–29% → 37%.**
+- **But it is still `mem`-bound and still DMA-saturated (84.5%)** — the memory-bound
+  diagnosis *holds* at realistic proportions; scale moves it toward the ridge, not
+  across it. That is the answer task 4 exists to give.
+- Not full 224×224 (intractable cycle-by-cycle: a stage-4 3×3 conv on 512 channels
+  is K = 4608, hundreds of K-slices per output tile). `--full` trades absolute size
+  for the *structure* that matters — growth + depth + downsampling.
+
 ---
 
 ## 7. Research roadmap
@@ -369,12 +402,16 @@ Ordered by dependency:
    `TileTracker` L3|L2|L1/array bands for a representative conv plus peak occupancy
    per level. Peaks sit far below capacity (L3 4/32, L2 2/64) — buffers are **not**
    the bottleneck, corroborating the DMA-bandwidth-bound finding.
-4. **Full-scale ResNet-18** — larger spatial dims + `[2,2,2,2]` + channel growth as
-   a benchmark spec (slow; run offline, not in CI). **Now the top open task** —
-   needed before any number is quoted as representative.
+4. ~~**Representative-scale ResNet-18**~~ — **done** (§6): `m2_resnet --full` runs a
+   `{16,32,64,128}×2` channel-growing `[2,2,2,2]` config offline (~50 s, not in CI).
+   Finding: AI rises 5.2 → 7.6 (toward the ridge) and peak efficiency 22–29% → 37%,
+   but it stays memory-bound and DMA-saturated — the diagnosis holds at scale.
+   Remaining: a true full-resolution run (needs a native grouped/large-K schedule to
+   be tractable) and a per-layer AI breakdown.
 5. **Concurrent branch scheduling** — the sequential-node assumption caps
    achievable utilization; overlapping execution-level-independent branches is the
-   architectural lever the utilization study will eventually motivate.
+   architectural lever the utilization study will eventually motivate. **Now the top
+   open task.**
 6. **JSON output + regression baseline** — emit the same schema as
    `tests/benchmarks/baselines/baseline.json` and add ResNet to the
    `benchmark-regression` workflow so utilization is tracked over time.

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -119,5 +119,6 @@ cmake --build --preset release --target m2_resnet
 ./build/examples/milestones/m2_resnet            # benchmark table + validation
 ./build/examples/milestones/m2_resnet --dot resnet18.dot   # + KernelGraph
 ./build/examples/milestones/m2_resnet --occupancy          # buffer-occupancy timeline
+./build/examples/milestones/m2_resnet --full               # representative-scale offline run (~50s)
 ctest -R m2_resnet                               # CI smoke test
 ```

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -191,30 +191,109 @@ int run_occupancy() {
     return 0;
 }
 
+// The three benchmark tables (timing+stalls, movement utilization, compute FLOP
+// efficiency) for a set of already-run configurations.
+void print_all_tables(const std::vector<Row>& rows) {
+    std::cout << "  " << std::left << std::setw(22) << "configuration" << std::right
+              << std::setw(7) << "nodes" << std::setw(6) << "ops"
+              << std::setw(11) << "cycles" << std::setw(10) << "cyc/op"
+              << std::setw(9) << "dmaStl" << std::setw(9) << "bmStl"
+              << std::setw(9) << "strStl" << std::setw(11) << "maxErr"
+              << std::setw(7) << "check" << "\n";
+    std::cout << "  " << std::string(97, '-') << "\n";
+    for (const auto& r : rows) print_row(r);
+
+    std::cout << "\n  " << std::left << std::setw(22) << "utilization" << std::right
+              << std::setw(8) << "dmaU%" << std::setw(8) << "bmU%" << std::setw(8) << "strU%"
+              << std::setw(9) << "tilesLd" << std::setw(9) << "tilesMv" << std::setw(9) << "tilesFd"
+              << std::setw(10) << "ldGB/s" << std::setw(10) << "stGB/s" << "\n";
+    std::cout << "  " << std::string(93, '-') << "\n";
+    for (const auto& r : rows) print_util_row(r);
+    std::cout << "\n  Utilization = Sum(active)/Sum(total) per mover: directly"
+                 " measured cycles a\n  transfer occupied each component (excludes"
+                 " stalled + idle), summed over the\n  sequentially executed ops;"
+                 " GB/s at "
+              << std::fixed << std::setprecision(1) << kAssumedClockGHz
+              << " GHz assumed clock. See\n"
+                 "  docs/benchmarking/resnet-benchmarking-guide.md.\n"
+              << std::defaultfloat;
+
+    std::cout << "\n  " << std::left << std::setw(22) << "compute" << std::right
+              << std::setw(10) << "MFLOP" << std::setw(10) << "GFLOP/s"
+              << std::setw(10) << "peakEff%" << std::setw(10) << "AI(F/B)"
+              << std::setw(10) << "roofEff%" << std::setw(8) << "bound" << "\n";
+    std::cout << "  " << std::string(80, '-') << "\n";
+    for (const auto& r : rows) print_compute_row(r);
+    std::cout << "\n  GEMM FLOPs (conv im2col + FC, 2/MAC) vs a "
+              << std::fixed << std::setprecision(0) << kPeakGflops
+              << " GFLOP/s peak (16x16 PE @ "
+              << std::setprecision(1) << kAssumedClockGHz << " GHz) and "
+              << std::setprecision(0) << kExtBwGbs << " GB/s DRAM. peakEff = achieved/peak;\n"
+                 "  roofEff = achieved/min(AI*bw, peak); bound = mem below the "
+              << std::setprecision(0) << kRidgeAI << " FLOP/byte ridge, else cmp.\n"
+              << std::defaultfloat;
+}
+
+// Full-scale offline run: realistic channel growth (64->512) + [2,2,2,2] depth +
+// larger spatial. Slow (cycle-by-cycle over many more tiles) - not in the CI
+// smoke test, which runs the default no-arg scaled sweep.
+int run_full() {
+    // Representative-scale (not full 224x224, which is intractable cycle-by-cycle):
+    // realistic channel GROWTH (16->128) across four stages with stride-2
+    // downsampling + 1x1 projections, at the true [2,2,2,2] depth. The scaled
+    // spatial (8x8) keeps a whole forward pass to a few million cycles.
+    ResNet18Spec full;
+    full.batch = 16;
+    full.in_channels = 16;
+    full.height = full.width = 8;
+    full.stage_channels = {16, 32, 64, 128};
+    full.blocks_per_stage = 2;
+    full.num_classes = 16;
+
+    std::cout << "\n"
+        "======================================================================\n"
+        "Representative-scale ResNet-18 (offline) - batch " << full.batch << ", stem "
+        << full.in_channels << "ch " << full.height << "x" << full.width
+        << ", stages {16,32,64,128} x2\n"
+        "([2,2,2,2] with stride-2 downsampling + 1x1 projections), "
+        << full.num_classes << " classes. Channel growth + real depth; slow.\n"
+        "======================================================================\n\n";
+
+    std::vector<Row> rows{ run_spec("resnet18 (full)", full, {}) };
+    print_all_tables(rows);
+    std::cout << "\n  Validation: " << (rows.front().pass ? "PASS" : "FAIL")
+              << " (oracle: composed whole-network host reference, tol 5e-3)\n\n";
+    return rows.front().pass ? 0 : 1;
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {
     std::string dot_path;
-    bool occupancy = false;
+    bool occupancy = false, full = false;
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--dot") == 0 && i + 1 < argc) {
             dot_path = argv[++i];
         } else if (std::strcmp(argv[i], "--occupancy") == 0) {
             occupancy = true;
+        } else if (std::strcmp(argv[i], "--full") == 0) {
+            full = true;
         } else {
-            std::cout << "Usage: " << argv[0] << " [--dot FILE | --occupancy]\n";
+            std::cout << "Usage: " << argv[0] << " [--dot FILE | --occupancy | --full]\n";
             return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
         }
     }
 
-    // Occupancy timeline is a focused debug view of the buffer hierarchy; it does
-    // not build the whole-network graph, so --dot has nothing to emit alongside it.
-    if (occupancy) {
+    // --occupancy and --full are focused modes that do not build the whole-network
+    // graph the way the default sweep does, so --dot has nothing to emit alongside
+    // them; reject the combination rather than silently ignore --dot.
+    if (occupancy || full) {
         if (!dot_path.empty()) {
-            std::cerr << "error: --occupancy and --dot are mutually exclusive\n";
+            std::cerr << "error: --" << (occupancy ? "occupancy" : "full")
+                      << " and --dot are mutually exclusive\n";
             return 2;
         }
-        return run_occupancy();
+        return occupancy ? run_occupancy() : run_full();
     }
 
     std::cout << "\n"
@@ -237,48 +316,10 @@ int main(int argc, char* argv[]) {
     ResNet18Spec batch32 = base; batch32.batch = 32;
     rows.push_back(run_spec("resnet18 (batch 32)", batch32, {}));
 
-    std::cout << "  " << std::left << std::setw(22) << "configuration" << std::right
-              << std::setw(7) << "nodes" << std::setw(6) << "ops"
-              << std::setw(11) << "cycles" << std::setw(10) << "cyc/op"
-              << std::setw(9) << "dmaStl" << std::setw(9) << "bmStl"
-              << std::setw(9) << "strStl" << std::setw(11) << "maxErr"
-              << std::setw(7) << "check" << "\n";
-    std::cout << "  " << std::string(97, '-') << "\n";
+    print_all_tables(rows);
 
     bool all_pass = true;
-    for (const auto& r : rows) { print_row(r); all_pass = all_pass && r.pass; }
-
-    // Movement-fabric utilization (busy/total per mover, tiles, effective BW).
-    std::cout << "\n  " << std::left << std::setw(22) << "utilization" << std::right
-              << std::setw(8) << "dmaU%" << std::setw(8) << "bmU%" << std::setw(8) << "strU%"
-              << std::setw(9) << "tilesLd" << std::setw(9) << "tilesMv" << std::setw(9) << "tilesFd"
-              << std::setw(10) << "ldGB/s" << std::setw(10) << "stGB/s" << "\n";
-    std::cout << "  " << std::string(93, '-') << "\n";
-    for (const auto& r : rows) print_util_row(r);
-    std::cout << "\n  Utilization = Sum(active)/Sum(total) per mover: directly"
-                 " measured cycles a\n  transfer occupied each component (excludes"
-                 " stalled + idle), summed over the\n  sequentially executed ops;"
-                 " GB/s at "
-              << std::fixed << std::setprecision(1) << kAssumedClockGHz
-              << " GHz assumed clock. See\n"
-                 "  docs/benchmarking/resnet-benchmarking-guide.md.\n"
-              << std::defaultfloat;
-
-    // Compute FLOP efficiency (roofline position).
-    std::cout << "\n  " << std::left << std::setw(22) << "compute" << std::right
-              << std::setw(10) << "MFLOP" << std::setw(10) << "GFLOP/s"
-              << std::setw(10) << "peakEff%" << std::setw(10) << "AI(F/B)"
-              << std::setw(10) << "roofEff%" << std::setw(8) << "bound" << "\n";
-    std::cout << "  " << std::string(80, '-') << "\n";
-    for (const auto& r : rows) print_compute_row(r);
-    std::cout << "\n  GEMM FLOPs (conv im2col + FC, 2/MAC) vs a "
-              << std::fixed << std::setprecision(0) << kPeakGflops
-              << " GFLOP/s peak (16x16 PE @ "
-              << std::setprecision(1) << kAssumedClockGHz << " GHz) and "
-              << std::setprecision(0) << kExtBwGbs << " GB/s DRAM. peakEff = achieved/peak;\n"
-                 "  roofEff = achieved/min(AI*bw, peak); bound = mem below the "
-              << std::setprecision(0) << kRidgeAI << " FLOP/byte ridge, else cmp.\n"
-              << std::defaultfloat;
+    for (const auto& r : rows) all_pass = all_pass && r.pass;
 
     std::cout << "\n  Fusion: BatchNorm folded into conv, ReLU fused as the conv"
                  " epilogue -\n  the base network's " << rows.front().nodes


### PR DESCRIPTION
## Summary

Item **4** of the benchmarking roadmap: `m2_resnet --full` runs one **channel-growing, real-depth** config offline, to check the memory-bound finding survives realistic proportions before any number is quoted as representative.

Config: batch 16, stem 16ch 8×8, stages **{16, 32, 64, 128} ×2** — the true `[2,2,2,2]` depth with stride-2 downsampling + 1×1 projections. Runs through the same benchmark / utilization / compute tables in **~50 s** (offline; not in the CI smoke test, which keeps the default scaled sweep). `--full`/`--occupancy` are rejected in combination with `--dot`.

## Result — the diagnosis holds at scale

```text
  configuration       nodes  ops   cycles    cyc/op   dmaStl    bmStl   strStl    maxErr  check
  resnet18 (full)        67   38   393927    10366   161274  1019258   244014   1.1e-06  PASS
  utilization          dmaU%  bmU%  strU%          ldGB/s  stGB/s
  resnet18 (full)       84.5  15.7  16.1            21.8    2.8
  compute              MFLOP  GFLOP/s  peakEff%  AI(F/B)  roofEff%  bound
  resnet18 (full)      73.99   187.8    36.7     7.62     38.5     mem
```

- **Arithmetic intensity rises 5.2 → 7.6 FLOP/byte** (toward the 8 ridge) and **compute efficiency 22–29% → 37%** as channels grow.
- **But it stays `mem`-bound and DMA-saturated (84.5%)** — scale moves it toward the ridge, not across it. That is the answer item 4 exists to give.
- Full 224×224 stays intractable cycle-by-cycle (a stage-4 3×3 conv on 512 channels is K = 4608, hundreds of K-slices per output tile); `--full` trades absolute size for the *structure* that matters (growth + depth + downsampling). A true full-resolution run needs a native large-K/grouped schedule (noted as remaining follow-on).

## Changes

- `examples/milestones/m2_resnet.cpp` — `--full` mode + `run_full`; table-printing extracted into a shared `print_all_tables` helper (**default-path output unchanged**).
- `docs/benchmarking/resnet-benchmarking-guide.md`, `docs/milestones/M2_resnet.md` — results + usage; roadmap item 4 marked done (item 5 now top open).
- `CHANGELOG.md`.

## Test results

- `clang++ -Werror -Wall -Wextra -Wshorten-64-to-32 -fsyntax-only` OK.
- `ctest -R m2_resnet` (default path) passes; the refactor leaves the default output identical.
- `--full` validated **PASS** (max_err 1.1e-6) in ~50 s.

## Test plan

- [ ] Fast CI passes
- [ ] Resolve CodeRabbit review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)