### PR TITLE
docs(plan): model-ingestion & compilation epic (ONNX → domain_flow → KPU)

### DIFF
--- a/docs/plans/dfg-kpu-versioning.md
+++ b/docs/plans/dfg-kpu-versioning.md
@@ -1,0 +1,121 @@
+# Versioning the `.dfg` source IR and the `.kpu` binary program
+
+**Status:** requirements analysis (companion to `model-ingestion-compilation-epic.md`,
+epic #229). Resolves the plan's §9 Q1.
+
+**Motivation:** ONNX, StableHLO, and TOSA/MLIR all carry explicit version numbers and
+compatibility policies. domain_flow's `.dfg` today has **none** — no format version,
+and the `DomainFlowOperator` enum is an *implicit, unversioned* opset. The `.kpu`
+binary program (the compiler↔simulator ABI, epic decision D5) has the same gap and a
+higher stakes. This note extracts the versioning requirements from prior art.
+
+---
+
+## 1. How the major formats version themselves
+
+### ONNX — three orthogonal axes
+ONNX versions three independent things
+([ONNX Versioning](https://onnx.ai/onnx/repo-docs/Versioning.html),
+[IR spec](https://onnx.ai/onnx/repo-docs/IR.html)):
+- **IR / format version** (`ir_version`) — the container structure; a monotonic
+  integer, bumped atomically.
+- **Operator-set version** (`opset_import`) — a list of `(domain, version)` pairs.
+  `""` = the standard `ai.onnx` set; other domains = vendor sets, each versioned
+  independently. Any op add/remove/**semantic change** MUST bump the domain version;
+  each op carries a `since_version`.
+- **Model version** (`model_version`) — the trained model's own version. Plus
+  `producer_name`/`producer_version`.
+
+**Takeaway:** *format structure* and *operator semantics* version separately; ops
+live in versioned **domains**.
+
+### StableHLO — semver + explicit windows + a separate serialization dialect (VHLO)
+[StableHLO Compatibility](https://openxla.org/stablehlo/compatibility),
+[VHLO](https://openxla.org/stablehlo/vhlo):
+- `MAJOR.MINOR.PATCH`; explicit compatibility windows (≈2 years forward; backward
+  across 1 major release).
+- Serialization goes through **VHLO**, an **add-only** dialect: every op/type/attr is
+  individually versioned with a `[min, max]` range; once released, semantics are
+  **frozen**; changes require a *new* version. Serialization targets a specific
+  version; deserialization upgrades/downgrades. Both directions are **CI-tested every
+  PR**.
+
+**Takeaway:** *serialization stability is a first-class, separately-versioned,
+freeze-on-release concern — real only if enforced by a golden-artifact suite.*
+
+### TOSA — version number plus capability dimensions
+[TOSA dialect](https://mlir.llvm.org/docs/Dialects/TOSA/),
+[RFC v1.0](https://discourse.llvm.org/t/rfc-tosa-dialect-increment-to-v1-0/83708):
+- Versioned (→ v1.0; minor versions backward-compatible), but layered with
+  **profiles** (base/main inference, training), **levels**, **extensions**, and
+  **datatype combinations**. A module can be *syntactically valid but invalid for a
+  given profile/level*. The dialect is a **superset** of the spec, with a validation
+  pass checking conformance.
+
+**Takeaway:** *a version number is not enough — an artifact declares required
+capabilities, a consumer advertises supported ones, mismatch is a clean refusal.*
+
+### Supporting patterns
+- **TF GraphDef** `VersionDef { producer, min_consumer, bad_consumers[] }` — the
+  cleanest **forward-compat gate**: an artifact states the minimum consumer version
+  (old readers refuse too-new files cleanly) + a **blocklist of known-bad producers**.
+- **PyTorch `torch.export`** versions its serialization schema as a `(major, minor)`
+  tuple with defined bump rules; **TFLite** carries a flatbuffer schema `version`.
+
+---
+
+## 2. Requirements for `.dfg`
+
+| # | Requirement | Sourced from |
+|---|---|---|
+| **R1** | **Three orthogonal version axes**: (a) `.dfg` format/container version, (b) operator-set version(s), (c) producer name+version. | ONNX |
+| **R2** | **Operators namespaced by domain** — every op is `(domain, name, version)`; a core `stillwater.dfa` opset versions independently of vendor/experimental ops. | ONNX |
+| **R3** | **Semver with documented bump rules** per axis: MAJOR = breaking, MINOR = additive/back-compat, PATCH = fixes. | StableHLO, torch.export |
+| **R4** | **`min_consumer` gate**: the file declares the minimum reader version; an older loader **refuses cleanly** rather than mis-parsing. Plus a `bad_producers` blocklist. | TF GraphDef, StableHLO |
+| **R5** | **Add-only / freeze-on-release** for the serialized op/attr/type surface, backed by a versioned registry with per-element `[min,max]` ranges. | StableHLO VHLO |
+| **R6** | **Capability/profile metadata beyond the version**: datatype set + (for KPU) target-config assumptions; artifact declares *required* profiles, consumer advertises *supported*. | TOSA |
+| **R7** | **Pin the type-system version** — `.dfg` embeds `tensor<…>` strings; that grammar is a versioned surface and must be declared, not assumed. | MLIR/TOSA, ONNX |
+| **R8** | **Defined unknown-op/attr policy**: strict-fail on unknown *ops* in a required opset; additive-tolerant on optional *attrs*. | ONNX, StableHLO |
+| **R9** | **Explicit compatibility windows**, documented and **CI-tested** with a golden-`.dfg` corpus. | StableHLO |
+
+### Proposed `.dfg` versioned preamble (the current format has none)
+
+```
+DFG 1.0                       # R1a format version (MAJOR.MINOR)
+PRODUCER domain_flow 0.4.2    # R1c producer + version
+OPSET   stillwater.dfa 3      # R1b/R2 (domain, opset_version) — repeatable
+MIN_CONSUMER 1.0              # R4 minimum reader; older readers refuse
+PROFILE fp32                  # R6 datatype/capability profile(s)
+TYPESYS mlir-tensor 1         # R7 type-string grammar version
+... existing DIRECTED/NODES/EDGES/ADJACENCY body ...
+```
+
+---
+
+## 3. The `.kpu` binary program needs its own, stricter versioning
+
+`.dfg` is the compiler-front-facing *source* IR. The **`.kpu` binary program is the
+hardware ABI** — the D5 contract between the domain_flow compiler and the simulated
+KPU — and a binary ABI is exactly where versioning matters most. It needs its **own**
+version stamp:
+- **(a) ISA / format version** of the binary program.
+- **(b) KPU functional-spec profile it targets** — fabric config + datatype support.
+  The R6 capability dimension is load-bearing here: an int8 program on an fp32-only
+  fabric must be **rejected, not mis-run**.
+- **(c) producer compiler version.**
+
+Treat it like a StableHLO portable artifact: freeze-on-release + `min_consumer` gate +
+a **golden-binary conformance suite** — which is already the epic's D5 / Phase 0
+deliverable. kpu-sim owns this spec (it is the hardware); the compiler targets it.
+
+---
+
+## 4. Recommendation
+
+- **Version `.dfg` in place** by adding the preamble (§2) — do **not** fork a parallel
+  schema; extend the existing text format so kpu-sim's current reader evolves rather
+  than a second path appearing.
+- **Version `.kpu` from day one** (Phase 0) — it is the ABI; retrofitting a version
+  onto an unversioned binary contract later is far more expensive.
+- **Enforce with golden corpora** in CI for both — a version policy that isn't tested
+  rots (StableHLO's discipline).

--- a/docs/plans/dfg-kpu-versioning.md
+++ b/docs/plans/dfg-kpu-versioning.md
@@ -1,13 +1,14 @@
-# Versioning the `.dfg` source IR and the `.kpu` binary program
+# Versioning the `.dfg` source IR and the `.kpubin` binary program
 
 **Status:** requirements analysis (companion to `model-ingestion-compilation-epic.md`,
 epic #229). Resolves the plan's §9 Q1.
 
 **Motivation:** ONNX, StableHLO, and TOSA/MLIR all carry explicit version numbers and
 compatibility policies. domain_flow's `.dfg` today has **none** — no format version,
-and the `DomainFlowOperator` enum is an *implicit, unversioned* opset. The `.kpu`
-binary program (the compiler↔simulator ABI, epic decision D5) has the same gap and a
-higher stakes. This note extracts the versioning requirements from prior art.
+and the `DomainFlowOperator` enum is an *implicit, unversioned* opset. The `.kpubin`
+binary program (the compiler↔simulator ABI, epic decision D4/D5) has a partial header
+(magic + version) but lacks the full stamp. This note extracts the versioning
+requirements from prior art.
 
 ---
 
@@ -78,44 +79,74 @@ capabilities, a consumer advertises supported ones, mismatch is a clean refusal.
 | **R8** | **Defined unknown-op/attr policy**: strict-fail on unknown *ops* in a required opset; additive-tolerant on optional *attrs*. | ONNX, StableHLO |
 | **R9** | **Explicit compatibility windows**, documented and **CI-tested** with a golden-`.dfg` corpus. | StableHLO |
 
-### Proposed `.dfg` versioned preamble (the current format has none)
+### Illustrative `.dfg` versioned preamble (the current format has none)
 
-```
-DFG 1.0                       # R1a format version (MAJOR.MINOR)
-PRODUCER domain_flow 0.4.2    # R1c producer + version
-OPSET   stillwater.dfa 3      # R1b/R2 (domain, opset_version) — repeatable
-MIN_CONSUMER 1.0              # R4 minimum reader; older readers refuse
-PROFILE fp32                  # R6 datatype/capability profile(s)
-TYPESYS mlir-tensor 1         # R7 type-string grammar version
+The example below is **illustrative** — it shows the *fields* the requirements imply,
+not the final grammar. The **complete, normative grammar** (exact field order,
+repetition, semver comparison + bump rules, legacy-file policy, and the precise
+refusal behavior for malformed / unsupported-version / capability-mismatch /
+unknown-op cases) is a **Phase 0 deliverable** of the epic (issue #230), written once
+and shared by producer (domain_flow) and consumer (kpu-sim's loader).
+
+```text
+DFG 1.0.0                     # R1a/R3 format version (MAJOR.MINOR.PATCH semver)
+MIN_CONSUMER 1.0.0            # R4 minimum reader format version; older readers refuse
+PRODUCER domain_flow 0.4.2    # R1c producer name + semver
+BAD_PRODUCERS domain_flow 0.4.0  # R4 known-bad producer blocklist (repeatable)
+OPSET   stillwater.dfa 3.0.0  # R1b/R2/R3 (domain, opset semver) — repeatable
+TYPESYS mlir-tensor 1.0.0     # R7 type-string grammar semver
+REQUIRES_PROFILE fp32         # R6 profiles this artifact NEEDS (repeatable)
+                              #    (consumer separately advertises SUPPORTS_PROFILE;
+                              #     REQUIRES ⊄ SUPPORTS ⇒ clean refusal)
 ... existing DIRECTED/NODES/EDGES/ADJACENCY body ...
 ```
 
+Semver comparison (R3): a consumer accepts an artifact iff its reader format version
+≥ `MIN_CONSUMER`, the producer is not in its `BAD_PRODUCERS` set, each required
+`OPSET`/`TYPESYS` MAJOR matches a supported one (MINOR/PATCH additive-tolerant, R8),
+and `REQUIRES_PROFILE ⊆ SUPPORTS_PROFILE`; otherwise it refuses with a specific
+diagnostic. Unknown *ops* in a required opset are hard errors; unknown optional
+*attrs* are ignored (R8).
+
 ---
 
-## 3. The `.kpu` binary program needs its own, stricter versioning
+## 3. The `.kpubin` binary program needs its own, stricter versioning
 
-`.dfg` is the compiler-front-facing *source* IR. The **`.kpu` binary program is the
-hardware ABI** — the D5 contract between the domain_flow compiler and the simulated
-KPU — and a binary ABI is exactly where versioning matters most. It needs its **own**
-version stamp:
-- **(a) ISA / format version** of the binary program.
+`.dfg` is the compiler-front-facing *source* IR. The **`.kpubin` binary program (the
+`DMProgram` ISA stream) is the hardware ABI** — the D5 contract between the
+domain_flow compiler and the simulated KPU (epic decision D4) — and a binary ABI is
+exactly where versioning matters most.
+
+**Prior art already in-repo:** `ProgramSerializer` (`src/software/isa/program_serializer.cpp`)
+already writes a header with `DMPROGRAM_MAGIC` + `DMPROGRAM_VERSION` and magic-checks
+on read ("format v2"). That is the **seed** — Phase 0 extends it to the full stamp:
+- **(a) ISA / format version** — already present (`DMPROGRAM_VERSION`); add a
+  `MIN_CONSUMER` gate (R4) so an old loader refuses a too-new binary cleanly.
 - **(b) KPU functional-spec profile it targets** — fabric config + datatype support.
-  The R6 capability dimension is load-bearing here: an int8 program on an fp32-only
-  fabric must be **rejected, not mis-run**.
-- **(c) producer compiler version.**
+  The R6 capability dimension is load-bearing: an int8 program on an fp32-only fabric
+  must be **rejected, not mis-run**. (Not represented in the current header.)
+- **(c) producer compiler version** (+ `bad_producers`, R4). (Not present today.)
 
 Treat it like a StableHLO portable artifact: freeze-on-release + `min_consumer` gate +
-a **golden-binary conformance suite** — which is already the epic's D5 / Phase 0
-deliverable. kpu-sim owns this spec (it is the hardware); the compiler targets it.
+a **golden-binary conformance suite** — the epic's D5 / Phase 0 deliverable (#230).
+kpu-sim owns this spec (it is the hardware); the compiler targets it. **Do not add a
+second binary format** — extend `.kpubin`/`ProgramSerializer`; the higher-level `dfx`
+`.kpu` object's fate (intermediate vs dropped) is a separate Phase 0 decision (epic
+D4).
 
 ---
 
 ## 4. Recommendation
 
 - **Version `.dfg` in place** by adding the preamble (§2) — do **not** fork a parallel
-  schema; extend the existing text format so kpu-sim's current reader evolves rather
-  than a second path appearing.
-- **Version `.kpu` from day one** (Phase 0) — it is the ABI; retrofitting a version
-  onto an unversioned binary contract later is far more expensive.
+  schema; extend domain_flow's existing text format. `.dfg` is **compiler-internal**
+  (the source IR that ONNX imports into and passes rewrite); it is versioned for the
+  *compiler front-end*, **not** as a kpu-sim runtime input. kpu-sim's runtime
+  execution contract is the `.kpubin` binary (epic D4/D5), not `.dfg`.
+- **Version `.kpubin` from day one** (Phase 0) by extending the existing
+  `ProgramSerializer` header (§3) — it is the ABI; retrofitting a fuller version onto a
+  binary contract later is far more expensive.
+- **One binary format, one source format** — do not add a third path; the `dfx` `.kpu`
+  object's status (intermediate vs dropped) is a Phase 0 decision (epic D4).
 - **Enforce with golden corpora** in CI for both — a version policy that isn't tested
   rots (StableHLO's discipline).

--- a/docs/plans/model-ingestion-compilation-epic.md
+++ b/docs/plans/model-ingestion-compilation-epic.md
@@ -1,0 +1,290 @@
+# Epic: Real-DNN Ingestion & Compilation (ONNX/PyTorch → domain_flow → KPU)
+
+**Status:** Approved direction (decisions D1–D4 resolved 2026-07-19) — implementation not started.
+**Author:** planning session 2026-07-19.
+**Scope:** two repos — `kpu-sim` and `branes-ai/domain_flow` (consumed via FetchContent).
+
+**Resolved decisions (2026-07-19):**
+- **D1 — direct `ONNX → dfg` reader** (no LLVM/MLIR) for the front-end.
+- **D2 — topology + timing first**: the first milestone needs weight *shapes*, not
+  *values*; numerical trained-weight fidelity is a later milestone.
+- **D3 — canonical IR = domain_flow's `DomainFlowGraph`** (not kpu-sim's
+  `KernelGraph`). domain_flow is the compiler; its IR is the single source of truth.
+  `ComputationalGraph` retires; `KernelGraph` is demoted to a generated lowering
+  artifact (and a candidate for eventual removal). See §4a.
+- **D4 — file as a formal epic + per-phase sub-issues, run alongside the M4
+  milestone** (attention → flash attention).
+
+---
+
+## 1. Goal
+
+Replace the hand-written DNN facsimiles (`resnet18.hpp`, `mobilenetv2.hpp`,
+`efficientnet.hpp`, `m2_resnet.cpp`) with a real pipeline: **load a trained DNN from
+disk (ONNX / PyTorch), compile it through domain_flow into cached KPU programs, and
+execute it on the simulator with real weights.**
+
+Target end-to-end flow:
+
+```
+  ONNX / PyTorch (.onnx / .pt)
+     │  [A] domain_flow front-end: model file → domain flow graph
+     ▼
+  .dfg  (+ weight blob)                         ◄── the cross-repo interchange contract
+     │  [B] kpu-sim import: .dfg → KernelGraph;  weights → HOST_MEMORY
+     ▼
+  KernelGraph + weights resident in host memory (ResourceManager)
+     │  [C] compiler pass: operators → KPU "domain flow programs" (schedules)
+     ▼
+  compiled program (dfx / .kpu)  →  [D] program cache
+     │  [E] loader: bind program → fabric resources  =  "personalize the data path"
+     ▼
+  execute on GraphCspExecutor / ConcurrentTimingExecutor  (real weights, timing model)
+```
+
+The five stages **[A]–[E]** are the user's description, mapped to concrete seams
+below.
+
+---
+
+## 2. Current state (grounded in both repos)
+
+### 2.1 domain_flow (`build/_deps/domain_flow-src`, header-only, `sw::dfa`)
+
+| Capability | State | Evidence |
+|---|---|---|
+| dfg IR (`DomainFlowGraph` / `Node` / `Edge`, ~40 TOSA/DNN ops) | ✅ mature | `include/dfa/domain_flow_graph.hpp`, `domain_flow_operator.hpp:10-54` |
+| `.dfg` **text** serialization (`save`/`load`, `<<`/`>>`) | ✅ works, round-trips | `domain_flow_graph.hpp:265-451`; samples `data/dfg/mobilenet_v2.dfg` |
+| TOSA-MLIR-text → dfg importer | ✅ real, but **MLIR-gated** | `tools/import/dfa_import_tosa.cpp`, `include/dfa/mlir/dialect/tosa.hpp` |
+| **ONNX importer** | ❌ none | repo-wide grep: zero onnx/protobuf hits |
+| **PyTorch/torch importer** | ❌ stub | `dfa_import_torch.cpp` is a copy of the TOSA one; `torch.hpp` dialect empty |
+| Polyhedral machinery (domain-of-computation, constraint sets, index spaces, simplex LP, schedules) | ⚠️ real primitives, **thin op coverage** | `domain_of_computation.hpp:116-390` implements only MATMUL / elementwise / CONSTANT |
+| Whole-graph scheduling / fabric generation | ❌ TODO stubs | `domain_flow_graph.hpp:158-170,232` |
+| **KPU-target lowering / backend / resource model** | ❌ none | hardware-agnostic; `sim/` is an empty placeholder |
+
+**Front-end reality:** the intended path is `ONNX/PyTorch → TOSA MLIR → dfg`, where
+the `ONNX → TOSA MLIR` step happens **upstream** (torch-mlir / iree-import) and is
+**not in domain_flow**. The in-repo importer starts at TOSA MLIR text and needs a
+full LLVM/MLIR 20.x build (`DOMAINFLOW_MLIR_TOOLS=ON`, default OFF).
+
+### 2.2 kpu-sim (`7a992ad`)
+
+| Concept the user named | State | Evidence |
+|---|---|---|
+| Executed graph = `KernelGraph` (12 op types) | ✅ | `include/sw/kpu/kernel_graph.hpp`, `kernel.hpp:19` |
+| **Weights live OUTSIDE the graph** (`NodeData` map of `std::vector<float>`) | ⚠️ impedance mismatch | `graph_csp_executor.hpp:41-52`, synthetic `rn_synth` `resnet18.hpp:71` |
+| `.dfg` reader (`DomainFlowGraphLoader`) | ⚠️ partial, **disconnected** | reads into `ComputationalGraph`, tensor metadata + topo-sort **stubbed**, not wired to the executor: `src/software/compiler/graph_loader.cpp:210,359` |
+| Second graph type `ComputationalGraph` (compiler-side) | ⚠️ parallel to `KernelGraph` | `include/sw/compiler/graph_loader.hpp:91` |
+| "DFX" = **two** layers: `sw::kpu::compiler::dfx` (`.kpu` object file, "PTX-for-KPU", serializable) + `sw::kpu::dfx` (DSL) | ⚠️ neither wired to `GraphCspExecutor` | `include/sw/compiler/dfx/dfx.hpp:1-24`, `dfx_object_file.hpp` |
+| Prototype `.dfg → .kpu → BoundSchedule` toolchain | ⚠️ exists in `tools/`, **not integrated** | `tools/compiler/kpu-kernel-compiler/main.cpp`, `tools/runtime/kpu-loader/schedule_binder.hpp:82` |
+| **ResourceManager** (HOST_MEMORY, L3/L2/L1, DMA/BM/STR alloc + r/w) | ✅ real allocator | `include/sw/kpu/resource_api.hpp:53`, `resource_manager.cpp` |
+| Data-path "personalization" = `ConcurrentTimingExecutor::Config` (fabric topology) | ✅ but rebuilt per-op | `concurrent_timing_executor.hpp:72`; `csp_op_runners.hpp:264` |
+| Host/DRAM memory model (`ExternalMemory`, HOST_MEMORY) | ✅ exists, **off the exec path** | `include/sw/memory/external_memory.hpp:32` |
+| **Program cache** (compiled-graph persistence) | ❌ none | only single-`Kernel` `KernelSerializer` + tools-only `.kpu` |
+| `KernelGraph`-level serialization | ❌ none | — |
+| Schedule generators (matmul/conv2d/…) → `ScheduleResult` on CSP executor | ✅ the de-facto "KPU program", but **generated per-op at runtime, never serialized** | `include/sw/kpu/timing/schedule/*` |
+
+**Execution seam (the integration point):**
+`GraphCspExecutor::run(const KernelGraph&, const std::vector<float>& input, const
+std::unordered_map<size_t,NodeData>& node_data, Size T)`
+(`graph_csp_executor.hpp:70`). A loaded model must materialize as
+`(KernelGraph, weights, input)`.
+
+---
+
+## 3. Gap analysis
+
+| # | Gap | Where | Severity |
+|---|-----|-------|----------|
+| G1 | **ONNX/PyTorch → dfg front-end** | domain_flow | 🔴 largest — nothing exists |
+| G2 | **Weights transport**: model file weights → resident in HOST_MEMORY; kernels reference by handle, not in-process `vector<float>` | kpu-sim (+ contract) | 🔴 cross-cutting refactor of the exec path |
+| G3 | **`.dfg` → executed `KernelGraph`** (not the dead-end `ComputationalGraph`); real tensor metadata + topo sort; full op-config mapping | kpu-sim | 🟠 |
+| G4 | **`.dfg` contract formalization** — versioned op set + shapes/dtypes + weight references shared by both repos | both | 🟠 the API between the repos |
+| G5 | **Operator-set alignment** — domain_flow `DomainFlowOperator` (~40, TOSA; no softmax/layernorm/attention) vs kpu-sim `KernelOpType` (12; has them) | both | 🟠 |
+| G6 | **Compile → serialized KPU program** (persist per-op schedules + tiling/dataflow strategy) | kpu-sim | 🟠 partly in `.kpu`/tools |
+| G7 | **Program cache** (keyed compiled-program store, load-from-cache fast path) | kpu-sim | 🟠 net-new |
+| G8 | **Op→resource binding / data-path personalization** wired to the real executor | kpu-sim | 🟠 prototype in `tools/schedule_binder.hpp`, unconnected |
+| G9 | **Convergence risk** — two graph types + two DFX layers + a tools/ pipeline; must connect, not add a fourth path | kpu-sim | 🟡 architectural discipline |
+| G10 | **Real-weight validation** — need an external reference (onnxruntime) since today's oracle is self-consistent synthetic | kpu-sim | 🟡 |
+
+---
+
+## 4. Decisions needed (before/early in the work)
+
+These change the shape of the plan; recommendations given, but they are yours.
+
+- **D1 — Front-end path (G1).**
+  (a) *MLIR route*: `ONNX → TOSA MLIR` (torch-mlir/iree upstream) → domain_flow's
+  existing TOSA importer. Pro: reuses real machinery, general. Con: heavy LLVM/MLIR
+  20.x dependency; torch dialect still unimplemented.
+  (b) *Direct route*: new `ONNX-protobuf → dfg` reader (no MLIR), curated to the op
+  set we already execute. Pro: light, no LLVM; fast to a working slice. Con:
+  reimplements op coverage; ONNX-opset churn.
+  **Recommendation:** start **(b)** for the CNN op set to get a working vertical
+  slice, keep **(a)** as the long-term general front-end. Revisit once transformer
+  models (which need the broader op set) are in scope.
+
+- **D2 — Weight transport format (G2).** ONNX initializers / PyTorch `state_dict`
+  → what on-disk blob does the sim load? **Recommendation:** a sidecar
+  `safetensors`-style flat blob (name → dtype/shape/offset) referenced by the
+  `.dfg` node attributes; deposited into `ExternalMemory`/HOST_MEMORY via
+  `ResourceManager`. Avoids embedding large tensors in the `.dfg` text.
+
+- **D3 — Canonical IR = domain_flow's `DomainFlowGraph`.** *(Resolved: standardize on
+  the compiler's IR — see §4a.)* domain_flow is the compiler; ONNX imports into
+  `DomainFlowGraph`, the compiler passes rewrite it, and it serializes as `.dfg`.
+  kpu-sim consumes it and lowers it to an executable KPU program. `ComputationalGraph`
+  retires; `KernelGraph` is demoted to a *generated* lowering artifact (never
+  hand-authored), on a path to removal.
+
+- **D4 — Compiled-program artifact (G6).** Reuse the existing **`sw::kpu::compiler::dfx`
+  `.kpu` object file** (already "serializable, PTX-for-KPU") as the compiled-program
+  format rather than inventing one; make the schedule-generators emit into it. This
+  is the *lowered* form — distinct from the `DomainFlowGraph` source (§4a).
+
+### 4a. Canonical IR & dependency direction (the D3 architecture)
+
+Two representations, cleanly separated — this is the crux of the design:
+
+| Level | Representation | Owner | Carries |
+|---|---|---|---|
+| **Source / compute IR** | `sw::dfa::DomainFlowGraph` (`.dfg`) | **domain_flow (canonical)** | operators, shapes/dtypes, op attributes (conv stride/pad, matmul dims), weight *references* |
+| **Lowered executable form** | `.kpu` object / CSP schedules | kpu-sim (derived) | tiling `T`, dataflow strategy, per-op schedules, resource binding |
+
+`KernelGraph` today conflates both roles and is *hand-authored*; under D3 it stops
+being a source of truth. The migration (§6) makes `DomainFlowGraph` the only graph
+that is imported, rewritten, and serialized; kpu-sim **lowers** it to execution.
+This dissolves gaps **G3, G5, G9** (no dual graph, no op-mapping impedance, no path
+proliferation) at the cost of one refactor (executor consumes/derives-from
+`DomainFlowGraph`).
+
+**Dependency direction.** Making `DomainFlowGraph` canonical makes domain_flow a
+**hard dependency of kpu-sim's execution path** (today it is *optional*,
+`KPU_HAS_DOMAIN_FLOW`). This is acceptable and light **because** the relevant header
+`<dfa/dfg.hpp>` is **header-only and MLIR-free** (the MLIR bridge `dfa_mlir.hpp` is
+separate and stays out). **Prerequisite:** domain_flow's optional tools
+(`DOMAINFLOW_MATPLOT_TOOLS`→Matplot++, `DOMAINFLOW_VISUALIZATION`→CGAL/Qt6,
+`DOMAINFLOW_MLIR_TOOLS`→LLVM) must be forced **OFF** in
+`cmake/DomainFlowIntegration.cmake` so the hard dependency never drags in heavy
+packages — this also fixes the current Windows configure breakage.
+
+---
+
+## 5. Target architecture (seam-by-seam)
+
+| Stage | Owner | Input → Output | Reuse / build |
+|---|---|---|---|
+| **[A]** front-end | domain_flow | `.onnx`/`.pt` → `.dfg` + weight blob | build (D1); weights per D2 |
+| **[B]** import | kpu-sim | `.dfg` + weights → `KernelGraph` + HOST_MEMORY-resident weights | extend `DomainFlowGraphLoader`; new weight loader |
+| **[C]** compile | kpu-sim | `KernelGraph` → compiled program (`.kpu`) | reuse schedule generators + `dfx` object file |
+| **[D]** cache | kpu-sim | program ↔ cache keyed by (op sig, shapes, dtype, fabric cfg) | net-new (small) |
+| **[E]** bind/exec | kpu-sim | program → bound to `ResourceManager` fabric → run | productionize `ScheduleBinder`; wire to `GraphCspExecutor` |
+
+---
+
+## 6. Phased implementation strategy
+
+Each phase ends with a demonstrable milestone (DoD). The spine
+(`DomainFlowGraph → lower → execute`) is stood up **before** the ONNX front-end
+(Phase 2) by generating a golden `.dfg` from an existing hand-built graph — this
+de-risks the canonical-IR migration and isolates the heaviest external gap (G1).
+Per D2, the early phases carry weight **shapes**, not values (placeholder/synthetic
+values); real weight values + numerical validation are Phase 5.
+
+### Phase 0 — Foundation: build hygiene + contract + lowering spine  *(kpu-sim)*
+- **Build hygiene** (prereq for the hard dep, §4a): force domain_flow's optional
+  tools OFF in `DomainFlowIntegration.cmake` (unblocks Windows; keeps the dep
+  header-only + MLIR-free).
+- Formalize the **`.dfg` contract v1**: operator mapping (`DomainFlowOperator` ↔
+  kpu-sim runners), tensor shape/dtype encoding, weight-*reference* convention.
+- Stand up the **lowering spine** `DomainFlowGraph → KernelGraph` (KernelGraph now a
+  *generated* execution artifact, D3/§4a) feeding the existing `GraphCspExecutor`.
+  Add a one-time `KernelGraph → DomainFlowGraph` exporter to mint golden `.dfg`s.
+- **DoD:** `build_resnet18`'s graph → export `DomainFlowGraph` → lower → execute →
+  **identical topology + cycle counts** to the direct build. Round-trips the contract.
+
+### Phase 1 — `.dfg` on disk → execution; retire the dual graph  *(kpu-sim)*
+- Productionize `DomainFlowGraphLoader` to load `.dfg` → `DomainFlowGraph` (real
+  tensor metadata, real topo sort). **Retire `ComputationalGraph`** — the loader now
+  yields the canonical IR, lowered by Phase 0's spine.
+- **DoD:** `m2_resnet --from-dfg model.dfg` runs ResNet-18 from a disk `.dfg`
+  (shapes real, values synthetic); timing/utilization match the direct build.
+
+### Phase 2 — Direct `ONNX → dfg` front-end  *(domain_flow; the big gap G1)*
+- Per D1: implement a **direct ONNX-protobuf → `DomainFlowGraph`** reader (no MLIR)
+  for the CNN op set — map ONNX ops → `DomainFlowOperator`, read tensor **shapes**
+  from initializers/value-info (values optional at this stage, D2).
+- Fill any `DomainFlowOperator` domain coverage the reader needs (G5).
+- **DoD:** a stock `resnet18.onnx` (torchvision) → `.dfg` → runs on the sim with
+  **correct topology + timing** (numerical output *not* yet validated — Phase 5).
+
+### Phase 3 — Compile to a serialized KPU program + program cache  *(kpu-sim; G6, G7)*
+- Make the schedule generators emit a **serialized** compiled program (reuse the
+  `dfx` `.kpu` object file, D4): per-op schedules + tiling + dataflow strategy — the
+  *lowered* form (§4a).
+- Build the program cache: key = (op signature, shapes, dtype, fabric config) →
+  compiled program; load-from-cache on repeat.
+- **DoD:** second run of the same model loads compiled kernels from cache (no
+  recompile); cache hit/miss reported.
+
+### Phase 4 — Resource binding / data-path personalization  *(kpu-sim; G8)*
+- Productionize `ScheduleBinder`: bind compiled-program ops → concrete fabric
+  resources (DMA/BM/STR ids, L3/L2/L1 allocations) via `ResourceManager` =
+  "personalize the data path"; wire the bound program into `GraphCspExecutor`.
+- **DoD:** a cached, bound program executes on the personalized fabric; timing
+  (utilization/cycles) matches the direct path.
+
+### Phase 5 — Weight values, numerical validation & model zoo  *(both)*
+- **Real weight values** (the deferred half of D2): load weight blob into
+  `ExternalMemory`/HOST_MEMORY via `ResourceManager`; kernels reference by handle.
+- Add an **onnxruntime reference** path; validate real-weight numerical output (G10).
+- Extend to transformer ops (softmax/layernorm/attention — kpu-sim has them,
+  `DomainFlowOperator` must be extended), and the milestone-ladder models; retire the
+  synthetic builders as they are superseded.
+- **DoD:** ≥2 real models beyond ResNet run from disk with reference-validated output.
+
+---
+
+## 7. Recommended first increment (thin vertical slice)
+
+**Phase 0 for ResNet-18: `DomainFlowGraph` exported from `build_resnet18`, lowered,
+executed.** Proves the canonical-IR spine — build hygiene → `.dfg` contract →
+`DomainFlowGraph` → lowering → `GraphCspExecutor` → identical topology + cycles —
+**without** the ONNX front-end (G1) and **without** the weight-values refactor
+(topology + timing only, D2). Guard it with the existing `resnet_regression` harness
+(identical cycles ⇒ the round-trip is lossless). Phase 1 then moves the source to a
+disk `.dfg` and retires `ComputationalGraph`; Phase 2's ONNX reader plugs in ahead of
+the proven spine with low risk.
+
+## 8. Risks & mitigations
+
+- **LLVM/MLIR weight (D1).** The "real" front-end needs LLVM/MLIR 20.x; also the
+  cause of the current Windows `Matplot++`/`CGAL` configure breakage (domain_flow's
+  optional tools). *Mitigation:* direct-ONNX route for the first slice; force
+  domain_flow's optional tool flags OFF in `DomainFlowIntegration.cmake` so the
+  library integration never drags in MLIR/CGAL/Matplot++.
+- **Path proliferation (G9).** Two graph types, two DFX layers, a disconnected
+  tools/ pipeline. *Mitigation:* D3 — canonical `DomainFlowGraph` source IR + the
+  `dfx` `.kpu` lowered artifact; retire `ComputationalGraph`, demote `KernelGraph` to
+  generated, connect the tools/ prototype rather than fork it.
+- **Hard-dependency + build hygiene (§4a).** Canonical `DomainFlowGraph` makes
+  domain_flow a hard dep of the exec path. *Mitigation:* it is header-only + MLIR-free;
+  force domain_flow's optional tools OFF in `DomainFlowIntegration.cmake` (Phase 0
+  prereq — also fixes the Windows Matplot++/CGAL breakage).
+- **Weight-values refactor blast radius (G2b).** Deferred to Phase 5 per D2; the early
+  milestones use shapes only, so the exec-seam refactor is not on the critical path.
+- **Cross-repo coordination.** Front-end lands in domain_flow, the rest in kpu-sim,
+  coupled only by the versioned `.dfg` contract (G4). *Mitigation:* freeze the contract
+  in Phase 0 before parallelizing.
+- **Executor migration risk.** Making `DomainFlowGraph` canonical means the tested
+  `GraphCspExecutor` path changes. *Mitigation:* the Phase 0 lowering keeps the
+  executor unchanged (fed by a *generated* `KernelGraph`); `resnet_regression` guards
+  identical cycles.
+
+## 9. Open questions (remaining, D1–D4 resolved)
+
+1. `.dfg` contract versioning: extend domain_flow's existing text format in place, or
+   introduce a versioned schema alongside it? (Affects Phase 0.)
+2. Epic sub-issue granularity — one per phase, or per phase-DoD?
+3. Fine sequencing vs. M4 (agreed: run alongside) — which phases interleave with M4
+   vs. run after it?

--- a/docs/plans/model-ingestion-compilation-epic.md
+++ b/docs/plans/model-ingestion-compilation-epic.md
@@ -1,6 +1,6 @@
 # Epic: Real-DNN Ingestion & Compilation (ONNX/PyTorch → domain_flow → KPU)
 
-**Status:** Approved direction (decisions D1–D4 resolved 2026-07-19) — implementation not started.
+**Status:** Approved direction (decisions D1–D5 resolved 2026-07-19) — implementation not started.
 **Author:** planning session 2026-07-19.
 **Scope:** two repos — `kpu-sim` and `branes-ai/domain_flow` (consumed via FetchContent).
 
@@ -25,8 +25,14 @@
 
 Replace the hand-written DNN facsimiles (`resnet18.hpp`, `mobilenetv2.hpp`,
 `efficientnet.hpp`, `m2_resnet.cpp`) with a real pipeline: **load a trained DNN from
-disk (ONNX / PyTorch), compile it through the domain_flow compiler into a cached
-binary KPU program, and execute that program on the simulator.**
+disk, compile it through the domain_flow compiler into a cached binary KPU program,
+and execute that program on the simulator.**
+
+**Input scope:** the ingestion path for this epic is **ONNX only** (D1: direct
+`ONNX → DomainFlowGraph`). **PyTorch is supported by exporting to ONNX upstream**
+(`torch.onnx` / `torch.export → ONNX`), *not* by a native `.pt`/TorchScript reader —
+domain_flow's `torch` importer is a stub (§2.1), and a native path is a later,
+separate milestone. `.pt` in the diagram below denotes that upstream export step.
 
 **Separation of concerns (the load-bearing principle).** domain_flow is the
 *compiler*; kpu-sim is the *hardware simulator*. **All compilation/lowering happens
@@ -98,7 +104,8 @@ full LLVM/MLIR 20.x build (`DOMAINFLOW_MLIR_TOOLS=ON`, default OFF).
 | Host/DRAM memory model (`ExternalMemory`, HOST_MEMORY) | ✅ exists, **off the exec path** | `include/sw/memory/external_memory.hpp:32` |
 | **Program cache** (compiled-graph persistence) | ❌ none | only single-`Kernel` `KernelSerializer` + tools-only `.kpu` |
 | `KernelGraph`-level serialization | ❌ none | — |
-| Schedule generators (matmul/conv2d/…) → `ScheduleResult` on CSP executor | ✅ the de-facto "KPU program", but **generated per-op at runtime, never serialized** | `include/sw/kpu/timing/schedule/*` |
+| Schedule generators (matmul/conv2d/…) → `ScheduleResult` on the **CSP cycle-accurate** executor (`ConcurrentTimingExecutor`) | ✅ the benchmarked timing path, but **generated per-op at runtime, never serialized** | `include/sw/kpu/timing/schedule/*` |
+| **ISA binary program path**: `DMProgram` (DMInstruction stream) → **`.kpubin`** (versioned: `DMPROGRAM_MAGIC` + `DMPROGRAM_VERSION`, magic-checked) / `.kpujson`, via `ProgramSerializer`; loaded by **`kpu-loader`**; executed by `IProgramExecutor` (**Behavioral / Transactional** wrappers) | ✅ a real, **serialized, versioned** binary + reader + loader + executors — but on behavioral/transactional fidelity, **not** the CSP cycle-accurate model | `include/sw/kpu/isa/program_serializer.hpp`, `behavioral_program_executor.hpp`, `program_executor_interface.cpp`, `tools/runtime/kpu-loader/` |
 
 **Execution seam.** Today: `GraphCspExecutor::run(KernelGraph, input, node_data, T)`
 (`graph_csp_executor.hpp:70`) — but note this seam *generates* the schedule inline,
@@ -119,7 +126,7 @@ model is therefore the **binary program reader** (P0) plus `ResourceManager` set
 | G3 | **`.dfg` → executed `KernelGraph`** (not the dead-end `ComputationalGraph`); real tensor metadata + topo sort; full op-config mapping | kpu-sim | 🟠 |
 | G4 | **`.dfg` contract formalization** — versioned op set + shapes/dtypes + weight references shared by both repos | both | 🟠 the API between the repos |
 | G5 | **Operator-set alignment** — domain_flow `DomainFlowOperator` (~40, TOSA; no softmax/layernorm/attention) vs kpu-sim `KernelOpType` (12; has them) | both | 🟠 |
-| G6 | **Compile → serialized binary KPU program** (schedules + tiling/dataflow strategy) — the *compiler backend* | domain_flow (relocated) + `.kpu` format owned by kpu-sim | 🟠 backend logic exists in kpu-sim's generators; must relocate + serialize |
+| G6 | **Compile → serialized binary KPU program** (schedules + tiling/dataflow strategy) — the *compiler backend* | domain_flow (relocated) + `.kpubin` format owned by kpu-sim | 🟠 backend logic exists in kpu-sim's generators; must relocate + serialize |
 | G6b | **Binary program reader/executor + KPU functional-spec conformance** | kpu-sim | 🟠 net-new; `ScheduleExecutor` executes, but nothing deserializes a program |
 | G7 | **Program cache** (keyed compiled-program store, load-from-cache fast path) | kpu-sim | 🟠 net-new |
 | G8 | **Op→resource binding / data-path personalization** wired to the real executor | kpu-sim | 🟠 prototype in `tools/schedule_binder.hpp`, unconnected |
@@ -157,19 +164,28 @@ These change the shape of the plan; recommendations given, but they are yours.
   graph-walking schedule-generation are *compiler-backend* concerns (§5) — the
   simulator runtime keeps only the executor.
 
-- **D4 — Compiled-program artifact = the binary KPU program.** Reuse the existing
-  **`sw::kpu::compiler::dfx` `.kpu` object file** (already "serializable, PTX-for-KPU")
-  as the binary-program format rather than inventing one. It is the *lowered* form
-  (D5), distinct from the `DomainFlowGraph` source.
+- **D4 — Canonical binary artifact = the ISA `.kpubin` (`DMProgram`).** The repo
+  already has a **serialized, versioned** ISA binary: `DMProgram` →
+  `ProgramSerializer` → `.kpubin` (magic + `DMPROGRAM_VERSION`) / `.kpujson`, with a
+  `kpu-loader` and `IProgramExecutor`s. **This is the canonical binary KPU program**
+  (D5) — Phase 0 builds on it, not the greenfield `dfx` `.kpu` object. *Two things to
+  reconcile (Phase 0 decisions, not yet settled):* (1) the higher-level `dfx` `.kpu`
+  object file — does the compiler emit it as an intermediate that lowers to `.kpubin`,
+  or is it dropped? (2) `.kpubin`/`DMProgram` executes today on **behavioral/
+  transactional** models, while the **cycle-accurate CSP** timing model (the
+  benchmarked one) runs a non-serialized `ScheduleResult` — so either the CSP executor
+  gains a `DMProgram`/`.kpubin` front-end, or the binary format carries a
+  schedule/tiling section the CSP path consumes, or the two paths unify. Resolving
+  this is the heart of Phase 0/2.
 
 - **D5 — The KPU binary functional spec is the contract; kpu-sim owns it, the
-  compiler targets it.** kpu-sim defines the binary program format + the execution
-  semantics (the "ISA": the sequence of DMA/BlockMover/Streamer/COMPUTE/DRAIN/
-  WRITEBACK/STORE operations with tile + resource operands — i.e. a serialized
-  `ScheduleResult` + fabric config + resource bindings). domain_flow emits binaries
-  conforming to it. **kpu-sim reads and executes; it never compiles.** *(Recommended:
-  formalize the format as a versioned spec doc + a golden-binary conformance suite so
-  the two repos stay in lockstep.)*
+  compiler targets it.** The spec is embodied by the existing ISA binary
+  (`DMProgram`/`.kpubin`, D4): the instruction stream of DMA/BlockMover/Streamer/
+  COMPUTE/DRAIN/WRITEBACK/STORE ops with tile + resource operands + memory map, with a
+  versioned header. domain_flow emits binaries conforming to it. **kpu-sim reads and
+  executes; it never compiles.** *(Recommended: promote the existing `.kpubin` header
+  to the full versioned spec per `dfg-kpu-versioning.md`, with a golden-binary
+  conformance suite so the two repos stay in lockstep.)*
 
 ### 4a. The compiler/hardware boundary & the two artifacts (D3 + D5)
 
@@ -178,7 +194,7 @@ Two artifacts, two owners, one hard boundary — this is the crux of the design:
 | Artifact | Representation | Produced by | Consumed by | Carries |
 |---|---|---|---|---|
 | **Source / compute IR** | `sw::dfa::DomainFlowGraph` (`.dfg`) | domain_flow front-end | domain_flow passes | operators, shapes/dtypes, op attrs, weight *references* |
-| **Binary KPU program** (the contract) | `.kpu` object (per the KPU binary functional spec) | **domain_flow compiler** (lowering) | **kpu-sim** (execution) | the op/tile/resource *schedule* — the "ISA" the KPU runs |
+| **Binary KPU program** (the contract) | `.kpubin` (`DMProgram`, per the KPU binary functional spec) | **domain_flow compiler** (lowering) | **kpu-sim** (execution) | the op/tile/resource *schedule* — the "ISA" the KPU runs |
 | Model weights/data | weight blob → HOST_MEMORY | (model file) | kpu-sim `ResourceManager` | tensor values (Phase 5) / shapes (early) |
 
 The boundary is the **binary KPU program**. Everything *left* of it (ONNX import,
@@ -214,15 +230,20 @@ The hard boundary is between **[C]** and **[D]**: the binary KPU program.
 
 | Stage | Owner | Input → Output | Reuse / build |
 |---|---|---|---|
-| **[A]** front-end | **domain_flow** | `.onnx`/`.pt` → `DomainFlowGraph` | new direct ONNX reader (D1) |
+| **[A]** front-end | **domain_flow** | `.onnx` → `DomainFlowGraph` | new direct ONNX reader (D1). `.pt` is out of scope — export to ONNX upstream (§ Goal note) |
 | **[B]** passes / KPU backend | **domain_flow** | `DomainFlowGraph` → tiled/scheduled lowering | relocate kpu-sim's schedule generators here (shared `kpu-backend`) |
-| **[C]** emit binary program | **domain_flow** | lowering → `.kpu` binary (per the spec, D5) | reuse the `dfx` `.kpu` object format |
-| **[D]** program cache | kpu-sim | `.kpu` ↔ cache keyed by (op sig, shapes, dtype, fabric cfg) | net-new (small) |
-| **[E]** load + execute | **kpu-sim** | read `.kpu` + weights; `ResourceManager` sets up fabric; run | reader + productionize `ScheduleBinder`; keep `ScheduleExecutor`/`ConcurrentTimingExecutor` |
+| **[C]** emit binary program | **domain_flow** | lowering → **`.kpubin`** (`DMProgram`, per the spec, D4/D5) | reuse `ProgramSerializer`'s versioned format |
+| **[D]** program cache | kpu-sim | `.kpubin` ↔ cache keyed by *(op sig, shapes, dtype, fabric cfg, **ISA/ABI version, compiler version, opset+type-sys version, target profile**)* | net-new (small) |
+| **[E]** load + execute | **kpu-sim** | read `.kpubin` (via `ProgramSerializer`/`kpu-loader`) + weights; `ResourceManager` sets up fabric; run | reader exists; reconcile ISA-executor vs CSP timing path (D4); productionize `ScheduleBinder` |
 
-**Spec doc (D5):** the `.kpu` binary format + execution semantics are written up as
-the *KPU binary functional spec* (versioned), with a golden-binary conformance suite
-run by kpu-sim — the single artifact that keeps compiler and simulator in lockstep.
+`.dfg` (the `DomainFlowGraph` source IR) is **compiler-internal**; kpu-sim's runtime
+**execution** input is `.kpubin`, not `.dfg`. kpu-sim reads model *data/weights* into
+`HOST_MEMORY` (Phase 5) but does not consume `.dfg` to execute.
+
+**Spec doc (D5):** the `.kpubin` binary format + execution semantics are written up as
+the *KPU binary functional spec* (versioned per `dfg-kpu-versioning.md`), with a
+golden-binary conformance suite run by kpu-sim — the single artifact keeping compiler
+and simulator in lockstep.
 
 ---
 
@@ -241,41 +262,45 @@ the compiler side (ISA producer) proceed in parallel against the binary contract
 ### Phase 0 — KPU binary program spec + simulator reader/executor  *(kpu-sim)*
 - **Build hygiene** (§4a prereq): force domain_flow's optional tools OFF in
   `DomainFlowIntegration.cmake` (unblocks Windows; keeps the dep header-only + MLIR-free).
-- Define & version the **KPU binary program format (D5)**: serialize a
-  `ScheduleResult` (+ fabric config + resource bindings) into the `dfx` `.kpu` object;
-  write the *KPU binary functional spec* doc. Apply the versioning requirements
-  (R1–R9, `.kpu` §3) from `dfg-kpu-versioning.md` — version stamp + `min_consumer`
-  gate + profile/capability dimension + golden-binary conformance corpus.
-- Add a **program reader** in kpu-sim that loads a `.kpu` and runs it through the
-  existing `ScheduleExecutor`/`ConcurrentTimingExecutor` — **no inline generation**.
-- **DoD:** the ResNet schedule → serialize `.kpu` → read back → execute → **identical
-  cycles** to the inline path (guarded by `resnet_regression`). Proves kpu-sim
-  consumes a binary program.
+- Promote the **existing `.kpubin` (`DMProgram`) format (D4)** to the versioned **KPU
+  binary functional spec (D5)**: extend `ProgramSerializer`'s header per
+  `dfg-kpu-versioning.md` (R1–R9 + `.kpu`/`.kpubin` §3 — version stamp + `min_consumer`
+  gate + profile/capability dimension) and write the spec doc + golden-binary
+  conformance corpus.
+- **Reconcile the two execution paths (the crux, D4):** the `.kpubin`/`DMProgram`
+  reader + `IProgramExecutor` exist but on behavioral/transactional models; the
+  cycle-accurate CSP path (`ConcurrentTimingExecutor`) runs a non-serialized
+  `ScheduleResult`. Decide + implement: give the CSP path a `.kpubin` front-end, or
+  carry the schedule in the binary, or unify — so kpu-sim executes a *deserialized*
+  program with **no inline generation**.
+- **DoD:** the ResNet program → serialize `.kpubin` → read back → execute on the CSP
+  timing model → **identical cycles** to the inline path (guarded by
+  `resnet_regression`). Proves kpu-sim consumes a binary program.
 
 ### Phase 1 — Hardware-identical execution: ResourceManager setup + host memory  *(kpu-sim)*
 - Execute the binary program through the **hardware flow**: `ResourceManager`
   allocates/sets up fabric resources per the program, deposits DNN data (shapes) in
   `HOST_MEMORY`, signals "ready → start", executes — the same APIs a real KPU exposes.
-- **DoD:** `m2_resnet --run-program model.kpu` executes a serialized program end-to-end
+- **DoD:** `m2_resnet --run-program model.kpubin` executes a serialized program end-to-end
   through the resource-manager APIs; timing matches the direct path.
 
 ### Phase 2 — Relocate the KPU compiler backend to domain_flow  *(domain_flow / shared lib)*
 - Move kpu-sim's schedule-generation (tiling/scheduling/dataflow strategy — the
   matmul/conv2d/… generators + graph-walk) into domain_flow (or a shared
-  `kpu-backend` library the compiler links). domain_flow: `DomainFlowGraph` → `.kpu`
+  `kpu-backend` library the compiler links). domain_flow: `DomainFlowGraph` → `.kpubin`
   binary conforming to the spec (D5). Retire kpu-sim's `ComputationalGraph`.
-- **DoD:** domain_flow emits a `.kpu` from a `DomainFlowGraph` that kpu-sim executes
+- **DoD:** domain_flow emits a `.kpubin` from a `DomainFlowGraph` that kpu-sim executes
   with **identical results to P0's golden** (conformance suite passes).
 
 ### Phase 3 — Direct `ONNX → DomainFlowGraph` front-end  *(domain_flow; gap G1)*
 - Per D1: direct ONNX-protobuf → `DomainFlowGraph` reader (no MLIR) for the CNN op
   set — map ONNX ops → `DomainFlowOperator`, read tensor **shapes** (values optional,
-  D2). Then P2's backend compiles it to `.kpu`.
-- **DoD:** torchvision `resnet18.onnx` → `DomainFlowGraph` → `.kpu` → runs on kpu-sim
+  D2). Then P2's backend compiles it to `.kpubin`.
+- **DoD:** torchvision `resnet18.onnx` → `DomainFlowGraph` → `.kpubin` → runs on kpu-sim
   with **correct topology + timing** (numerical output not yet validated — P5).
 
 ### Phase 4 — Program cache + data-path personalization  *(kpu-sim; G7, G8)*
-- **Program cache**: keyed compiled `.kpu` programs (op sig, shapes, dtype, fabric
+- **Program cache**: keyed compiled `.kpubin` programs (op sig, shapes, dtype, fabric
   cfg) → fast-load on repeat. Productionize `ScheduleBinder` to bind program ops →
   concrete fabric resources (DMA/BM/STR ids, L3/L2/L1) = "personalize the data path".
 - **DoD:** second run fast-loads from cache (no recompile); the bound program runs on
@@ -292,7 +317,7 @@ the compiler side (ISA producer) proceed in parallel against the binary contract
 
 ## 7. Recommended first increment (thin vertical slice)
 
-**Phase 0 for ResNet-18: serialize the ResNet schedule to a `.kpu` binary, read it
+**Phase 0 for ResNet-18: serialize the ResNet schedule to a `.kpubin` binary, read it
 back, and execute it.** Proves the pivot — build hygiene → binary program format
 (D5) → kpu-sim reader → `ScheduleExecutor` → **identical cycles** to the inline path
 — **without** the compiler backend (P2), the ONNX front-end (P3), or weight values
@@ -326,11 +351,11 @@ same binary, validated against P0's golden.
   executor unchanged (fed by a *generated* `KernelGraph`); `resnet_regression` guards
   identical cycles.
 
-## 9. Open questions (remaining, D1–D4 resolved)
+## 9. Open questions (remaining, D1–D5 resolved)
 
 1. ~~`.dfg` contract versioning~~ — **analyzed** in `dfg-kpu-versioning.md`: version
    `.dfg` **in place** (3 axes + `min_consumer` gate + profile dimension + golden
-   corpus), and version the `.kpu` binary from day one. Feeds Phase 0.
+   corpus), and version the `.kpubin` binary from day one. Feeds Phase 0.
 2. Epic sub-issue granularity — one per phase, or per phase-DoD?
 3. Fine sequencing vs. M4 (agreed: run alongside) — which phases interleave with M4
    vs. run after it?

--- a/docs/plans/model-ingestion-compilation-epic.md
+++ b/docs/plans/model-ingestion-compilation-epic.md
@@ -8,12 +8,16 @@
 - **D1 — direct `ONNX → dfg` reader** (no LLVM/MLIR) for the front-end.
 - **D2 — topology + timing first**: the first milestone needs weight *shapes*, not
   *values*; numerical trained-weight fidelity is a later milestone.
-- **D3 — canonical IR = domain_flow's `DomainFlowGraph`** (not kpu-sim's
-  `KernelGraph`). domain_flow is the compiler; its IR is the single source of truth.
-  `ComputationalGraph` retires; `KernelGraph` is demoted to a generated lowering
-  artifact (and a candidate for eventual removal). See §4a.
+- **D3 — canonical *source* IR = domain_flow's `DomainFlowGraph`** (the compiler's
+  IR). **The compiler lowers it to a binary KPU program; kpu-sim does not compile.**
+  `ComputationalGraph` retires; kpu-sim's schedule-generation is compiler-backend work
+  that relocates to domain_flow. See §4a.
 - **D4 — file as a formal epic + per-phase sub-issues, run alongside the M4
   milestone** (attention → flash attention).
+- **D5 — kpu-sim is the KPU *hardware simulator*, not a compiler.** It owns/defines
+  the **KPU binary functional spec** (the binary program format + execution
+  semantics); the domain_flow compiler *targets* it; kpu-sim *reads and executes* the
+  binary with hardware-identical APIs. This is the crux — see §1 and §4a.
 
 ---
 
@@ -21,29 +25,41 @@
 
 Replace the hand-written DNN facsimiles (`resnet18.hpp`, `mobilenetv2.hpp`,
 `efficientnet.hpp`, `m2_resnet.cpp`) with a real pipeline: **load a trained DNN from
-disk (ONNX / PyTorch), compile it through domain_flow into cached KPU programs, and
-execute it on the simulator with real weights.**
+disk (ONNX / PyTorch), compile it through the domain_flow compiler into a cached
+binary KPU program, and execute that program on the simulator.**
 
-Target end-to-end flow:
+**Separation of concerns (the load-bearing principle).** domain_flow is the
+*compiler*; kpu-sim is the *hardware simulator*. **All compilation/lowering happens
+in domain_flow**, which emits a **binary KPU program** ("domain flow program")
+conforming to the **KPU binary functional spec**. **kpu-sim does not compile** — it
+*reads and executes* that binary with **exactly the APIs a real KPU exposes**
+(the `ResourceManager` sets up resources and signals "ready/start"; the fabric
+executes). The binary program is the contract: **kpu-sim owns/defines the spec, the
+compiler targets it.**
 
 ```
   ONNX / PyTorch (.onnx / .pt)
-     │  [A] domain_flow front-end: model file → domain flow graph
-     ▼
-  .dfg  (+ weight blob)                         ◄── the cross-repo interchange contract
-     │  [B] kpu-sim import: .dfg → KernelGraph;  weights → HOST_MEMORY
-     ▼
-  KernelGraph + weights resident in host memory (ResourceManager)
-     │  [C] compiler pass: operators → KPU "domain flow programs" (schedules)
-     ▼
-  compiled program (dfx / .kpu)  →  [D] program cache
-     │  [E] loader: bind program → fabric resources  =  "personalize the data path"
-     ▼
-  execute on GraphCspExecutor / ConcurrentTimingExecutor  (real weights, timing model)
+   ┌───────────────────────────────────────────────── domain_flow  (COMPILER) ──┐
+   │  [A] direct ONNX → DomainFlowGraph   (canonical source IR, D1/D3)           │
+   │  [B] compiler passes: rewrite / tile / schedule / KPU-backend lowering      │
+   │  [C] emit BINARY KPU PROGRAM  (the "domain flow program", per the spec)     │
+   └───────────────────────────────┬─────────────────────────────────────────────┘
+                                    │  binary program (+ model weights/data)
+                                    ▼           ◄── KPU binary functional spec = the contract
+   ┌───────────────────────────────────────────────── kpu-sim  (HARDWARE SIM) ──┐
+   │  [D] program cache: fast-load precompiled kernels                           │
+   │  [E] ResourceManager sets up resources / "KPU ready → start";               │
+   │      read the binary program; deposit DNN data in HOST_MEMORY;              │
+   │      execute on the transactional/functional timing model —                 │
+   │      SAME APIs as the real KPU. kpu-sim does NOT lower/compile.             │
+   └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-The five stages **[A]–[E]** are the user's description, mapped to concrete seams
-below.
+kpu-sim's runtime keeps only the **executor** (today `ScheduleExecutor` +
+`ConcurrentTimingExecutor`), now fed by a *deserialized* binary program instead of
+one generated inline. The scheduling/tiling logic currently in kpu-sim's schedule
+generators is *compiler-backend* work that relocates to domain_flow (or a shared
+KPU-backend library) — see §5.
 
 ---
 
@@ -84,11 +100,13 @@ full LLVM/MLIR 20.x build (`DOMAINFLOW_MLIR_TOOLS=ON`, default OFF).
 | `KernelGraph`-level serialization | ❌ none | — |
 | Schedule generators (matmul/conv2d/…) → `ScheduleResult` on CSP executor | ✅ the de-facto "KPU program", but **generated per-op at runtime, never serialized** | `include/sw/kpu/timing/schedule/*` |
 
-**Execution seam (the integration point):**
-`GraphCspExecutor::run(const KernelGraph&, const std::vector<float>& input, const
-std::unordered_map<size_t,NodeData>& node_data, Size T)`
-(`graph_csp_executor.hpp:70`). A loaded model must materialize as
-`(KernelGraph, weights, input)`.
+**Execution seam.** Today: `GraphCspExecutor::run(KernelGraph, input, node_data, T)`
+(`graph_csp_executor.hpp:70`) — but note this seam *generates* the schedule inline,
+which is the compiler-backend work that relocates out (§4a). The **target** seam is
+one level down: `ScheduleExecutor` running a *deserialized* `ScheduleResult` (the
+binary program) on `ConcurrentTimingExecutor`. The integration point for a loaded
+model is therefore the **binary program reader** (P0) plus `ResourceManager` setup
+(P1) — not `GraphCspExecutor`.
 
 ---
 
@@ -101,7 +119,8 @@ std::unordered_map<size_t,NodeData>& node_data, Size T)`
 | G3 | **`.dfg` → executed `KernelGraph`** (not the dead-end `ComputationalGraph`); real tensor metadata + topo sort; full op-config mapping | kpu-sim | 🟠 |
 | G4 | **`.dfg` contract formalization** — versioned op set + shapes/dtypes + weight references shared by both repos | both | 🟠 the API between the repos |
 | G5 | **Operator-set alignment** — domain_flow `DomainFlowOperator` (~40, TOSA; no softmax/layernorm/attention) vs kpu-sim `KernelOpType` (12; has them) | both | 🟠 |
-| G6 | **Compile → serialized KPU program** (persist per-op schedules + tiling/dataflow strategy) | kpu-sim | 🟠 partly in `.kpu`/tools |
+| G6 | **Compile → serialized binary KPU program** (schedules + tiling/dataflow strategy) — the *compiler backend* | domain_flow (relocated) + `.kpu` format owned by kpu-sim | 🟠 backend logic exists in kpu-sim's generators; must relocate + serialize |
+| G6b | **Binary program reader/executor + KPU functional-spec conformance** | kpu-sim | 🟠 net-new; `ScheduleExecutor` executes, but nothing deserializes a program |
 | G7 | **Program cache** (keyed compiled-program store, load-from-cache fast path) | kpu-sim | 🟠 net-new |
 | G8 | **Op→resource binding / data-path personalization** wired to the real executor | kpu-sim | 🟠 prototype in `tools/schedule_binder.hpp`, unconnected |
 | G9 | **Convergence risk** — two graph types + two DFX layers + a tools/ pipeline; must connect, not add a fourth path | kpu-sim | 🟡 architectural discipline |
@@ -130,131 +149,155 @@ These change the shape of the plan; recommendations given, but they are yours.
   `.dfg` node attributes; deposited into `ExternalMemory`/HOST_MEMORY via
   `ResourceManager`. Avoids embedding large tensors in the `.dfg` text.
 
-- **D3 — Canonical IR = domain_flow's `DomainFlowGraph`.** *(Resolved: standardize on
-  the compiler's IR — see §4a.)* domain_flow is the compiler; ONNX imports into
-  `DomainFlowGraph`, the compiler passes rewrite it, and it serializes as `.dfg`.
-  kpu-sim consumes it and lowers it to an executable KPU program. `ComputationalGraph`
-  retires; `KernelGraph` is demoted to a *generated* lowering artifact (never
-  hand-authored), on a path to removal.
+- **D3 — Canonical *source* IR = domain_flow's `DomainFlowGraph`.** *(§4a.)*
+  domain_flow is the compiler; ONNX imports into `DomainFlowGraph`, the compiler
+  passes rewrite it, and it serializes as `.dfg`. **The compiler lowers it to the
+  binary KPU program (D5); kpu-sim does not.** `DomainFlowGraph` and its lowering are
+  compiler-internal. `ComputationalGraph` retires; kpu-sim's `KernelGraph` +
+  graph-walking schedule-generation are *compiler-backend* concerns (§5) — the
+  simulator runtime keeps only the executor.
 
-- **D4 — Compiled-program artifact (G6).** Reuse the existing **`sw::kpu::compiler::dfx`
-  `.kpu` object file** (already "serializable, PTX-for-KPU") as the compiled-program
-  format rather than inventing one; make the schedule-generators emit into it. This
-  is the *lowered* form — distinct from the `DomainFlowGraph` source (§4a).
+- **D4 — Compiled-program artifact = the binary KPU program.** Reuse the existing
+  **`sw::kpu::compiler::dfx` `.kpu` object file** (already "serializable, PTX-for-KPU")
+  as the binary-program format rather than inventing one. It is the *lowered* form
+  (D5), distinct from the `DomainFlowGraph` source.
 
-### 4a. Canonical IR & dependency direction (the D3 architecture)
+- **D5 — The KPU binary functional spec is the contract; kpu-sim owns it, the
+  compiler targets it.** kpu-sim defines the binary program format + the execution
+  semantics (the "ISA": the sequence of DMA/BlockMover/Streamer/COMPUTE/DRAIN/
+  WRITEBACK/STORE operations with tile + resource operands — i.e. a serialized
+  `ScheduleResult` + fabric config + resource bindings). domain_flow emits binaries
+  conforming to it. **kpu-sim reads and executes; it never compiles.** *(Recommended:
+  formalize the format as a versioned spec doc + a golden-binary conformance suite so
+  the two repos stay in lockstep.)*
 
-Two representations, cleanly separated — this is the crux of the design:
+### 4a. The compiler/hardware boundary & the two artifacts (D3 + D5)
 
-| Level | Representation | Owner | Carries |
-|---|---|---|---|
-| **Source / compute IR** | `sw::dfa::DomainFlowGraph` (`.dfg`) | **domain_flow (canonical)** | operators, shapes/dtypes, op attributes (conv stride/pad, matmul dims), weight *references* |
-| **Lowered executable form** | `.kpu` object / CSP schedules | kpu-sim (derived) | tiling `T`, dataflow strategy, per-op schedules, resource binding |
+Two artifacts, two owners, one hard boundary — this is the crux of the design:
 
-`KernelGraph` today conflates both roles and is *hand-authored*; under D3 it stops
-being a source of truth. The migration (§6) makes `DomainFlowGraph` the only graph
-that is imported, rewritten, and serialized; kpu-sim **lowers** it to execution.
-This dissolves gaps **G3, G5, G9** (no dual graph, no op-mapping impedance, no path
-proliferation) at the cost of one refactor (executor consumes/derives-from
-`DomainFlowGraph`).
+| Artifact | Representation | Produced by | Consumed by | Carries |
+|---|---|---|---|---|
+| **Source / compute IR** | `sw::dfa::DomainFlowGraph` (`.dfg`) | domain_flow front-end | domain_flow passes | operators, shapes/dtypes, op attrs, weight *references* |
+| **Binary KPU program** (the contract) | `.kpu` object (per the KPU binary functional spec) | **domain_flow compiler** (lowering) | **kpu-sim** (execution) | the op/tile/resource *schedule* — the "ISA" the KPU runs |
+| Model weights/data | weight blob → HOST_MEMORY | (model file) | kpu-sim `ResourceManager` | tensor values (Phase 5) / shapes (early) |
 
-**Dependency direction.** Making `DomainFlowGraph` canonical makes domain_flow a
-**hard dependency of kpu-sim's execution path** (today it is *optional*,
-`KPU_HAS_DOMAIN_FLOW`). This is acceptable and light **because** the relevant header
-`<dfa/dfg.hpp>` is **header-only and MLIR-free** (the MLIR bridge `dfa_mlir.hpp` is
-separate and stays out). **Prerequisite:** domain_flow's optional tools
+The boundary is the **binary KPU program**. Everything *left* of it (ONNX import,
+graph rewrite, tiling, scheduling, KPU-backend lowering) is **compiler** work in
+domain_flow. Everything *right* of it (load program + data, set up resources,
+execute with hardware-identical APIs) is **hardware-simulator** work in kpu-sim.
+kpu-sim **never lowers**. This dissolves gaps **G3, G5, G9** (no dual graph, no
+op-mapping impedance, no path proliferation) *and* correctly places the compiler
+where it belongs.
+
+**Where does kpu-sim's current schedule-generation go?** The schedule generators
+(`matmul_schedule_generator`, `conv2d_im2col`, …) and the `GraphCspExecutor`
+graph-walk are, architecturally, the **KPU compiler backend** — they turn ops into
+the tile/resource schedule. Under this boundary they **relocate to domain_flow** (or
+a shared `kpu-backend` library the compiler links). kpu-sim keeps only the
+**executor** (`ScheduleExecutor` + `ConcurrentTimingExecutor`) that *interprets* a
+deserialized program, plus the `ResourceManager` and memory model.
+
+**Dependency direction.** kpu-sim's runtime depends on domain_flow **only** through
+the binary-program format (and, for reading `.dfg`/weights into host memory, the
+header-only, MLIR-free `<dfa/dfg.hpp>`). It does **not** depend on domain_flow's
+compiler passes. **Prerequisite either way:** domain_flow's optional tools
 (`DOMAINFLOW_MATPLOT_TOOLS`→Matplot++, `DOMAINFLOW_VISUALIZATION`→CGAL/Qt6,
 `DOMAINFLOW_MLIR_TOOLS`→LLVM) must be forced **OFF** in
-`cmake/DomainFlowIntegration.cmake` so the hard dependency never drags in heavy
-packages — this also fixes the current Windows configure breakage.
+`cmake/DomainFlowIntegration.cmake` so the coupling never drags in heavy packages —
+this also fixes the current Windows configure breakage.
 
 ---
 
 ## 5. Target architecture (seam-by-seam)
 
+The hard boundary is between **[C]** and **[D]**: the binary KPU program.
+
 | Stage | Owner | Input → Output | Reuse / build |
 |---|---|---|---|
-| **[A]** front-end | domain_flow | `.onnx`/`.pt` → `.dfg` + weight blob | build (D1); weights per D2 |
-| **[B]** import | kpu-sim | `.dfg` + weights → `KernelGraph` + HOST_MEMORY-resident weights | extend `DomainFlowGraphLoader`; new weight loader |
-| **[C]** compile | kpu-sim | `KernelGraph` → compiled program (`.kpu`) | reuse schedule generators + `dfx` object file |
-| **[D]** cache | kpu-sim | program ↔ cache keyed by (op sig, shapes, dtype, fabric cfg) | net-new (small) |
-| **[E]** bind/exec | kpu-sim | program → bound to `ResourceManager` fabric → run | productionize `ScheduleBinder`; wire to `GraphCspExecutor` |
+| **[A]** front-end | **domain_flow** | `.onnx`/`.pt` → `DomainFlowGraph` | new direct ONNX reader (D1) |
+| **[B]** passes / KPU backend | **domain_flow** | `DomainFlowGraph` → tiled/scheduled lowering | relocate kpu-sim's schedule generators here (shared `kpu-backend`) |
+| **[C]** emit binary program | **domain_flow** | lowering → `.kpu` binary (per the spec, D5) | reuse the `dfx` `.kpu` object format |
+| **[D]** program cache | kpu-sim | `.kpu` ↔ cache keyed by (op sig, shapes, dtype, fabric cfg) | net-new (small) |
+| **[E]** load + execute | **kpu-sim** | read `.kpu` + weights; `ResourceManager` sets up fabric; run | reader + productionize `ScheduleBinder`; keep `ScheduleExecutor`/`ConcurrentTimingExecutor` |
+
+**Spec doc (D5):** the `.kpu` binary format + execution semantics are written up as
+the *KPU binary functional spec* (versioned), with a golden-binary conformance suite
+run by kpu-sim — the single artifact that keeps compiler and simulator in lockstep.
 
 ---
 
 ## 6. Phased implementation strategy
 
-Each phase ends with a demonstrable milestone (DoD). The spine
-(`DomainFlowGraph → lower → execute`) is stood up **before** the ONNX front-end
-(Phase 2) by generating a golden `.dfg` from an existing hand-built graph — this
-de-risks the canonical-IR migration and isolates the heaviest external gap (G1).
-Per D2, the early phases carry weight **shapes**, not values (placeholder/synthetic
-values); real weight values + numerical validation are Phase 5.
+Each phase ends with a demonstrable milestone (DoD). Ordering principle: **prove the
+simulator can consume a binary program first (P0–P1), then build the compiler that
+produces it (P2–P3), then optimize/validate (P4–P5).** The binary KPU program (D5)
+is the pivot. Per D2, early phases carry weight **shapes**, not values.
 
-### Phase 0 — Foundation: build hygiene + contract + lowering spine  *(kpu-sim)*
-- **Build hygiene** (prereq for the hard dep, §4a): force domain_flow's optional
-  tools OFF in `DomainFlowIntegration.cmake` (unblocks Windows; keeps the dep
-  header-only + MLIR-free).
-- Formalize the **`.dfg` contract v1**: operator mapping (`DomainFlowOperator` ↔
-  kpu-sim runners), tensor shape/dtype encoding, weight-*reference* convention.
-- Stand up the **lowering spine** `DomainFlowGraph → KernelGraph` (KernelGraph now a
-  *generated* execution artifact, D3/§4a) feeding the existing `GraphCspExecutor`.
-  Add a one-time `KernelGraph → DomainFlowGraph` exporter to mint golden `.dfg`s.
-- **DoD:** `build_resnet18`'s graph → export `DomainFlowGraph` → lower → execute →
-  **identical topology + cycle counts** to the direct build. Round-trips the contract.
+Bootstrap note: in P0 the golden binary is produced by kpu-sim's *existing* inline
+schedule generators, used **temporarily** as the KPU-backend *reference producer* —
+they relocate to the compiler in P2. This lets the simulator side (ISA consumer) and
+the compiler side (ISA producer) proceed in parallel against the binary contract.
 
-### Phase 1 — `.dfg` on disk → execution; retire the dual graph  *(kpu-sim)*
-- Productionize `DomainFlowGraphLoader` to load `.dfg` → `DomainFlowGraph` (real
-  tensor metadata, real topo sort). **Retire `ComputationalGraph`** — the loader now
-  yields the canonical IR, lowered by Phase 0's spine.
-- **DoD:** `m2_resnet --from-dfg model.dfg` runs ResNet-18 from a disk `.dfg`
-  (shapes real, values synthetic); timing/utilization match the direct build.
+### Phase 0 — KPU binary program spec + simulator reader/executor  *(kpu-sim)*
+- **Build hygiene** (§4a prereq): force domain_flow's optional tools OFF in
+  `DomainFlowIntegration.cmake` (unblocks Windows; keeps the dep header-only + MLIR-free).
+- Define & version the **KPU binary program format (D5)**: serialize a
+  `ScheduleResult` (+ fabric config + resource bindings) into the `dfx` `.kpu` object;
+  write the *KPU binary functional spec* doc.
+- Add a **program reader** in kpu-sim that loads a `.kpu` and runs it through the
+  existing `ScheduleExecutor`/`ConcurrentTimingExecutor` — **no inline generation**.
+- **DoD:** the ResNet schedule → serialize `.kpu` → read back → execute → **identical
+  cycles** to the inline path (guarded by `resnet_regression`). Proves kpu-sim
+  consumes a binary program.
 
-### Phase 2 — Direct `ONNX → dfg` front-end  *(domain_flow; the big gap G1)*
-- Per D1: implement a **direct ONNX-protobuf → `DomainFlowGraph`** reader (no MLIR)
-  for the CNN op set — map ONNX ops → `DomainFlowOperator`, read tensor **shapes**
-  from initializers/value-info (values optional at this stage, D2).
-- Fill any `DomainFlowOperator` domain coverage the reader needs (G5).
-- **DoD:** a stock `resnet18.onnx` (torchvision) → `.dfg` → runs on the sim with
-  **correct topology + timing** (numerical output *not* yet validated — Phase 5).
+### Phase 1 — Hardware-identical execution: ResourceManager setup + host memory  *(kpu-sim)*
+- Execute the binary program through the **hardware flow**: `ResourceManager`
+  allocates/sets up fabric resources per the program, deposits DNN data (shapes) in
+  `HOST_MEMORY`, signals "ready → start", executes — the same APIs a real KPU exposes.
+- **DoD:** `m2_resnet --run-program model.kpu` executes a serialized program end-to-end
+  through the resource-manager APIs; timing matches the direct path.
 
-### Phase 3 — Compile to a serialized KPU program + program cache  *(kpu-sim; G6, G7)*
-- Make the schedule generators emit a **serialized** compiled program (reuse the
-  `dfx` `.kpu` object file, D4): per-op schedules + tiling + dataflow strategy — the
-  *lowered* form (§4a).
-- Build the program cache: key = (op signature, shapes, dtype, fabric config) →
-  compiled program; load-from-cache on repeat.
-- **DoD:** second run of the same model loads compiled kernels from cache (no
-  recompile); cache hit/miss reported.
+### Phase 2 — Relocate the KPU compiler backend to domain_flow  *(domain_flow / shared lib)*
+- Move kpu-sim's schedule-generation (tiling/scheduling/dataflow strategy — the
+  matmul/conv2d/… generators + graph-walk) into domain_flow (or a shared
+  `kpu-backend` library the compiler links). domain_flow: `DomainFlowGraph` → `.kpu`
+  binary conforming to the spec (D5). Retire kpu-sim's `ComputationalGraph`.
+- **DoD:** domain_flow emits a `.kpu` from a `DomainFlowGraph` that kpu-sim executes
+  with **identical results to P0's golden** (conformance suite passes).
 
-### Phase 4 — Resource binding / data-path personalization  *(kpu-sim; G8)*
-- Productionize `ScheduleBinder`: bind compiled-program ops → concrete fabric
-  resources (DMA/BM/STR ids, L3/L2/L1 allocations) via `ResourceManager` =
-  "personalize the data path"; wire the bound program into `GraphCspExecutor`.
-- **DoD:** a cached, bound program executes on the personalized fabric; timing
-  (utilization/cycles) matches the direct path.
+### Phase 3 — Direct `ONNX → DomainFlowGraph` front-end  *(domain_flow; gap G1)*
+- Per D1: direct ONNX-protobuf → `DomainFlowGraph` reader (no MLIR) for the CNN op
+  set — map ONNX ops → `DomainFlowOperator`, read tensor **shapes** (values optional,
+  D2). Then P2's backend compiles it to `.kpu`.
+- **DoD:** torchvision `resnet18.onnx` → `DomainFlowGraph` → `.kpu` → runs on kpu-sim
+  with **correct topology + timing** (numerical output not yet validated — P5).
+
+### Phase 4 — Program cache + data-path personalization  *(kpu-sim; G7, G8)*
+- **Program cache**: keyed compiled `.kpu` programs (op sig, shapes, dtype, fabric
+  cfg) → fast-load on repeat. Productionize `ScheduleBinder` to bind program ops →
+  concrete fabric resources (DMA/BM/STR ids, L3/L2/L1) = "personalize the data path".
+- **DoD:** second run fast-loads from cache (no recompile); the bound program runs on
+  the personalized fabric.
 
 ### Phase 5 — Weight values, numerical validation & model zoo  *(both)*
-- **Real weight values** (the deferred half of D2): load weight blob into
-  `ExternalMemory`/HOST_MEMORY via `ResourceManager`; kernels reference by handle.
-- Add an **onnxruntime reference** path; validate real-weight numerical output (G10).
-- Extend to transformer ops (softmax/layernorm/attention — kpu-sim has them,
-  `DomainFlowOperator` must be extended), and the milestone-ladder models; retire the
-  synthetic builders as they are superseded.
+- **Real weight values** (deferred half of D2): weight blob → `HOST_MEMORY`; ops
+  reference by handle. Add an **onnxruntime reference** and validate numerically (G10).
+- Extend to transformer ops (`DomainFlowOperator` gains softmax/layernorm/attention),
+  the milestone-ladder models; retire superseded synthetic builders.
 - **DoD:** ≥2 real models beyond ResNet run from disk with reference-validated output.
 
 ---
 
 ## 7. Recommended first increment (thin vertical slice)
 
-**Phase 0 for ResNet-18: `DomainFlowGraph` exported from `build_resnet18`, lowered,
-executed.** Proves the canonical-IR spine — build hygiene → `.dfg` contract →
-`DomainFlowGraph` → lowering → `GraphCspExecutor` → identical topology + cycles —
-**without** the ONNX front-end (G1) and **without** the weight-values refactor
-(topology + timing only, D2). Guard it with the existing `resnet_regression` harness
-(identical cycles ⇒ the round-trip is lossless). Phase 1 then moves the source to a
-disk `.dfg` and retires `ComputationalGraph`; Phase 2's ONNX reader plugs in ahead of
-the proven spine with low risk.
+**Phase 0 for ResNet-18: serialize the ResNet schedule to a `.kpu` binary, read it
+back, and execute it.** Proves the pivot — build hygiene → binary program format
+(D5) → kpu-sim reader → `ScheduleExecutor` → **identical cycles** to the inline path
+— **without** the compiler backend (P2), the ONNX front-end (P3), or weight values
+(D2). Guard it with the existing `resnet_regression` harness (identical cycles ⇒ the
+serialize/execute round-trip is lossless). This establishes kpu-sim as a pure
+consumer of the binary contract; the compiler (P2–P3) is then built to *produce* that
+same binary, validated against P0's golden.
 
 ## 8. Risks & mitigations
 

--- a/docs/plans/model-ingestion-compilation-epic.md
+++ b/docs/plans/model-ingestion-compilation-epic.md
@@ -243,7 +243,9 @@ the compiler side (ISA producer) proceed in parallel against the binary contract
   `DomainFlowIntegration.cmake` (unblocks Windows; keeps the dep header-only + MLIR-free).
 - Define & version the **KPU binary program format (D5)**: serialize a
   `ScheduleResult` (+ fabric config + resource bindings) into the `dfx` `.kpu` object;
-  write the *KPU binary functional spec* doc.
+  write the *KPU binary functional spec* doc. Apply the versioning requirements
+  (R1–R9, `.kpu` §3) from `dfg-kpu-versioning.md` — version stamp + `min_consumer`
+  gate + profile/capability dimension + golden-binary conformance corpus.
 - Add a **program reader** in kpu-sim that loads a `.kpu` and runs it through the
   existing `ScheduleExecutor`/`ConcurrentTimingExecutor` — **no inline generation**.
 - **DoD:** the ResNet schedule → serialize `.kpu` → read back → execute → **identical
@@ -326,8 +328,9 @@ same binary, validated against P0's golden.
 
 ## 9. Open questions (remaining, D1–D4 resolved)
 
-1. `.dfg` contract versioning: extend domain_flow's existing text format in place, or
-   introduce a versioned schema alongside it? (Affects Phase 0.)
+1. ~~`.dfg` contract versioning~~ — **analyzed** in `dfg-kpu-versioning.md`: version
+   `.dfg` **in place** (3 axes + `min_consumer` gate + profile dimension + golden
+   corpus), and version the `.kpu` binary from day one. Feeds Phase 0.
 2. Epic sub-issue granularity — one per phase, or per phase-DoD?
 3. Fine sequencing vs. M4 (agreed: run alongside) — which phases interleave with M4
    vs. run after it?


### PR DESCRIPTION
## Summary

Design plan for the model-ingestion epic: load real DNNs (ONNX/PyTorch) via the domain_flow compiler and execute them on the simulator, replacing the hand-written builders (`resnet18.hpp`, etc.).

Grounded in a two-repo gap analysis (kpu-sim + `branes-ai/domain_flow`). Key findings: the `.dfg` text format is a working interchange contract already half-wired; the biggest gap is the ONNX front-end (domain_flow has none); the middle/back-end are fragmented but partly built (`ResourceManager`, `.kpu` object format, a disconnected `tools/` pipeline).

Decisions resolved with the user (D1–D4):
- **D1** direct `ONNX → dfg` reader (no LLVM/MLIR).
- **D2** topology + timing first — weight *shapes*, not values; numerical fidelity is a later phase.
- **D3** canonical IR = domain_flow's `DomainFlowGraph` (compiler-first); retire `ComputationalGraph`, demote `KernelGraph` to a generated lowering artifact.
- **D4** file as a formal epic, run alongside M4 (#132).

6-phase strategy (spine-first): Phase 0 canonical-IR lowering spine → Phase 1 disk `.dfg` → Phase 2 ONNX front-end → Phase 3 compile+cache → Phase 4 bind/personalize → Phase 5 weight values + numerical validation + model zoo.

Companion tracking issues filed as the epic + phase sub-issues.

## Test plan
- [ ] Docs-only; fast CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added versioning requirements for `.dfg` source files and `.kpu` binaries, including compatibility rules, capability metadata, and validation guidance.
  * Added an end-to-end planning guide for neural-network ingestion, compilation, binary generation, caching, and simulator execution.
  * Documented phased implementation milestones, architecture boundaries, risks, and open design questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->