### PR TITLE
feat(bench): ResNet JSON export + CI regression tracking (item 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ResNet benchmark JSON export + CI regression tracking.** `m2_resnet --json`
+  emits the deterministic sweep as structured JSON (config, timing, stalls,
+  throughput, utilization, compute). A committed baseline
+  (`tests/benchmarks/resnet_baseline.json`) plus
+  `scripts/resnet_regression_check.py` (generate/check) are wired as the
+  `resnet_regression` ctest, so every ResNet metric is diffed against the baseline on
+  every multi-platform CI run — integer metrics exact (deterministic schedule logic),
+  floats within `1e-6`. `max_err` is excluded (fp reduction order differs across
+  compilers; correctness is enforced by the `m2_resnet` PASS check). A ctest rather
+  than a graft into the matmul-specific `benchmark-regression` workflow, for
+  all-platform coverage on every change. Sweep construction refactored into a shared
+  `build_sweep` helper.
+
 - **Concurrency-headroom (branch-overlap) analysis in the ResNet benchmark.**
   `GraphCspExecutor` now records each executed node's cycle cost during the walk and
   computes the DAG **critical path** — `finish[n] = cost[n] + max over predecessors

--- a/docs/benchmarking/resnet-benchmarking-guide.md
+++ b/docs/benchmarking/resnet-benchmarking-guide.md
@@ -20,7 +20,9 @@ is memory-bound. The demo prints a "utilization" table and a "compute" table,
 `--full` runs a channel-growing `[2,2,2,2]` config offline to confirm the findings
 survive realistic scale (§6). A "concurrency" table reports the idealized
 branch-overlap critical path — for ResNet the headroom is ≤ 2%, so the
-sequential-node execution model costs almost nothing (§6).
+sequential-node execution model costs almost nothing (§6). `--json` exports the
+sweep, and a committed baseline + the `resnet_regression` ctest track every metric
+against drift in CI (§6).
 
 ---
 
@@ -169,8 +171,16 @@ dot -Tpng resnet18.dot -o resnet18.png     # optional, needs graphviz
 # Representative-scale offline run: channel growth + [2,2,2,2] depth (~50 s)
 ./build/examples/milestones/m2_resnet --full
 
-# CI smoke test (default scaled sweep only; --full/--occupancy are not in CI)
-ctest -R m2_resnet
+# Machine-readable sweep (for the regression baseline + external tooling)
+./build/examples/milestones/m2_resnet --json
+
+# CI smoke test + regression check (default sweep; --full/--occupancy are not in CI)
+ctest -R "m2_resnet|resnet_regression"
+
+# Regenerate the committed baseline after an intentional timing change
+python3 scripts/resnet_regression_check.py generate \
+  --binary ./build/examples/milestones/m2_resnet \
+  --baseline tests/benchmarks/resnet_baseline.json
 ```
 
 To sweep configurations beyond the three built-in rows, add rows to the sweep
@@ -414,6 +424,28 @@ the only one that matters. (The model is validated in
 `test_resnet_utilization.cpp`: a single-node graph is a chain, `critCyc == seqCyc`;
 the ResNet graph has branches, `critCyc < seqCyc`.)
 
+### JSON export + CI regression tracking
+
+`m2_resnet --json` emits the sweep as machine-readable JSON — per config: `config`,
+`timing` (cycles, critical path, ops, nodes), `stalls`, `throughput` (tiles/bytes),
+`utilization`, `compute` (macs, GFLOP/s, efficiencies, AI), `validation`. The sweep
+is **deterministic** (fixed-seed synthetic weights), so integer metrics reproduce
+exactly run-to-run and across platforms (integer schedule logic); the derived floats
+are IEEE-deterministic to well within `1e-6`.
+
+That determinism makes a tight regression check possible.
+`tests/benchmarks/resnet_baseline.json` is the committed snapshot;
+`scripts/resnet_regression_check.py check --binary <m2_resnet> --baseline <file>`
+diffs a fresh run against it — **integer metrics exact, floats within `1e-6`** — and
+exits non-zero on any drift. It is wired as the **`resnet_regression` ctest**, so it
+runs in the standard multi-platform CI on every PR (a ctest rather than a graft into
+the matmul-specific `benchmark-regression` workflow: it gets all-platform coverage
+on every change and avoids that workflow's artifact-baseline machinery). `max_err`
+is excluded from the diff — it is the one non-deterministic field (fp reduction
+order / FMA differ across compilers); correctness is enforced separately by the
+`m2_resnet` PASS check. If a change intentionally moves the numbers, regenerate:
+`resnet_regression_check.py generate ...`.
+
 ---
 
 ## 7. Research roadmap
@@ -444,10 +476,18 @@ Ordered by dependency:
    assumption costs almost nothing and true concurrent multi-op execution (a large
    executor rewrite) is **not worth building** for this workload. The DMA-bandwidth
    lever remains the only one that matters.
-6. **JSON output + regression baseline** — emit the same schema as
-   `tests/benchmarks/baselines/baseline.json` and add ResNet to the
-   `benchmark-regression` workflow so utilization is tracked over time. **Now the top
-   open task.**
+6. ~~**JSON output + regression baseline**~~ — **done** (§6): `m2_resnet --json`
+   emits the sweep as structured JSON; a committed baseline
+   (`tests/benchmarks/resnet_baseline.json`) + `scripts/resnet_regression_check.py`
+   are wired as the `resnet_regression` ctest, so every metric is diffed against the
+   baseline on every CI run (all platforms). Deterministic integer metrics must match
+   exactly; floats within `1e-6`.
+
+**All roadmap items (1–6) are complete.** Open follow-ons carried in the items above:
+a true full-resolution run (needs a native large-K/grouped schedule), a per-layer AI
+breakdown, and — only if a non-ResNet workload ever motivates it — real concurrent
+multi-op execution. For ResNet the study's conclusion is settled and triangulated
+from five angles: **the workload is DRAM-bandwidth-bound; nothing else binds.**
 
 ---
 
@@ -464,4 +504,7 @@ Ordered by dependency:
 | Milestone writeup | `docs/milestones/M2_resnet.md` |
 | Design plan | `docs/plans/m2_resnet_dfg.md` |
 | Validation tests | `tests/timing/test_m2_resnet*.cpp` |
+| Metric + concurrency tests | `tests/timing/test_resnet_utilization.cpp` |
+| Regression baseline | `tests/benchmarks/resnet_baseline.json` |
+| Regression check script | `scripts/resnet_regression_check.py` |
 | Matmul benchmark harness (utilization reference) | `tools/benchmark/kpu-benchmark/` |

--- a/docs/milestones/M2_resnet.md
+++ b/docs/milestones/M2_resnet.md
@@ -130,5 +130,6 @@ cmake --build --preset release --target m2_resnet
 ./build/examples/milestones/m2_resnet --dot resnet18.dot   # + KernelGraph
 ./build/examples/milestones/m2_resnet --occupancy          # buffer-occupancy timeline
 ./build/examples/milestones/m2_resnet --full               # representative-scale offline run (~50s)
-ctest -R m2_resnet                               # CI smoke test
+./build/examples/milestones/m2_resnet --json               # machine-readable sweep
+ctest -R "m2_resnet|resnet_regression"           # CI smoke test + regression check
 ```

--- a/examples/milestones/CMakeLists.txt
+++ b/examples/milestones/CMakeLists.txt
@@ -29,6 +29,22 @@ if(KPU_BUILD_TESTS)
     set_tests_properties(m2_resnet PROPERTIES
         LABELS "timing;resnet;milestone;v0.9"
     )
+
+    # ResNet benchmark regression: diff `m2_resnet --json` against the committed
+    # deterministic baseline (integer metrics exact, floats within tolerance).
+    # Tracks cycles / utilization / compute metrics over time in CI. Skipped if no
+    # Python 3 interpreter is available.
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(Python3_Interpreter_FOUND)
+        add_test(NAME resnet_regression COMMAND
+            ${Python3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/scripts/resnet_regression_check.py check
+            --binary $<TARGET_FILE:m2_resnet>
+            --baseline ${CMAKE_SOURCE_DIR}/tests/benchmarks/resnet_baseline.json)
+        set_tests_properties(resnet_regression PROPERTIES
+            LABELS "timing;resnet;benchmark;regression"
+        )
+    endif()
 endif()
 
 # M3: MobileNetV2 demo + benchmark (issue #131)

--- a/examples/milestones/m2_resnet.cpp
+++ b/examples/milestones/m2_resnet.cpp
@@ -52,6 +52,7 @@ struct Row {
     bool dot_ok = true;   // false if a requested --dot write failed
     float max_err = 0.0f;
     RunStats stats;
+    ResNet18Spec spec;    // the config that produced this row (for --json)
 };
 
 Row run_spec(const std::string& name, const ResNet18Spec& spec,
@@ -73,6 +74,7 @@ Row run_spec(const std::string& name, const ResNet18Spec& spec,
     r.nodes = net.num_nodes;
     r.ops = result.stats.ops;
     r.stats = result.stats;
+    r.spec = spec;
     r.dot_ok = dot_ok;
     r.pass = result.output.size() == net.oracle.size();
     for (std::size_t i = 0; i < result.output.size() && i < net.oracle.size(); ++i)
@@ -284,11 +286,78 @@ int run_full() {
     return rows.front().pass ? 0 : 1;
 }
 
+// The default scaled sweep: base, [2,2,2,2] depth, wider batch. dot_path (if set)
+// emits the base config's KernelGraph.
+std::vector<Row> build_sweep(const std::string& dot_path) {
+    std::vector<Row> rows;
+    ResNet18Spec base;
+    rows.push_back(run_spec("resnet18 (base)", base, dot_path));
+    ResNet18Spec deeper = base; deeper.blocks_per_stage = 2;   // [2,2,2,2]
+    rows.push_back(run_spec("resnet18 [2,2,2,2]", deeper, {}));
+    ResNet18Spec batch32 = base; batch32.batch = 32;
+    rows.push_back(run_spec("resnet18 (batch 32)", batch32, {}));
+    return rows;
+}
+
+// Machine-readable sweep results (for the regression baseline + external tooling).
+// The metrics are deterministic (fixed-seed synthetic weights), so integer fields
+// reproduce exactly run-to-run; floats to enough precision for a tolerance check.
+void emit_json(const std::vector<Row>& rows) {
+    std::cout << std::setprecision(9) << std::boolalpha;
+    std::cout << "{\n"
+                 "  \"name\": \"resnet18\",\n"
+                 "  \"description\": \"ResNet-18 on the CSP timing executor (deterministic scaled sweep)\",\n"
+                 "  \"clock_ghz\": " << kAssumedClockGHz << ",\n"
+                 "  \"peak_gflops\": " << kPeakGflops << ",\n"
+                 "  \"ext_bw_gbs\": " << kExtBwGbs << ",\n"
+                 "  \"results\": [\n";
+    for (std::size_t i = 0; i < rows.size(); ++i) {
+        const Row& r = rows[i];
+        const RunStats& s = r.stats;
+        const ResNet18Spec& sp = r.spec;
+        std::cout << "    {\n"
+                     "      \"name\": \"" << r.name << "\",\n"
+                     "      \"config\": {\"batch\": " << sp.batch
+                  << ", \"in_channels\": " << sp.in_channels
+                  << ", \"height\": " << sp.height << ", \"width\": " << sp.width
+                  << ", \"stage_channels\": [";
+        for (std::size_t c = 0; c < sp.stage_channels.size(); ++c)
+            std::cout << (c ? "," : "") << sp.stage_channels[c];
+        std::cout << "], \"blocks_per_stage\": " << sp.blocks_per_stage
+                  << ", \"num_classes\": " << sp.num_classes
+                  << ", \"tile\": " << sp.tile << "},\n"
+                     "      \"timing\": {\"cycles\": " << s.total_cycles
+                  << ", \"critical_path_cycles\": " << s.critical_path_cycles
+                  << ", \"ops\": " << s.ops << ", \"nodes\": " << r.nodes << "},\n"
+                     "      \"stalls\": {\"dma\": " << s.dma_stalls
+                  << ", \"block_mover\": " << s.bm_stalls
+                  << ", \"streamer\": " << s.str_stalls << "},\n"
+                     "      \"throughput\": {\"tiles_loaded\": " << s.tiles_loaded
+                  << ", \"tiles_moved\": " << s.tiles_moved
+                  << ", \"tiles_fed\": " << s.tiles_fed
+                  << ", \"bytes_loaded\": " << s.bytes_loaded
+                  << ", \"bytes_stored\": " << s.bytes_stored << "},\n"
+                     "      \"utilization\": {\"dma\": " << s.dma_utilization()
+                  << ", \"block_mover\": " << s.bm_utilization()
+                  << ", \"streamer\": " << s.str_utilization() << "},\n"
+                     "      \"compute\": {\"macs\": " << s.total_macs
+                  << ", \"gflops\": " << s.achieved_gflops(kAssumedClockGHz)
+                  << ", \"peak_efficiency\": " << s.compute_efficiency(kPeakFlopsPerCycle)
+                  << ", \"arithmetic_intensity\": " << s.arithmetic_intensity()
+                  << ", \"roofline_efficiency\": "
+                  << s.roofline_efficiency(kPeakGflops, kExtBwGbs, kAssumedClockGHz) << "},\n"
+                     "      \"validation\": {\"max_err\": " << r.max_err
+                  << ", \"pass\": " << r.pass << "}\n"
+                     "    }" << (i + 1 < rows.size() ? "," : "") << "\n";
+    }
+    std::cout << "  ]\n}\n" << std::defaultfloat << std::noboolalpha;
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {
     std::string dot_path;
-    bool occupancy = false, full = false;
+    bool occupancy = false, full = false, json = false;
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--dot") == 0 && i + 1 < argc) {
             dot_path = argv[++i];
@@ -296,22 +365,30 @@ int main(int argc, char* argv[]) {
             occupancy = true;
         } else if (std::strcmp(argv[i], "--full") == 0) {
             full = true;
+        } else if (std::strcmp(argv[i], "--json") == 0) {
+            json = true;
         } else {
-            std::cout << "Usage: " << argv[0] << " [--dot FILE | --occupancy | --full]\n";
+            std::cout << "Usage: " << argv[0]
+                      << " [--dot FILE | --occupancy | --full | --json]\n";
             return std::strcmp(argv[i], "--help") == 0 ? 0 : 1;
         }
     }
 
-    // --occupancy and --full are focused modes that do not build the whole-network
-    // graph the way the default sweep does, so --dot has nothing to emit alongside
-    // them; reject the combination rather than silently ignore --dot.
-    if (occupancy || full) {
+    // --json emits ONLY the machine-readable sweep (for the regression baseline);
+    // it and the other focused modes do not pair with --dot.
+    if (occupancy || full || json) {
         if (!dot_path.empty()) {
-            std::cerr << "error: --" << (occupancy ? "occupancy" : "full")
+            std::cerr << "error: --" << (occupancy ? "occupancy" : full ? "full" : "json")
                       << " and --dot are mutually exclusive\n";
             return 2;
         }
-        return occupancy ? run_occupancy() : run_full();
+        if (occupancy) return run_occupancy();
+        if (full) return run_full();
+        const auto rows = build_sweep({});
+        emit_json(rows);
+        bool pass = true;
+        for (const auto& r : rows) pass = pass && r.pass;
+        return pass ? 0 : 1;
     }
 
     std::cout << "\n"
@@ -322,18 +399,7 @@ int main(int argc, char* argv[]) {
         "FC); outputs are validated elementwise against a host oracle.\n"
         "======================================================================\n\n";
 
-    std::vector<Row> rows;
-
-    // Default scaled demo, plus two sweeps: wider batch, and deeper channels.
-    ResNet18Spec base;                                   // batch 16, 16ch 8x8
-    rows.push_back(run_spec("resnet18 (base)", base, dot_path));
-
-    ResNet18Spec deeper = base; deeper.blocks_per_stage = 2;   // [2,2,2,2]
-    rows.push_back(run_spec("resnet18 [2,2,2,2]", deeper, {}));
-
-    ResNet18Spec batch32 = base; batch32.batch = 32;
-    rows.push_back(run_spec("resnet18 (batch 32)", batch32, {}));
-
+    const std::vector<Row> rows = build_sweep(dot_path);
     print_all_tables(rows);
 
     bool all_pass = true;

--- a/scripts/resnet_regression_check.py
+++ b/scripts/resnet_regression_check.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""ResNet-on-CSP benchmark regression check.
+
+The m2_resnet demo emits a deterministic sweep (fixed-seed synthetic weights) as
+JSON via `m2_resnet --json`. This script compares a fresh run against a committed
+baseline so that any code change altering ResNet's timing / utilization / compute
+metrics is caught in CI.
+
+Because the sweep is deterministic, integer metrics (cycles, ops, tiles, bytes,
+MACs, stalls) must match EXACTLY; floating metrics (utilization, GFLOP/s,
+arithmetic intensity, efficiencies, max_err) are compared within a small relative
+tolerance to absorb JSON float formatting.
+
+Usage:
+    resnet_regression_check.py generate --binary PATH --baseline FILE
+    resnet_regression_check.py check    --binary PATH --baseline FILE [--rtol R]
+
+`check` exits non-zero (and prints a diff) on any regression.
+"""
+import argparse
+import json
+import subprocess
+import sys
+
+REL_TOL = 1e-6      # relative tolerance for float fields
+ABS_TOL = 1e-9      # absolute tolerance near zero
+
+# Keys excluded from the regression comparison. max_err is the fp validation error
+# (conv/matmul reduction order and FMA use differ across compilers/platforms), so
+# it is NOT bit-deterministic; correctness is enforced separately by the m2_resnet
+# PASS check (max_err < 5e-3). All timing/utilization/compute metrics ARE
+# deterministic (integer schedule logic + IEEE double arithmetic on integer inputs).
+IGNORE_KEYS = {"max_err"}
+
+
+def run_binary(binary: str) -> dict:
+    """Run `<binary> --json` and parse its stdout as JSON."""
+    out = subprocess.run([binary, "--json"], capture_output=True, text=True, check=True)
+    return json.loads(out.stdout)
+
+
+def _floats_close(a: float, b: float, rtol: float) -> bool:
+    return abs(a - b) <= max(rtol * abs(b), ABS_TOL)
+
+
+def _compare(path: str, base, cur, rtol: float, out: list):
+    """Recursively compare cur against base, appending mismatches to `out`."""
+    if isinstance(base, dict):
+        if not isinstance(cur, dict):
+            out.append(f"{path}: type changed dict -> {type(cur).__name__}")
+            return
+        for k in base:
+            if k in IGNORE_KEYS:
+                continue
+            if k not in cur:
+                out.append(f"{path}.{k}: missing in current run")
+            else:
+                _compare(f"{path}.{k}", base[k], cur[k], rtol, out)
+        return
+    if isinstance(base, list):
+        if not isinstance(cur, list) or len(cur) != len(base):
+            out.append(f"{path}: list changed {base} -> {cur}")
+            return
+        for i, (b, c) in enumerate(zip(base, cur)):
+            _compare(f"{path}[{i}]", b, c, rtol, out)
+        return
+    # bool is a subclass of int; check it first so True != 1 confusion is avoided.
+    if isinstance(base, bool) or isinstance(cur, bool):
+        if base != cur:
+            out.append(f"{path}: {base} -> {cur}")
+        return
+    if isinstance(base, int) and isinstance(cur, int):
+        if base != cur:                                   # deterministic: exact
+            out.append(f"{path}: {base} -> {cur}  (integer metric must be exact)")
+        return
+    if isinstance(base, (int, float)) and isinstance(cur, (int, float)):
+        if not _floats_close(float(cur), float(base), rtol):
+            out.append(f"{path}: {base} -> {cur}  (rtol {rtol})")
+        return
+    if base != cur:
+        out.append(f"{path}: {base!r} -> {cur!r}")
+
+
+def compare(baseline: dict, current: dict, rtol: float) -> list:
+    """Return a list of human-readable regression messages (empty if clean)."""
+    mismatches: list = []
+    base_by_name = {r["name"]: r for r in baseline.get("results", [])}
+    cur_by_name = {r["name"]: r for r in current.get("results", [])}
+    for name, br in base_by_name.items():
+        if name not in cur_by_name:
+            mismatches.append(f"result '{name}': missing in current run")
+        else:
+            _compare(f"result '{name}'", br, cur_by_name[name], rtol, mismatches)
+    for name in cur_by_name:
+        if name not in base_by_name:
+            mismatches.append(f"result '{name}': new, not in baseline")
+    # top-level scalar knobs (clock/peak/bw) should be stable too
+    for k in ("clock_ghz", "peak_gflops", "ext_bw_gbs"):
+        if k in baseline:
+            _compare(k, baseline[k], current.get(k), rtol, mismatches)
+    return mismatches
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="ResNet-on-CSP regression check")
+    ap.add_argument("command", choices=["generate", "check"])
+    ap.add_argument("--binary", required=True, help="path to the m2_resnet executable")
+    ap.add_argument("--baseline", required=True, help="path to the baseline JSON")
+    ap.add_argument("--rtol", type=float, default=REL_TOL)
+    args = ap.parse_args()
+
+    current = run_binary(args.binary)
+
+    if args.command == "generate":
+        with open(args.baseline, "w") as f:
+            json.dump(current, f, indent=2)
+            f.write("\n")
+        print(f"Wrote baseline: {args.baseline}")
+        return 0
+
+    with open(args.baseline) as f:
+        baseline = json.load(f)
+    mismatches = compare(baseline, current, args.rtol)
+    if mismatches:
+        print("ResNet benchmark REGRESSION (vs committed baseline):", file=sys.stderr)
+        for m in mismatches:
+            print("  " + m, file=sys.stderr)
+        print(f"\n{len(mismatches)} metric(s) changed. If intentional, regenerate:\n"
+              f"  python3 scripts/resnet_regression_check.py generate "
+              f"--binary {args.binary} --baseline {args.baseline}", file=sys.stderr)
+        return 1
+    print("ResNet benchmark: no regression (all metrics match the baseline).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmarks/resnet_baseline.json
+++ b/tests/benchmarks/resnet_baseline.json
@@ -1,0 +1,165 @@
+{
+  "name": "resnet18",
+  "description": "ResNet-18 on the CSP timing executor (deterministic scaled sweep)",
+  "clock_ghz": 1,
+  "peak_gflops": 512,
+  "ext_bw_gbs": 64,
+  "results": [
+    {
+      "name": "resnet18 (base)",
+      "config": {
+        "batch": 16,
+        "in_channels": 16,
+        "height": 4,
+        "width": 4,
+        "stage_channels": [
+          16,
+          16,
+          16,
+          16
+        ],
+        "blocks_per_stage": 1,
+        "num_classes": 16,
+        "tile": 16
+      },
+      "timing": {
+        "cycles": 39881,
+        "critical_path_cycles": 39119,
+        "ops": 22,
+        "nodes": 39
+      },
+      "stalls": {
+        "dma": 7016,
+        "block_mover": 99797,
+        "streamer": 26511
+      },
+      "throughput": {
+        "tiles_loaded": 1805,
+        "tiles_moved": 1438,
+        "tiles_fed": 1438,
+        "bytes_loaded": 738304,
+        "bytes_stored": 114688
+      },
+      "utilization": {
+        "dma": 0.846092124,
+        "block_mover": 0.141069682,
+        "streamer": 0.106893007
+      },
+      "compute": {
+        "macs": 2240512,
+        "gflops": 112.359871,
+        "peak_efficiency": 0.219452872,
+        "arithmetic_intensity": 5.25330132,
+        "roofline_efficiency": 0.334194228
+      },
+      "validation": {
+        "max_err": 5.96046448e-08,
+        "pass": true
+      }
+    },
+    {
+      "name": "resnet18 [2,2,2,2]",
+      "config": {
+        "batch": 16,
+        "in_channels": 16,
+        "height": 4,
+        "width": 4,
+        "stage_channels": [
+          16,
+          16,
+          16,
+          16
+        ],
+        "blocks_per_stage": 2,
+        "num_classes": 16,
+        "tile": 16
+      },
+      "timing": {
+        "cycles": 51469,
+        "critical_path_cycles": 50707,
+        "ops": 38,
+        "nodes": 67
+      },
+      "stalls": {
+        "dma": 9984,
+        "block_mover": 108557,
+        "streamer": 29951
+      },
+      "throughput": {
+        "tiles_loaded": 2773,
+        "tiles_moved": 2318,
+        "tiles_fed": 2318,
+        "bytes_loaded": 1307648,
+        "bytes_stored": 204800
+      },
+      "utilization": {
+        "dma": 0.77901261,
+        "block_mover": 0.184382832,
+        "streamer": 0.139248868
+      },
+      "compute": {
+        "macs": 3862528,
+        "gflops": 150.091434,
+        "peak_efficiency": 0.293147331,
+        "arithmetic_intensity": 5.10765064,
+        "roofline_efficiency": 0.459150168
+      },
+      "validation": {
+        "max_err": 5.96046448e-08,
+        "pass": true
+      }
+    },
+    {
+      "name": "resnet18 (batch 32)",
+      "config": {
+        "batch": 32,
+        "in_channels": 16,
+        "height": 4,
+        "width": 4,
+        "stage_channels": [
+          16,
+          16,
+          16,
+          16
+        ],
+        "blocks_per_stage": 1,
+        "num_classes": 16,
+        "tile": 16
+      },
+      "timing": {
+        "cycles": 72169,
+        "critical_path_cycles": 71333,
+        "ops": 22,
+        "nodes": 39
+      },
+      "stalls": {
+        "dma": 16430,
+        "block_mover": 196470,
+        "streamer": 49551
+      },
+      "throughput": {
+        "tiles_loaded": 3610,
+        "tiles_moved": 2876,
+        "tiles_fed": 2876,
+        "bytes_loaded": 1389568,
+        "bytes_stored": 229376
+      },
+      "utilization": {
+        "dma": 0.923235738,
+        "block_mover": 0.148845072,
+        "streamer": 0.118139367
+      },
+      "compute": {
+        "macs": 4481024,
+        "gflops": 124.181408,
+        "peak_efficiency": 0.242541812,
+        "arithmetic_intensity": 5.53573688,
+        "roofline_efficiency": 0.350510607
+      },
+      "validation": {
+        "max_err": 5.96046448e-08,
+        "pass": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Final roadmap item (6): machine-readable output + a CI regression guard so ResNet's metrics are tracked over time.

- **`m2_resnet --json`** emits the deterministic sweep as structured JSON per config: `config`, `timing` (cycles, critical path, ops, nodes), `stalls`, `throughput` (tiles/bytes), `utilization`, `compute` (macs, GFLOP/s, efficiencies, AI), `validation`.
- **Committed baseline** `tests/benchmarks/resnet_baseline.json` + **`scripts/resnet_regression_check.py`** (generate/check), wired as the **`resnet_regression` ctest** so every metric is diffed against the baseline on every multi-platform CI run.

## Why a ctest (not the benchmark-regression workflow)

The sweep is **deterministic** (fixed-seed synthetic weights), so integer metrics reproduce exactly run-to-run *and across platforms* (integer schedule logic), and the derived floats are IEEE-deterministic to within `1e-6`. That makes a tight committed-golden check possible, which is cleaner than the matmul harness's statistical >5% threshold + artifact baseline. A ctest gets all-platform coverage on every PR and avoids that workflow's artifact machinery. (`tests/benchmarks/baselines/` is gitignored — CI-artifact convention — so the ResNet golden baseline lives at `tests/benchmarks/resnet_baseline.json`.)

- **Integer metrics exact; floats within `1e-6`.**
- **`max_err` excluded** — the one non-deterministic field (fp reduction order / FMA differ across compilers); correctness is enforced separately by the `m2_resnet` PASS check.

## Verification

- `check` passes on match; ignores a `max_err` tamper; catches a 1-cycle and a 1% utilization drift (exit 1 with a clear diff).
- `--json` output is valid JSON (round-trips through `json.tool`).
- **59/59 timing tests pass** (incl. the new `resnet_regression`); `clang++ -Werror -Wall -Wextra -Wshorten-64-to-32 -fsyntax-only` OK. Sweep construction refactored into a shared `build_sweep` helper — default-path output unchanged.

## Roadmap complete

This closes items 1–6. The study's conclusion is triangulated from five angles (utilization, compute efficiency, occupancy, scale, concurrency): **ResNet on this KPU is DRAM-bandwidth-bound; nothing else binds** — and it's now regression-guarded in CI.

## Test plan

- [ ] Fast CI passes (incl. `resnet_regression` on all platforms)
- [ ] Resolve CodeRabbit review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)