### PR TITLE
feat(bench): concurrency-headroom (branch-overlap) analysis (item 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Concurrency-headroom (branch-overlap) analysis in the ResNet benchmark.**
+  `GraphCspExecutor` now records each executed node's cycle cost during the walk and
+  computes the DAG **critical path** — `finish[n] = cost[n] + max over predecessors
+  of finish[p]`, so execution-level-independent branches (a residual's 1×1 projection
+  skip vs. its main path) overlap (a `max`, not a sum) with unbounded resources —
+  exposed as `RunStats::critical_path_cycles` and `overlap_speedup()`. The demo
+  prints a "concurrency" table (seqCyc / critCyc / ovlp×). Finding: **≤ 2%** — ResNet
+  is essentially a chain, so the sequential-node execution model costs almost nothing
+  and true concurrent multi-op execution is not worth building for this workload; the
+  DMA-bandwidth lever remains the only one that matters. It is an idealized
+  resource-free upper bound. `test_resnet_utilization.cpp` validates it: a single-node
+  graph is a chain (`critCyc == seqCyc`, speedup 1.0); the ResNet graph has branches
+  (`critCyc < seqCyc`).
+
 - **Representative-scale offline ResNet run (`m2_resnet --full`).** Runs one
   channel-growing config — batch 16, stem 16ch 8×8, stages `{16,32,64,128}×2` (true
   `[2,2,2,2]` depth with stride-2 downsampling + 1×1 projections) — through the same

--- a/docs/benchmarking/resnet-benchmarking-guide.md
+++ b/docs/benchmarking/resnet-benchmarking-guide.md
@@ -18,7 +18,9 @@ intensity, and roofline position — §6), which independently confirms the work
 is memory-bound. The demo prints a "utilization" table and a "compute" table,
 `--occupancy` renders a `TileTracker` L3|L2|L1/array buffer-occupancy timeline, and
 `--full` runs a channel-growing `[2,2,2,2]` config offline to confirm the findings
-survive realistic scale (§6).
+survive realistic scale (§6). A "concurrency" table reports the idealized
+branch-overlap critical path — for ResNet the headroom is ≤ 2%, so the
+sequential-node execution model costs almost nothing (§6).
 
 ---
 
@@ -384,6 +386,34 @@ What scaling up changes — and what it doesn't:
   is K = 4608, hundreds of K-slices per output tile). `--full` trades absolute size
   for the *structure* that matters — growth + depth + downsampling.
 
+### Concurrency headroom — how much would branch overlap buy?
+
+Nodes execute strictly sequentially today (§3), so a fair question is how much the
+sequential-node assumption itself costs. The demo now answers it with an idealized
+**critical-path** model: give each executed node its measured cycle cost, then
+compute `finish[n] = cost[n] + max over predecessors of finish[p]` — so
+execution-level-independent branches (a residual's 1×1 projection skip vs. its main
+`conv→conv` path) *overlap* (a `max`, not a sum), with **unbounded resources**. The
+critical path is the resource-free **upper bound** on what concurrent branch
+scheduling could achieve:
+
+```text
+  concurrency          seqCyc   critCyc   ovlp x
+  resnet18 (base)       39881    39119     1.02
+  resnet18 [2,2,2,2]    51469    50707     1.02
+  resnet18 (batch 32)   72169    71333     1.01
+```
+
+The headline: **≤ 2%.** ResNet's DAG is essentially a chain — its only parallelism
+is the short 1×1 projection skips in the three downsampling blocks, and those convs
+are so cheap they hide almost entirely behind the main path even when *serial*. So
+the sequential-node assumption is **not** leaving meaningful performance on the
+table for this workload, and true concurrent multi-op execution (a large executor
+rewrite) is not worth building for ResNet — the DMA-bandwidth lever from §5 remains
+the only one that matters. (The model is validated in
+`test_resnet_utilization.cpp`: a single-node graph is a chain, `critCyc == seqCyc`;
+the ResNet graph has branches, `critCyc < seqCyc`.)
+
 ---
 
 ## 7. Research roadmap
@@ -408,13 +438,16 @@ Ordered by dependency:
    but it stays memory-bound and DMA-saturated — the diagnosis holds at scale.
    Remaining: a true full-resolution run (needs a native grouped/large-K schedule to
    be tractable) and a per-layer AI breakdown.
-5. **Concurrent branch scheduling** — the sequential-node assumption caps
-   achievable utilization; overlapping execution-level-independent branches is the
-   architectural lever the utilization study will eventually motivate. **Now the top
-   open task.**
+5. ~~**Concurrent branch scheduling (headroom analysis)**~~ — **done** (§6): the
+   demo prints the idealized branch-overlap critical path (`seqCyc`/`critCyc`/`ovlp`).
+   Finding: **≤ 2%** — ResNet's DAG is essentially a chain, so the sequential-node
+   assumption costs almost nothing and true concurrent multi-op execution (a large
+   executor rewrite) is **not worth building** for this workload. The DMA-bandwidth
+   lever remains the only one that matters.
 6. **JSON output + regression baseline** — emit the same schema as
    `tests/benchmarks/baselines/baseline.json` and add ResNet to the
-   `benchmark-regression` workflow so utilization is tracked over time.
+   `benchmark-regression` workflow so utilization is tracked over time. **Now the top
+   open task.**
 
 ---
 

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -72,6 +72,11 @@ compute                    MFLOP   GFLOP/s  peakEff%   AI(F/B)  roofEff%   bound
 resnet18 (base)             4.48     112.4      21.9      5.25      33.4     mem
 resnet18 [2,2,2,2]          7.73     150.1      29.3      5.11      45.9     mem
 resnet18 (batch 32)         8.96     124.2      24.3      5.54      35.1     mem
+
+concurrency          seqCyc   critCyc   ovlp x
+resnet18 (base)       39881    39119     1.02
+resnet18 [2,2,2,2]    51469    50707     1.02
+resnet18 (batch 32)   72169    71333     1.01
 ```
 
 **Fusion payoff:** the `[2,2,2,2]` network's 67 graph nodes execute as **38 CSP
@@ -89,6 +94,11 @@ all parallel components (so they can exceed `cycles`); see
 arithmetic intensity ≈ 5.2 FLOP/byte is below the 8 FLOP/byte ridge of a 16×16 PE
 array (512 GFLOP/s @ 1 GHz) with 64 GB/s DRAM, so every config is **memory-bound**,
 reaching only ~22–29% of compute peak.
+
+**Concurrency headroom** (`critCyc` = idealized branch-overlap critical path) is
+**≤ 2%**: ResNet's DAG is essentially a chain (only the short 1×1 projection skips
+overlap), so the sequential-node execution model costs almost nothing and true
+concurrent multi-op execution is not worth building here.
 
 ## Scope & scaling notes
 

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -232,6 +232,24 @@ void print_all_tables(const std::vector<Row>& rows) {
                  "  roofEff = achieved/min(AI*bw, peak); bound = mem below the "
               << std::setprecision(0) << kRidgeAI << " FLOP/byte ridge, else cmp.\n"
               << std::defaultfloat;
+
+    // Concurrency headroom: sequential cycles vs the idealized branch-overlap
+    // critical path (upper bound on what concurrent branch scheduling could buy).
+    std::cout << "\n  " << std::left << std::setw(22) << "concurrency" << std::right
+              << std::setw(11) << "seqCyc" << std::setw(11) << "critCyc"
+              << std::setw(9) << "ovlp x" << "\n";
+    std::cout << "  " << std::string(51, '-') << "\n";
+    for (const auto& r : rows)
+        std::cout << "  " << std::left << std::setw(22) << r.name << std::right
+                  << std::setw(11) << r.stats.total_cycles
+                  << std::setw(11) << r.stats.critical_path_cycles
+                  << std::setw(9) << std::fixed << std::setprecision(2) << r.stats.overlap_speedup()
+                  << "\n" << std::defaultfloat;
+    std::cout << "\n  Nodes execute sequentially today; critCyc is the DAG critical"
+                 " path if\n  execution-level-independent branches (e.g. a residual's"
+                 " 1x1 projection\n  skip vs. its main path) overlapped with unbounded"
+                 " resources. ovlp = seqCyc/\n  critCyc is the resource-free UPPER"
+                 " bound on that speedup.\n";
 }
 
 // Full-scale offline run: realistic channel growth (64->512) + [2,2,2,2] depth +

--- a/include/sw/kpu/timing/graph/csp_op_runners.hpp
+++ b/include/sw/kpu/timing/graph/csp_op_runners.hpp
@@ -67,6 +67,12 @@ struct RunStats {
     Cycle str_stalls = 0;
     std::size_t ops = 0;
 
+    // Idealized concurrent-branch-overlap latency: the DAG critical path assuming
+    // execution-level-independent ops run concurrently with unbounded resources.
+    // <= total_cycles; equal when the graph is a chain. An upper bound on what
+    // concurrent branch scheduling could buy (ignores DMA/mover contention).
+    Cycle critical_path_cycles = 0;
+
     // Movement-fabric activity (summed per-op). busy is fractional: each op's
     // per-component mean active cycles is exact (not integer-floored), so the
     // whole-network sum carries that precision.
@@ -113,6 +119,15 @@ struct RunStats {
     // Conventions match the matmul benchmark harness (sw::benchmark::HardwareSpec):
     // 2 FLOPs per MAC, achieved GFLOP/s = FLOP/cycle * clock, peak/bandwidth
     // supplied by the caller (no PE-array peak lives in the timing config).
+
+    /// Best-case speedup from overlapping execution-level-independent branches
+    /// (resource-unconstrained upper bound): sequential cycles / critical path.
+    /// 1.0 for a chain graph; > 1 when independent branches could overlap.
+    [[nodiscard]] double overlap_speedup() const {
+        return critical_path_cycles
+            ? static_cast<double>(total_cycles) / static_cast<double>(critical_path_cycles)
+            : 1.0;
+    }
 
     /// Total floating-point operations (2 per MAC).
     [[nodiscard]] double total_flops() const { return 2.0 * static_cast<double>(total_macs); }

--- a/include/sw/kpu/timing/graph/graph_csp_executor.hpp
+++ b/include/sw/kpu/timing/graph/graph_csp_executor.hpp
@@ -118,10 +118,12 @@ public:
 
         // --- topological execution --------------------------------------------
         std::size_t last = 0;
+        std::unordered_map<std::size_t, Cycle> node_cost;   // executed cycles per node
         for (auto id : g.get_execution_order()) {
-            if (consumed.count(id)) continue;
+            if (consumed.count(id)) continue;   // fused/folded: no execution, cost 0
             const auto& k = g.get_kernel(id);
             const NodeData* nd = data_or_null(node_data, id);
+            const Cycle cost_before = result.stats.total_cycles;
 
             switch (k.op_type()) {
                 case KernelOpType::CONV2D: {
@@ -257,7 +259,33 @@ public:
                 default:
                     throw std::runtime_error("GraphCspExecutor: unsupported kernel op type");
             }
+            node_cost[id] = result.stats.total_cycles - cost_before;
         }
+
+        // Idealized concurrent-branch-overlap latency: the DAG critical path with
+        // independent branches overlapping (finish[n] = cost[n] + max over
+        // predecessors of finish[p]). Consumed (fused/folded) nodes have cost 0,
+        // so they pass their producer's finish through to consumers unchanged. The
+        // ADD nodes' two incoming branches take a max (overlap), not a sum - that
+        // is exactly the residual skip vs. main-path overlap. Resource-unbounded,
+        // so an upper bound on what concurrent scheduling could buy.
+        {
+            std::unordered_map<std::size_t, Cycle> finish;
+            Cycle crit = 0;
+            for (auto id : g.get_execution_order()) {
+                Cycle pred_max = 0;
+                for (auto eidx : g.incoming_edges(id)) {
+                    auto it = finish.find(g.get_edge(eidx).from_node);
+                    if (it != finish.end()) pred_max = std::max(pred_max, it->second);
+                }
+                auto cit = node_cost.find(id);
+                const Cycle f = pred_max + (cit != node_cost.end() ? cit->second : 0);
+                finish[id] = f;
+                crit = std::max(crit, f);
+            }
+            result.stats.critical_path_cycles = crit;
+        }
+
         result.output = out.at(last);
         return result;
     }

--- a/tests/timing/test_resnet_utilization.cpp
+++ b/tests/timing/test_resnet_utilization.cpp
@@ -100,6 +100,15 @@ TEST_CASE("ResNet RunStats utilization is directly measured and consistent",
         REQUIRE(roof_eff > 0.0);
         REQUIRE(std::isfinite(roof_eff));
         REQUIRE(roof_eff <= 1.0 + 1e-9);              // cannot beat the roofline
+
+        // Concurrency headroom (idealized branch overlap). The critical path never
+        // exceeds the sequential total, and is strictly less for ResNet because the
+        // residual projection skips create some branch parallelism.
+        REQUIRE(st.critical_path_cycles > 0);
+        REQUIRE(st.critical_path_cycles <= st.total_cycles);
+        REQUIRE(st.critical_path_cycles < st.total_cycles);   // branches overlap
+        REQUIRE(st.overlap_speedup() > 1.0);
+        REQUIRE(st.overlap_speedup() <= static_cast<double>(st.total_cycles));
     }
 }
 
@@ -152,6 +161,11 @@ TEST_CASE("GraphCspExecutor counts GEMM MACs from the FC matmul",
     const std::uint64_t expected = static_cast<std::uint64_t>(M) * N * K;   // 24576
     REQUIRE(result.stats.total_macs == expected);
     REQUIRE(result.stats.total_flops() == Catch::Approx(2.0 * static_cast<double>(expected)));
+
+    // A single node is a chain: no independent branches, so the critical path
+    // equals the sequential total and the overlap speedup is exactly 1.0.
+    REQUIRE(result.stats.critical_path_cycles == result.stats.total_cycles);
+    REQUIRE(result.stats.overlap_speedup() == Catch::Approx(1.0));
 }
 
 TEST_CASE("RunStats effective bandwidth guards the clock argument",


### PR DESCRIPTION
## Summary

Item **5** of the roadmap, scoped (per your choice) as the **critical-path overlap analysis** rather than a full concurrent-execution rewrite: quantify how much overlapping execution-level-independent branches *could* buy, as a resource-free upper bound.

`GraphCspExecutor` records each executed node's cycle cost during the topological walk, then computes the DAG critical path:

```
finish[n] = cost[n] + max over predecessors of finish[p]
critCyc   = max_n finish[n]        seqCyc = Σ cost[n]        ovlp = seqCyc / critCyc
```

Independent branches (a residual's 1×1 projection skip vs. its main `conv→conv` path) **overlap** — a `max`, not a sum — with unbounded resources. Consumed (fused/folded) nodes have cost 0 and pass their producer's finish through, so the conv+BN / conv+ReLU fusion structure is handled correctly. Surfaced as `RunStats::critical_path_cycles` + `overlap_speedup()`; the demo prints a "concurrency" table.

## Finding — ≤ 2%, so the sequential-node model is fine

```text
  concurrency          seqCyc   critCyc   ovlp x
  resnet18 (base)       39881    39119     1.02
  resnet18 [2,2,2,2]    51469    50707     1.02
  resnet18 (batch 32)   72169    71333     1.01
```

ResNet's DAG is essentially a chain — its only parallelism is the short 1×1 projection skips in the three downsampling blocks, and those convs hide almost entirely behind the main path even when *serial*. So:

- The **sequential-node execution assumption costs almost nothing** for ResNet.
- **True concurrent multi-op execution (a large executor rewrite) is not worth building** for this workload.
- The **DMA-bandwidth lever** (items 1–4) remains the only one that matters.

This closes the loop on the whole study: every angle — utilization, compute efficiency, occupancy, scaling, and now concurrency — points to DRAM bandwidth, and rules the others out.

## Tests

`test_resnet_utilization.cpp`:
- Single-node graph = chain: `critCyc == seqCyc`, `overlap_speedup() == 1.0`.
- ResNet graph has branches: `0 < critCyc < seqCyc`, `speedup > 1`.

## Test results

- All **58 timing tests pass** (the executor change is pure cycle-accounting; values unchanged, all m2/m3 graph tests green).
- `clang++ -Werror -Wall -Wextra -Wshorten-64-to-32 -fsyntax-only` OK on the demo and the test.

## Test plan

- [ ] Fast CI passes
- [ ] Resolve CodeRabbit review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)