### PR TITLE
docs(session): ResNet-on-KPU benchmarking study wrapup log

### DIFF
--- a/docs/sessions/2026-07-18_v0.9_resnet-benchmarking-study.md
+++ b/docs/sessions/2026-07-18_v0.9_resnet-benchmarking-study.md
@@ -1,0 +1,145 @@
+# v0.9 ResNet-on-KPU Benchmarking Study Decision Log
+
+**Date:** 2026-07-18
+**Version:** v0.9
+**Status:** Complete (roadmap items 1–6 done; #226 pending merge)
+**Tests:** 59/59 timing tests passing (incl. new `resnet_regression`)
+
+## 1. Summary
+
+Turned the M2 ResNet-18 demo from a correctness artifact into a **performance
+research instrument**, to answer "what utilization / where is the bottleneck when
+ResNet runs on the KPU." Wrote a research guide
+(`docs/benchmarking/resnet-benchmarking-guide.md`) and drove a six-item roadmap to
+completion, one PR per item (#220–#226). The demo now reports movement-fabric
+utilization (directly measured), compute FLOP efficiency + roofline position, a
+buffer-occupancy timeline, a representative-scale offline run, a concurrency-overlap
+upper bound, and machine-readable JSON with a CI regression guard. The study's
+conclusion is triangulated from five independent angles: **ResNet on this KPU is
+DRAM-bandwidth-bound; nothing else binds.**
+
+## 2. Scope
+
+| Item | Deliverable | PR | Status |
+|------|-------------|----|--------|
+| Guide | `resnet-benchmarking-guide.md` (assets/assumptions/howto/results) | #220 | ✅ |
+| 1 | Movement utilization surfaced in `RunStats` + demo table | #220 | ✅ |
+| 1 (fix) | Instrumentation-gap fix (4 runners not threading busy cycles) | #220 | ✅ |
+| 1b | Directly-measured active-cycle counter (per-component `tick()`) | #221 | ✅ |
+| 2 | Compute FLOP efficiency + roofline (`--` MACs, AI, peak/roofline eff) | #222 | ✅ |
+| 3 | Occupancy timeline via `TileTracker` (`--occupancy`) | #223 | ✅ |
+| 4 | Representative-scale offline run (`--full`, channel growth + `[2,2,2,2]`) | #224 | ✅ |
+| 5 | Concurrency-headroom (branch-overlap critical path) | #225 | ✅ |
+| 6 | JSON export (`--json`) + committed baseline + `resnet_regression` ctest | #226 | pending merge |
+
+**The headline numbers (base scaled config):** DMA util 84.6%, BlockMover 14.1%,
+Streamer 10.7%; compute peakEff 21.9%, AI 5.25 FLOP/byte (memory-bound); occupancy
+peaks L3 4/32, L2 2/64 (buffers not the limit); branch-overlap upper bound 1.02×.
+At representative scale (`--full`, 16→128ch, `[2,2,2,2]`): AI rises to 7.6, peakEff
+to 37%, still memory-bound and DMA-saturated (84.5%).
+
+## 3. Technical Decisions
+
+- **Decision 1: Directly measured active cycles over the derived heuristic (1b).**
+  - **Choice:** each CSP component (`DMAEngineProcess`, `BlockMoverProcess`,
+    `StreamerProcess`) increments an `active_cycles_` counter in its `tick()` only
+    when a transfer occupies that cycle; `collect_statistics` averages per component.
+  - **Alternatives:** keep the `busy = total_cycles − stalls/N` heuristic (counts
+    idle as busy).
+  - **Rationale:** the heuristic mis-ranked the bottleneck (see §5); direct
+    measurement excludes idle and gives a true activity fraction.
+  - **Files:** `dma_engine_process.hpp`, `block_mover_process.hpp`,
+    `streamer_process.hpp`, `concurrent_timing_executor.hpp`, `csp_op_runners.hpp`.
+
+- **Decision 2: Fractional (`double`) per-component busy.**
+  - **Choice:** keep `busy_cycles` fractional so the per-op mean is exact.
+  - **Alternatives:** integer division (floors, systematic undercount when N∤sum).
+  - **Rationale:** CodeRabbit flagged the floor; power-of-two N makes it bit-exact
+    for the real config, negligible non-systematic rounding otherwise.
+
+- **Decision 3: Critical-path *analysis* for item 5, not a concurrent-execution
+  rewrite.** (User-confirmed scope via AskUserQuestion.)
+  - **Choice:** compute the DAG critical path (`finish[n]=cost[n]+max preds`) as a
+    resource-free upper bound on branch-overlap speedup.
+  - **Alternatives:** true concurrent multi-op execution on a shared executor.
+  - **Rationale:** answers the study's question at ~1 PR; the ≤2% result then shows
+    the rewrite is not worth building for ResNet.
+
+- **Decision 4: `resnet_regression` as a ctest, not a graft into
+  `benchmark-regression.yml`.**
+  - **Choice:** committed golden baseline + `resnet_regression_check.py` wired as a
+    ctest; integer metrics exact, floats within 1e-6, `max_err` excluded.
+  - **Alternatives:** extend the matmul-specific statistical workflow + its artifact
+    baseline.
+  - **Rationale:** the ResNet sweep is deterministic, so a tight committed-golden
+    check is cleaner and gets all-platform coverage on every PR.
+
+- **Decision 5: Representative-scale `--full`, not full 224×224.**
+  - **Choice:** `{16,32,64,128}×2` at 8×8, ~50 s offline.
+  - **Rationale:** full resolution is intractable cycle-by-cycle (see §4); this
+    keeps the *structure* (growth + depth + downsampling) that the finding depends on.
+
+## 4. Issues Encountered
+
+- **Instrumentation gap (utilization understated).** Four runners
+  (`run_elementwise`, `run_ve_unary`, `run_depthwise_conv`, `run_global_avg_pool`)
+  added only `total_cycles`/`ops` to `RunStats`, inflating the denominator without
+  the busy numerator. Root cause: `ExecutionResult` didn't carry `Statistics`.
+  Fix: thread `Statistics` through `ScheduleExecutor::ExecutionResult`; all runners
+  fold via `detail::accumulate`. Caught by CodeRabbit on #220.
+- **Intractable full-scale spec.** The first `--full` (64→512ch, 16×16) ran >20 min
+  with no completion — a stage-4 3×3 conv on 512 channels is K=4608 (hundreds of
+  K-slices/tile). Dialed down to `{16,32,64,128}` at 8×8 (~50 s).
+- **Gitignored baseline.** The committed golden baseline was first placed under the
+  gitignored `tests/benchmarks/baselines/` (CI-artifact convention), so the ctest
+  would reference a non-committed file. Moved to `tests/benchmarks/resnet_baseline.json`,
+  fixed all path references, amended + force-pushed.
+- **`gh pr merge` local-sync hiccup.** Twice, `gh pr merge --delete-branch` merged
+  remotely but errored during its local fast-forward ("cannot rebase onto multiple
+  branches"); local main was left one commit behind. Resolved each time with an
+  explicit `git fetch` + `git merge --ff-only origin/main` and branch-delete verify.
+
+## 5. Wrong Decisions (CRITICAL)
+
+- **Reported a bottleneck finding from an unvalidated metric.** Early in item 1 I
+  presented "utilization ≈ 20–40%, BlockMover is the bottleneck" as a finding. It
+  was an **artifact** of the instrumentation gap (§4) *and* of the weak
+  `busy=total−stall` heuristic. **Why wrong:** I surfaced a conclusion before the
+  metric was validated, and it was doubly incorrect — once fixed and once
+  re-measured directly, the picture flipped to **DMA-saturated (78–92%), on-chip
+  movers starving (11–18%)**. **Correction:** the instrumentation fix (#220) then
+  the direct-measurement counter (#221) reversed the diagnosis to DMA-bound.
+  **Lesson:** do not quote a performance finding until the metric that produced it
+  is validated (a consistency invariant or a directly-measured cross-check). The
+  regression guard (#226) now encodes the validated numbers so this can't silently
+  drift again.
+- **Nearly shipped a floored fractional metric.** Item 1b's first cut used integer
+  per-component division. **Correction (CodeRabbit):** made `busy` fractional +
+  added a non-divisible regression test. **Lesson:** a self-consistency assertion
+  (`util==busy/total`) does not catch a shared systematic bias; test the property
+  that would break (`busy(3)*3==busy(1)`).
+
+## 6. Verification
+
+```bash
+cmake --build --preset release
+ctest --preset default -L timing            # 59/59 pass (incl. resnet_regression)
+./build/examples/milestones/m2_resnet       # utilization / compute / concurrency tables
+./build/examples/milestones/m2_resnet --json | python3 -m json.tool   # valid JSON
+python3 scripts/resnet_regression_check.py check \
+  --binary ./build/examples/milestones/m2_resnet \
+  --baseline tests/benchmarks/resnet_baseline.json
+# clang gate (MSVC C4267 proxy):
+clang++ ... -Werror -Wall -Wextra -Wshorten-64-to-32 -fsyntax-only examples/milestones/m2_resnet.cpp
+```
+
+## 7. Next Steps
+
+Roadmap items 1–6 complete. Open follow-ons (carried in the guide, none blocking):
+- A true full-resolution ResNet run — needs a native large-K / grouped-conv
+  schedule generator to be tractable (the pooling-window/im2col paths explode at
+  512 channels).
+- A per-layer arithmetic-intensity breakdown (which convs are compute- vs
+  memory-bound).
+- Real concurrent multi-op execution — only if a *non-ResNet* workload with genuine
+  branch parallelism ever motivates it (ResNet's ≤2% headroom does not).


### PR DESCRIPTION
## Summary

Session decision log for the ResNet-on-KPU benchmarking study — the six-item roadmap delivered this session across PRs #220–#226. Docs-only.

Covers:
- **Scope** — items 1–6 with their PRs and the headline numbers.
- **Technical decisions** — directly-measured active cycles, fractional busy, critical-path analysis (user-chosen scope) over a concurrent-execution rewrite, ctest-over-workflow regression, representative-scale over full 224×224.
- **Issues** — instrumentation gap, intractable full-scale spec, gitignored baseline, gh local-sync hiccup.
- **Wrong decisions (mandatory)** — reported a bottleneck finding from an unvalidated metric (later reversed to DMA-bound); nearly shipped a floored fractional metric.
- **Conclusion** — ResNet on this KPU is DRAM-bandwidth-bound, triangulated from five angles and now regression-guarded in CI.

Per-item CHANGELOG entries were added with each PR; this is the session-level log required by the governance rules.

## Test plan

- [ ] Docs-only; fast CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)