### PR TITLE
fix(cmake): force domain_flow optional tools OFF (Phase 0 #230; fixes Windows configure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **domain_flow FetchContent no longer drags in Matplot++ / CGAL / LLVM (fixes the
+  Windows configure break).** kpu-sim consumes domain_flow only as a header-only
+  library, so `cmake/DomainFlowIntegration.cmake` now force-sets its optional tool
+  subprojects OFF before `FetchContent_MakeAvailable`
+  (`DOMAINFLOW_MATPLOT_TOOLS`→Matplot++, `DOMAINFLOW_VISUALIZATION`→CGAL/Qt6,
+  `DOMAINFLOW_MLIR_TOOLS`→LLVM, plus `DSE`/`DATABASE_TOOLS`/`TOOLS`). These default
+  OFF upstream but could be turned back on by an inherited preset/cache value; the
+  `FORCE` is authoritative, so configuring with `-DDOMAINFLOW_VISUALIZATION=ON` (etc.)
+  no longer fails on the missing packages. Phase 0 of the model-ingestion epic
+  (#230); keeps the dependency header-only + MLIR-free.
+
 - **ResNet utilization was understated by inconsistent instrumentation.** Four
   RunStats-producing runners (`run_elementwise`, `run_ve_unary`,
   `run_depthwise_conv`, `run_global_avg_pool`) added only `total_cycles`/`ops` to

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -20,7 +20,17 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Wstrict-null-sentinel -Wstrict-overflow=5 -Wswitch-default
         -Wundef -Wno-unused
     )
-    
+
+    # On newer x86 CI runners, `-march=native` enables a partial AVX10.1 target
+    # feature (`+avx10.1-256`), which Clang flags via -Winvalid-feature-combination
+    # ("will be promoted to avx10.1-512") and -Werror then turns fatal. It is a
+    # benign codegen-tuning note, not a source issue, so silence it for Clang.
+    # (GCC has no such warning; it builds cleanly with the same -march=native.)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        list(APPEND KPU_WARNING_FLAGS -Wno-invalid-feature-combination)
+    endif()
+
+
     # Architecture-specific optimizations
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
         list(APPEND KPU_CXX_FLAGS_RELEASE "-march=native -mtune=native")

--- a/cmake/DomainFlowIntegration.cmake
+++ b/cmake/DomainFlowIntegration.cmake
@@ -61,6 +61,22 @@ if(KPU_USE_DOMAIN_FLOW)
         # Set this before MakeAvailable to prevent policy warnings
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
+        # kpu-sim consumes domain_flow ONLY as a header-only library (the dfa IR +
+        # polyhedral math). Force its optional tool subprojects OFF so the fetched
+        # dependency never drags in heavy external packages or builds executables we
+        # do not use. Each defaults OFF in domain_flow, but a value inherited from a
+        # parent preset/cache can turn it back on; FORCE here is authoritative.
+        # (CMAKE_ARGS in FetchContent_Declare is ignored for the add_subdirectory
+        #  model, so these must be cache-set here, like BUILD_TESTING above.)
+        #   MATPLOT_TOOLS -> Matplot++ | VISUALIZATION -> CGAL/Qt6 | MLIR_TOOLS -> LLVM/MLIR
+        # This also fixes the Windows configure break (missing Matplot++ / CGAL).
+        set(DOMAINFLOW_MATPLOT_TOOLS  OFF CACHE BOOL "kpu-sim: no domain_flow plot tools"    FORCE)
+        set(DOMAINFLOW_VISUALIZATION  OFF CACHE BOOL "kpu-sim: no domain_flow viz tools"     FORCE)
+        set(DOMAINFLOW_MLIR_TOOLS     OFF CACHE BOOL "kpu-sim: no domain_flow MLIR tools"    FORCE)
+        set(DOMAINFLOW_DSE            OFF CACHE BOOL "kpu-sim: no domain_flow DSE tools"     FORCE)
+        set(DOMAINFLOW_DATABASE_TOOLS OFF CACHE BOOL "kpu-sim: no domain_flow DB tools"      FORCE)
+        set(DOMAINFLOW_TOOLS          OFF CACHE BOOL "kpu-sim: no domain_flow dfg/rdg tools" FORCE)
+
         FetchContent_MakeAvailable(domain_flow)
 
         # Restore BUILD_TESTING to enable kpu-sim's own tests


### PR DESCRIPTION
## Summary

First increment of **Phase 0** (#230) — the documented build-hygiene prerequisite, which also **fixes the Windows configure breakage** you hit (missing `Matplot++` / `CGAL`).

kpu-sim consumes domain_flow *only* as a header-only library (the `dfa` IR + polyhedral/SURE math). `cmake/DomainFlowIntegration.cmake` now force-sets domain_flow's optional tool subprojects OFF before `FetchContent_MakeAvailable`:

| Option | Would pull in |
|---|---|
| `DOMAINFLOW_MATPLOT_TOOLS` | Matplot++ |
| `DOMAINFLOW_VISUALIZATION` | CGAL / Qt6 |
| `DOMAINFLOW_MLIR_TOOLS` | LLVM / MLIR |
| `DOMAINFLOW_DSE`, `DOMAINFLOW_DATABASE_TOOLS`, `DOMAINFLOW_TOOLS` | DSE / DB / dfg-rdg tool executables |

These default OFF upstream, but an inherited preset/cache value can turn them back on — and `CMAKE_ARGS` in `FetchContent_Declare` is a no-op for the `add_subdirectory` model, so they must be cache-set with `FORCE` here (mirroring the existing `BUILD_TESTING` pattern).

## Verification

- **Configuring with `-DDOMAINFLOW_MATPLOT_TOOLS=ON -DDOMAINFLOW_VISUALIZATION=ON -DDOMAINFLOW_MLIR_TOOLS=ON` now succeeds** (exit 0, no `Matplot++`/`CGAL` errors) — the cache shows all six OFF, i.e. `FORCE` overrides the `-D`.
- `kpu_dataflow` (the header-only `dfa`/SURE consumer, `fused_mlp_sure.cpp`) and `m2_resnet` build.
- `ctest -R "resnet_regression|m2_resnet"` → **6/6 pass**.

Keeps the domain_flow dependency header-only + MLIR-free — the §4a prerequisite for making it a clean hard dependency of the execution path.

## Test plan
- [ ] CI passes on all platforms (esp. Windows configure)

Part of #230 (epic #229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows configuration reliability when optional domain-flow dependencies are unavailable.
  * Prevented unnecessary visualization, machine-learning, database, and analysis tools from being enabled during integration.
  * Suppressed a benign Clang warning related to native architecture feature combinations, avoiding configuration failures with strict warnings enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->