### PR TITLE
feat(230): L1 stream signatures — spatial/temporal layer over L0 (Phase 0 increment 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **L1 stream signatures — the spatial/temporal layer over L0 (Phase 0 increment 2,
-  #230).** L1 turns each L0 tile-into-port (`Feed`/`Drain`) into an **element stream**
-  and each tile-compute into a **systolic wavefront**, giving physically-shaped timing
-  *without changing values* (L0 stays the functional reference). New headers under
-  `include/sw/kpu/program/stream/`: `stream_signature.hpp` (`StreamSignature` — edge,
-  lanes, per-element lane + wavefront skew, rate; `WavefrontTiming` — the
-  fill+reduce+drain latency; `StreamProgram` keyed by L0 op index, with
-  `disassemble()`), and `derive/matmul_streams.hpp`. The matmul derivation encodes the
-  output-stationary systolic schedule `σ(i,j,k)=i+j+k`: `A→West` (lane = row, `t=i+k`),
-  `B→North` (lane = col, `t=j+k`), `C→South` drain (`t=i+j+K−1`); one `T×T×T`
-  tile-compute has latency `3(T−1)+1` (e.g. 46 for T=16) instead of a lumped MAC cost.
-  Design note `docs/plans/l1-stream-signatures.md` (schedule, signature model,
-  derivation, and the integration path — feeding `WavefrontTiming` into the
-  characterization DAG and eventually the cycle-accurate CSP model). Tests
-  (`tests/program/test_stream_signature.cpp`): signature/skew/lane correctness,
-  wavefront latency (incl. clamped trailing tiles), and value-orthogonality.
+- **L1 stream signatures — the spatial/temporal layer over L0, parameterized by the
+  space-time mapping (Phase 0 increment 2, #230).** L1 turns each L0 tile-into-port into
+  an **element stream** and each tile-compute into a **systolic wavefront**, giving
+  physically-shaped timing *without changing values* (L0 stays the functional
+  reference). The streams are **a function of the space-time mapping** (which operand is
+  stationary), so L1 is parameterized by a `SpaceTimeMap` (schedule τ + projection u)
+  and also records the **network** the streams require. New headers under
+  `include/sw/kpu/program/stream/`: `stream_signature.hpp` (`SpaceTimeMap` with the four
+  canonical projections; `StreamSignature` — role/flow/edge/lane-skew/**element-stride
+  (bubble)**; `WavefrontTiming` — fill+reduce+drain latency; `NetworkOverlay` —
+  Mesh2D vs. Hexagonal + overlay; `StreamProgram` + `disassemble()`) and
+  `derive/matmul_streams.hpp`. The derivation covers the dataflow taxonomy:
+  **output-stationary** (C held; A→West, B→North, **C evacuates North with a bubble** —
+  draining South would collide with B and sibling C; the northbound traversal spaces
+  successive results two cycles apart → stride 2), **weight(B)-stationary** and
+  **A-stationary** (C exits East dense, Mesh2D), and **fully-streaming** (`u=τ=[1,1,1]`
+  aligned → contention-free **hexagonal** array needing a network overlay on a 2-D
+  mesh). One `T×T×T` tile-compute has latency `3(T−1)+1` (46 for T=16) instead of a
+  lumped MAC cost. Design note `docs/plans/l1-stream-signatures.md`. Tests
+  (`tests/program/test_stream_signature.cpp`): the taxonomy roles, the
+  output-stationary evacuation bubble, the mesh-vs-hex network, wavefront latency
+  (incl. clamped tiles), and value-orthogonality.
 
 - **L0 `TileProgram` — the portable program's tile-sequence layer (#230, epic
   #229).** A device-independent, timing-free representation of a tiled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **L1 stream signatures — the spatial/temporal layer over L0 (Phase 0 increment 2,
+  #230).** L1 turns each L0 tile-into-port (`Feed`/`Drain`) into an **element stream**
+  and each tile-compute into a **systolic wavefront**, giving physically-shaped timing
+  *without changing values* (L0 stays the functional reference). New headers under
+  `include/sw/kpu/program/stream/`: `stream_signature.hpp` (`StreamSignature` — edge,
+  lanes, per-element lane + wavefront skew, rate; `WavefrontTiming` — the
+  fill+reduce+drain latency; `StreamProgram` keyed by L0 op index, with
+  `disassemble()`), and `derive/matmul_streams.hpp`. The matmul derivation encodes the
+  output-stationary systolic schedule `σ(i,j,k)=i+j+k`: `A→West` (lane = row, `t=i+k`),
+  `B→North` (lane = col, `t=j+k`), `C→South` drain (`t=i+j+K−1`); one `T×T×T`
+  tile-compute has latency `3(T−1)+1` (e.g. 46 for T=16) instead of a lumped MAC cost.
+  Design note `docs/plans/l1-stream-signatures.md` (schedule, signature model,
+  derivation, and the integration path — feeding `WavefrontTiming` into the
+  characterization DAG and eventually the cycle-accurate CSP model). Tests
+  (`tests/program/test_stream_signature.cpp`): signature/skew/lane correctness,
+  wavefront latency (incl. clamped trailing tiles), and value-orthogonality.
+
 - **L0 `TileProgram` — the portable program's tile-sequence layer (#230, epic
   #229).** A device-independent, timing-free representation of a tiled
   linear-algebra operator: an ordered sequence of tiles fed into / drained from

--- a/docs/plans/l1-stream-signatures.md
+++ b/docs/plans/l1-stream-signatures.md
@@ -4,99 +4,135 @@
 `kpu-program-model.md` §3/§6). L1 adds the **spatial/temporal (timing)** layer on top
 of the L0 `TileProgram`: it says *how* each L0 tile becomes an **element stream** into
 or out of the reactive fabric, and *how long* each tile-compute takes as a systolic
-wavefront. **L1 never changes values** — it is derived from L0 + the array mapping, so
-`L0` alone stays the functional reference and `L0+L1` is the timing model
+wavefront. **L1 never changes values** — it is derived from L0 + a **space-time
+mapping**, so `L0` alone stays the functional reference and `L0+L1` is the timing model
 (BEHAVIORAL vs. TRANSACTIONAL/CYCLE_ACCURATE, per `SIMULATION_FIDELITY_FRAMEWORK.md`).
+
+The central fact: **the streams are not fixed — they are a function of the space-time
+mapping** (which operand is held stationary). L1 must therefore be parameterized by
+that mapping and must also state the **network** the resulting streams require (a 2-D
+mesh vs. a hexagonal overlay).
 
 ---
 
-## 1. What L1 attaches to L0
+## 1. The space-time mapping
 
-For each L0 op:
-- **Feed / Drain** (a tile ↔ fabric-port injection) → a **`StreamSignature`**: which
-  array **edge**, how many **lanes**, the per-element **lane + wavefront skew**, and the
-  **rate** (elements/cycle/lane).
-- **compute** (`MatMulAccum`, …) → a **`WavefrontTiming`**: the systolic latency of
-  that tile-compute on the array.
-
-L1 is a thin layer keyed by L0 op index — it does not copy or mutate the L0 program.
-
-## 2. The systolic schedule (output-stationary matmul)
-
-Tile matmul `C[i,j] += Σ_k A[i,k]·B[k,j]`, with `i∈[0,R)`, `j∈[0,S)`, `k∈[0,K)`, mapped
-to an `R×S` array where **PE(i,j) accumulates C[i,j]** (output-stationary). The classic
-space-time schedule is the linear wavefront
-
+A tiled matmul is a 3-D uniform recurrence over the iteration domain `(i,j,k)`:
 ```
-σ(i,j,k) = i + j + k
+c(i,j,k) = c(i,j,k-1) + a(i,j,k)·b(i,j,k)      # C accumulates along +k
+a(i,j,k) = a(i,j-1,k)                          # A is invariant along j  → e_A = [0,1,0]
+b(i,j,k) = b(i-1,j,k)                          # B is invariant along i  → e_B = [1,0,0]
+                                               # C is invariant along nothing but +k → e_C = [0,0,1]
 ```
+Each variable `V` has a **propagation direction** `e_V` — the iteration axis along which
+its value is reused (constant).
 
-which gives, for each operand, a single skewed stream at one array edge:
+A **space-time mapping** is two integer vectors:
+- **schedule** `τ` — time of iteration `x` is `σ(x) = τ·x` (validity: `τ·e_V > 0` ∀V).
+- **projection** `u` — the direction collapsed to form the 2-D array; iterations that
+  differ by a multiple of `u` share one PE (`τ·u ≠ 0` so they run at different times).
 
-| Stream | Edge | Lane | Injection time of element | Propagation |
-|---|---|---|---|---|
-| **A** (`A[i,k]`) | **West** | row `i` | `t = i + k` | east, +1 cycle/column |
-| **B** (`B[k,j]`) | **North** | col `j` | `t = j + k` | south, +1 cycle/row |
-| **C** (`C[i,j]`) | **South** (drain) | col `j` | `t = i + j + (K−1)` | out the bottom |
+A variable is **stationary** iff `u ∥ e_V` (projecting along its reuse axis pins it in a
+PE); otherwise it **streams**. This one relation generates the whole dataflow taxonomy:
 
-Check: `A[i,k]` injected at West-PE(i,0) at `i+k` reaches PE(i,j) at `i+j+k`; `B[k,j]`
-injected at North-PE(0,j) at `j+k` reaches PE(i,j) at `i+j+k` — they meet exactly when
-PE(i,j) processes product `k`. ✔
+| `u` (project out) | Stationary | Streams | Analogy |
+|---|---|---|---|
+| `[0,0,1]` (k) | **C** | A, B | **output-stationary** |
+| `[1,0,0]` (i) | **B** | A, C | **weight(B)-stationary** (TPU MXU) |
+| `[0,1,0]` (j) | **A** | B, C | **A-stationary** |
+| `[1,1,1]` | *none* | A, B, C | **fully-streaming (hexagonal)** |
 
-**Latency of one tile-compute** (`R×S` array, depth `K`):
-```
-latency = (R−1) + (S−1) + (K−1) + 1        # fill + reduce + drain
-```
-e.g. a 16×16×16 tile-compute = 46 cycles (not a single lumped MAC cost) — the fill and
-drain ramps are now explicit, which is the point of L1.
+`τ = [1,1,1]` (`σ = i+j+k`) throughout below.
 
-## 3. `StreamSignature` (per feed/drain)
+## 2. Deriving a stream signature from the mapping
 
-A tile's `rows×cols` elements become a stream where element `(r,c)`:
-- injects on **lane** `= r` (row axis) or `= c` (col axis),
-- at **time** `t0 + skew_row·r + skew_col·c`,
-- at **rate** elements/cycle/lane.
+For a **streaming** variable, its physical flow in the array is `e_V` projected onto the
+2-D PE plane; it enters at the edge opposite the flow (or, for the result, exits). Two
+timing quantities come out of `τ` and the geometry:
+- **lane skew** — the per-lane start offset (successive lanes light up later).
+- **element stride** — cycles between consecutive elements on one lane. `stride = 1` is a
+  *dense* stream; `stride > 1` means a **bubble** of `stride-1` empty cycles per element.
 
-For the schedule above every matmul stream has `skew_row = skew_col = 1`; they differ
-only by **edge** and **lane axis**:
+**Bubbles come from result evacuation.** Input streams enter the boundary densely
+(stride 1). A result that must **traverse the filled array** to reach an edge picks up a
+bubble, because each successive result is produced one cycle later *and* one lattice
+point further from the exit — so its exit time advances by two, not one.
 
-| L0 op | operand | edge | lane axis | lanes |
-|---|---|---|---|---|
-| `Feed → West` | A tile (`Ti×Tk`) | West | Row | `Ti` |
-| `Feed → North` | B tile (`Tk×Tj`) | North | Col | `Tj` |
-| `Drain → South` | C tile (`Ti×Tj`) | South (output) | Col | `Tj` |
+### 2.1 Output-stationary (`u=[0,0,1]`) — the worked case
+PE`(i,j)` holds `C[i,j]`. With `σ=i+j+k`:
+- **A** → **West** edge, lane = row `i`, injected at `t=i+k` → dense (stride 1), skew `i`.
+- **B** → **North** edge, lane = col `j`, injected at `t=j+k` → dense, skew `j`.
+- **C** is stationary, ready at `t=i+j+K−1`, and must be **evacuated**. Draining it
+  **South** would collide with B's own southbound flow *and* with sibling C's — the
+  southbound links are occupied. So C drains **North**, over the free northbound links.
+  `C[i,j]` travels `i` rows up, exiting the North edge at lane `j` at
+  `t = (i+j+K−1) + i = 2i+j+K−1`. Along a column, consecutive rows exit **two** cycles
+  apart → **stride 2, bubble 1**. (The bubble is exactly what keeps successive results
+  from colliding en route.)
+- **Network:** flows are `A:+col`, `B:+row (S)`, `C:−row (N)` — all along the two mesh
+  axes (north/south links are distinct directions) → a **2-D mesh** suffices.
 
-`time_span = skew_row·(rows−1) + skew_col·(cols−1)` is the stream's first→last element
-delay; `element_count = rows·cols`.
+### 2.2 Weight(B)-stationary (`u=[1,0,0]`)
+`B[k,j]` is preloaded across the `(j,k)` array. **A** streams down each column
+(`t`-indexed by `i`), **C** accumulates along `+col` and exits the **East** edge — and,
+because C exits at the edge where its accumulation finishes (no orthogonal traversal),
+the C readout is **dense (no bubble)**. Two axes → **2-D mesh**. This is the TPU-style
+weight-stationary dataflow. `u=[0,1,0]` (A-stationary) is the mirror image.
+
+### 2.3 Fully-streaming / hexagonal (`u=[1,1,1]`)
+No variable is stationary. Because **`u ∥ τ`** (`s=τ=[1,1,1]`), space and time are
+*aligned*: every iteration on the plane `i+j+k=t` fires at time `t` and maps to a
+distinct PE, giving **perfect concurrency with no contention and no bubbles**. The three
+variables flow along the three projections of `e_A,e_B,e_C` onto the plane ⊥`[1,1,1]` —
+**three directions at 60°** → a **hexagonal** connectivity (Kung–Leiserson).
+- **Network:** a hex array needs three link directions. On a rectangular 2-D mesh this
+  is a **network overlay** (the third/diagonal direction added on top of the two mesh
+  axes); alternatively a **native hexagonal fabric** can be built. L1 records this
+  requirement so the driver-JIT placement (§4a of the program model) can refuse or
+  overlay.
+
+## 3. The L1 objects
+
+- **`SpaceTimeMap`** — `τ`, `u`, with the presets above; reports the stationary operand.
+- **`StreamSignature`** (per variable) — `role` (Stationary / StreamIn / StreamOut),
+  physical `flow` direction, entry/exit `edge`, `lane_skew`, `element_stride`
+  (`bubble = stride−1`), `lanes`, tile `rows×cols`, `rate`.
+- **`WavefrontTiming`** (per compute) — the systolic latency of one tile-compute
+  (`(R−1)+(S−1)+(K−1)+1` fill+reduce+drain for `τ=[1,1,1]`).
+- **`NetworkOverlay`** — required `FabricTopology` (Mesh2D / Hexagonal), whether it needs
+  an overlay on a 2-D mesh, and the distinct stream directions.
+- **`StreamProgram`** — the `SpaceTimeMap`, the per-variable signatures, the
+  `NetworkOverlay`, and per-op wavefront timings; `disassemble()` renders it.
 
 ## 4. Derivation from L0
 
-`derive_matmul_streams(L0)` walks the L0 ops and emits the table above from each tile's
-element extent (clamped trailing tiles handled), inferring the array dims from the tile
-shape. **Increment-1 assumption:** each tile fits the physical array (`R×S = Ti×Tj`,
-`K = Tk`). Larger tiles sub-blocking onto a fixed physical array (multiple passes) is a
-follow-on. This is the systolic specialization of the general derivation in
-`kpu-program-model.md` §4 (`stream_port(t) = { A[f_A(x)] : σ(x)=t }`); domain_flow's
-`IndexSpace`/`AffineMap`/`schedule`/`wavefront` are the general engine for non-matmul
-operators.
+`derive_matmul_streams(L0, SpaceTimeMap)` produces the signatures + network for the
+chosen mapping (the four canonical projections above), reading tile extents from L0
+(clamped trailing tiles handled) and inferring the array dims from the tile shape.
+Increment-1 assumption: each tile fits the physical array. This is the systolic
+specialization of the general rule in `kpu-program-model.md` §4
+(`stream_port(t) = { V[f_V(x)] : σ(x)=t }`); domain_flow's `IndexSpace`/`AffineMap`/
+`schedule`/`wavefront` are the general engine for arbitrary operators and mappings.
 
-## 5. Integration path (what L1 unlocks next)
+## 5. What L1 unlocks next
 
-1. **Physically-shaped compute cost.** The characterization DAG (`tile_dag.hpp`)
-   currently lumps a compute op at `MACs / macs_per_cycle`. Swapping in
-   `WavefrontTiming::latency()` makes the fill/drain ramps and the true wavefront depth
-   visible in the makespan — a follow-on that plugs into the existing harness with no
-   interface change.
-2. **Drive the cycle-accurate CSP model.** L1 stream signatures are the input the
-   `ConcurrentTimingExecutor` needs (injection order + rate + skew per port), replacing
-   the current inline schedule generation (Phase 0 §6.2).
-3. **Other operators.** LU/Cholesky/QR tile kernels get their own schedules (TRSM is a
-   substitution wavefront; GETRF/panel factor a triangular front) — derived via the
-   domain_flow polyhedral engine rather than the hand-specialized matmul schedule.
+1. **Physically-shaped compute + movement cost.** The characterization DAG
+   (`tile_dag.hpp`) can swap its lumped `MACs/macs_per_cycle` for `WavefrontTiming` and
+   the stream bubbles, exposing fill/drain ramps and the readout stalls in the makespan.
+2. **Network-aware placement.** The `NetworkOverlay` tells the driver-JIT placement pass
+   (§4a) whether the chosen schedule fits the device's fabric (mesh) or needs a hex
+   overlay — a feasibility input alongside capacity and mover capability.
+3. **Schedule search.** With the mapping parameterized, the characterization harness can
+   sweep *dataflow* (output- vs. weight- vs. A-stationary vs. hex) the way it sweeps
+   size/tiling — discovering which stationary operand and network a given problem+device
+   wants (the domain-flow analogue of choosing a dataflow in CUDA/CUTLASS).
+4. **Drive the cycle-accurate CSP model** from the stream signatures (Phase 0 §6.2), and
+   derive non-matmul schedules (TRSM/GETRF/QR) via the polyhedral engine.
 
-## 6. Scope of this first increment
+## 6. Scope of this increment
 
-Deliver the L1 representation (`StreamSignature`, `WavefrontTiming`, `StreamProgram`),
-the **matmul** derivation, and validation that the signatures + latency are correct and
-that values are untouched. Wiring L1 latency into the timing model (§5.1) and the
-non-matmul schedules (§5.3) are the next increments.
+The parameterized L1 representation (`SpaceTimeMap`, `StreamSignature` with role/flow/
+bubble, `NetworkOverlay`, `StreamProgram`) and the matmul derivation for the four
+canonical mappings, with validation of the signatures, the output-stationary evacuation
+bubble, and the mesh-vs-hex network classification. Wiring L1 into the timing model
+(§5.1), network-aware placement (§5.2), and non-matmul schedules are next increments.

--- a/docs/plans/l1-stream-signatures.md
+++ b/docs/plans/l1-stream-signatures.md
@@ -1,0 +1,102 @@
+# L1 Stream Signatures — the spatial/temporal layer over L0
+
+**Status:** design + first increment (Phase 0 increment 2, #230; companion to
+`kpu-program-model.md` §3/§6). L1 adds the **spatial/temporal (timing)** layer on top
+of the L0 `TileProgram`: it says *how* each L0 tile becomes an **element stream** into
+or out of the reactive fabric, and *how long* each tile-compute takes as a systolic
+wavefront. **L1 never changes values** — it is derived from L0 + the array mapping, so
+`L0` alone stays the functional reference and `L0+L1` is the timing model
+(BEHAVIORAL vs. TRANSACTIONAL/CYCLE_ACCURATE, per `SIMULATION_FIDELITY_FRAMEWORK.md`).
+
+---
+
+## 1. What L1 attaches to L0
+
+For each L0 op:
+- **Feed / Drain** (a tile ↔ fabric-port injection) → a **`StreamSignature`**: which
+  array **edge**, how many **lanes**, the per-element **lane + wavefront skew**, and the
+  **rate** (elements/cycle/lane).
+- **compute** (`MatMulAccum`, …) → a **`WavefrontTiming`**: the systolic latency of
+  that tile-compute on the array.
+
+L1 is a thin layer keyed by L0 op index — it does not copy or mutate the L0 program.
+
+## 2. The systolic schedule (output-stationary matmul)
+
+Tile matmul `C[i,j] += Σ_k A[i,k]·B[k,j]`, with `i∈[0,R)`, `j∈[0,S)`, `k∈[0,K)`, mapped
+to an `R×S` array where **PE(i,j) accumulates C[i,j]** (output-stationary). The classic
+space-time schedule is the linear wavefront
+
+```
+σ(i,j,k) = i + j + k
+```
+
+which gives, for each operand, a single skewed stream at one array edge:
+
+| Stream | Edge | Lane | Injection time of element | Propagation |
+|---|---|---|---|---|
+| **A** (`A[i,k]`) | **West** | row `i` | `t = i + k` | east, +1 cycle/column |
+| **B** (`B[k,j]`) | **North** | col `j` | `t = j + k` | south, +1 cycle/row |
+| **C** (`C[i,j]`) | **South** (drain) | col `j` | `t = i + j + (K−1)` | out the bottom |
+
+Check: `A[i,k]` injected at West-PE(i,0) at `i+k` reaches PE(i,j) at `i+j+k`; `B[k,j]`
+injected at North-PE(0,j) at `j+k` reaches PE(i,j) at `i+j+k` — they meet exactly when
+PE(i,j) processes product `k`. ✔
+
+**Latency of one tile-compute** (`R×S` array, depth `K`):
+```
+latency = (R−1) + (S−1) + (K−1) + 1        # fill + reduce + drain
+```
+e.g. a 16×16×16 tile-compute = 46 cycles (not a single lumped MAC cost) — the fill and
+drain ramps are now explicit, which is the point of L1.
+
+## 3. `StreamSignature` (per feed/drain)
+
+A tile's `rows×cols` elements become a stream where element `(r,c)`:
+- injects on **lane** `= r` (row axis) or `= c` (col axis),
+- at **time** `t0 + skew_row·r + skew_col·c`,
+- at **rate** elements/cycle/lane.
+
+For the schedule above every matmul stream has `skew_row = skew_col = 1`; they differ
+only by **edge** and **lane axis**:
+
+| L0 op | operand | edge | lane axis | lanes |
+|---|---|---|---|---|
+| `Feed → West` | A tile (`Ti×Tk`) | West | Row | `Ti` |
+| `Feed → North` | B tile (`Tk×Tj`) | North | Col | `Tj` |
+| `Drain → South` | C tile (`Ti×Tj`) | South (output) | Col | `Tj` |
+
+`time_span = skew_row·(rows−1) + skew_col·(cols−1)` is the stream's first→last element
+delay; `element_count = rows·cols`.
+
+## 4. Derivation from L0
+
+`derive_matmul_streams(L0)` walks the L0 ops and emits the table above from each tile's
+element extent (clamped trailing tiles handled), inferring the array dims from the tile
+shape. **Increment-1 assumption:** each tile fits the physical array (`R×S = Ti×Tj`,
+`K = Tk`). Larger tiles sub-blocking onto a fixed physical array (multiple passes) is a
+follow-on. This is the systolic specialization of the general derivation in
+`kpu-program-model.md` §4 (`stream_port(t) = { A[f_A(x)] : σ(x)=t }`); domain_flow's
+`IndexSpace`/`AffineMap`/`schedule`/`wavefront` are the general engine for non-matmul
+operators.
+
+## 5. Integration path (what L1 unlocks next)
+
+1. **Physically-shaped compute cost.** The characterization DAG (`tile_dag.hpp`)
+   currently lumps a compute op at `MACs / macs_per_cycle`. Swapping in
+   `WavefrontTiming::latency()` makes the fill/drain ramps and the true wavefront depth
+   visible in the makespan — a follow-on that plugs into the existing harness with no
+   interface change.
+2. **Drive the cycle-accurate CSP model.** L1 stream signatures are the input the
+   `ConcurrentTimingExecutor` needs (injection order + rate + skew per port), replacing
+   the current inline schedule generation (Phase 0 §6.2).
+3. **Other operators.** LU/Cholesky/QR tile kernels get their own schedules (TRSM is a
+   substitution wavefront; GETRF/panel factor a triangular front) — derived via the
+   domain_flow polyhedral engine rather than the hand-specialized matmul schedule.
+
+## 6. Scope of this first increment
+
+Deliver the L1 representation (`StreamSignature`, `WavefrontTiming`, `StreamProgram`),
+the **matmul** derivation, and validation that the signatures + latency are correct and
+that values are untouched. Wiring L1 latency into the timing model (§5.1) and the
+non-matmul schedules (§5.3) are the next increments.

--- a/include/sw/kpu/program/stream/derive/matmul_streams.hpp
+++ b/include/sw/kpu/program/stream/derive/matmul_streams.hpp
@@ -1,14 +1,17 @@
 // ============================================================================
 // include/sw/kpu/program/stream/derive/matmul_streams.hpp
-// Derive L1 stream signatures for an L0 matmul TileProgram.
+// Derive L1 stream signatures for an L0 matmul TileProgram under a chosen
+// space-time mapping. The streams depend on WHICH operand is stationary:
 //
-// Output-stationary systolic schedule σ(i,j,k)=i+j+k (docs/plans/l1-stream-signatures.md):
-//   A[i,k] streams in at the West edge  (lane = row i,  time = i+k),
-//   B[k,j] streams in at the North edge (lane = col j,  time = j+k),
-//   C[i,j] drains at the South edge     (lane = col j,  time = i+j+(K-1)),
-//   one tile-compute has latency (R-1)+(S-1)+(K-1)+1.
+//   output-stationary  (proj=k) : C held; A→West, B→North, C evacuates North (bubble 1)
+//   weight(B)-stationary (proj=i): B held; A→North, C→East (dense)
+//   A-stationary       (proj=j) : A held; B→North, C→East (dense)
+//   fully-streaming    (proj=[1,1,1]): all stream; hexagonal network (overlay on a mesh)
 //
-// Increment-1 assumption: each tile fits the physical array (R×S = Ti×Tj, K = Tk).
+// The result bubble in the output-stationary case is the crux: C traverses the filled
+// array to the free North edge, so successive results exit two cycles apart. The other
+// mappings evacuate C at the edge where accumulation finishes → dense.
+// See docs/plans/l1-stream-signatures.md.
 //
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024-2025 Stillwater Supercomputing, Inc.
@@ -22,66 +25,82 @@
 
 namespace sw::kpu::program::stream {
 
-// Derive the L1 layer for a matmul L0 program built by derive_matmul_tile_program.
-// `a`/`b`/`c` name the operands (defaults match the deriver). Values are untouched.
+namespace detail {
+inline StreamSignature make_sig(const std::string& var, FlowRole role, Edge edge,
+                                std::array<int, 2> flow, int skew, int stride,
+                                Dim rows, Dim cols) {
+    StreamSignature s;
+    s.var = var; s.role = role; s.rows = rows; s.cols = cols;
+    if (role == FlowRole::Stationary) {
+        s.edge = Edge::None; s.flow = {0, 0}; s.lanes = 0;
+        s.lane_skew = 0; s.element_stride = 1;
+    } else {
+        s.edge = edge; s.flow = flow; s.lane_skew = skew; s.element_stride = stride;
+        s.lanes = (flow[0] != 0) ? cols : rows;   // extent perpendicular to the flow
+    }
+    s.rate = 1.0 / static_cast<double>(s.element_stride);
+    return s;
+}
+} // namespace detail
+
+// Derive the L1 layer for a matmul L0 program under `map` (default output-stationary).
+// Values are untouched. Array dims are read from the (square) tile shape.
 inline StreamProgram derive_matmul_streams(const TileProgram& l0,
+                                           SpaceTimeMap map = SpaceTimeMap::output_stationary(),
                                            const std::string& a = "A",
                                            [[maybe_unused]] const std::string& b = "B",
                                            const std::string& c = "C") {
+    using detail::make_sig;
     StreamProgram sp;
-    const TensorOperand& C = l0.operand(c);
-    sp.array_rows = C.tile_rows;    // nominal physical array = the C tile shape
-    sp.array_cols = C.tile_cols;
+    sp.map = map;
 
+    const TensorOperand& C = l0.operand(c);
+    const TensorOperand& A = l0.operand(a);
+    sp.array_rows = C.tile_rows;
+    sp.array_cols = C.tile_cols;
+    const Dim Ti = C.tile_rows;      // M-tile
+    const Dim Tj = C.tile_cols;      // N-tile
+    const Dim Tk = A.tile_cols;      // K-tile
+    // per-variable tile shapes: A=Ti×Tk, B=Tk×Tj, C=Ti×Tj
+
+    const Vec3& u = map.proj;
+    if (u == Vec3{0, 0, 1}) {                 // output-stationary
+        sp.signatures["A"] = make_sig("A", FlowRole::StreamIn,  Edge::West,  {0, 1}, 1, 1, Ti, Tk);
+        sp.signatures["B"] = make_sig("B", FlowRole::StreamIn,  Edge::North, {1, 0}, 1, 1, Tk, Tj);
+        sp.signatures["C"] = make_sig("C", FlowRole::StreamOut, Edge::North, {-1, 0}, 1, 2, Ti, Tj);
+        sp.network = {FabricTopology::Mesh2D, false, {{0, 1}, {1, 0}, {-1, 0}}};
+    } else if (u == Vec3{1, 0, 0}) {          // weight(B)-stationary
+        sp.signatures["A"] = make_sig("A", FlowRole::StreamIn,  Edge::North, {1, 0}, 1, 1, Ti, Tk);
+        sp.signatures["B"] = make_sig("B", FlowRole::Stationary, Edge::None, {0, 0}, 0, 1, Tk, Tj);
+        sp.signatures["C"] = make_sig("C", FlowRole::StreamOut, Edge::East,  {0, 1}, 1, 1, Ti, Tj);
+        sp.network = {FabricTopology::Mesh2D, false, {{1, 0}, {0, 1}}};
+    } else if (u == Vec3{0, 1, 0}) {          // A-stationary
+        sp.signatures["A"] = make_sig("A", FlowRole::Stationary, Edge::None, {0, 0}, 0, 1, Ti, Tk);
+        sp.signatures["B"] = make_sig("B", FlowRole::StreamIn,  Edge::North, {1, 0}, 1, 1, Tk, Tj);
+        sp.signatures["C"] = make_sig("C", FlowRole::StreamOut, Edge::East,  {0, 1}, 1, 1, Ti, Tj);
+        sp.network = {FabricTopology::Mesh2D, false, {{1, 0}, {0, 1}}};
+    } else {                                  // fully-streaming: hexagonal (proj=[1,1,1])
+        // τ ∥ proj → aligned → dense (no bubbles), perfect concurrency; three stream
+        // directions at 60° require a hex network (an overlay on a 2-D mesh fabric).
+        sp.signatures["A"] = make_sig("A", FlowRole::StreamIn,  Edge::None, {1, 0},  0, 1, Ti, Tk);
+        sp.signatures["B"] = make_sig("B", FlowRole::StreamIn,  Edge::None, {0, 1},  0, 1, Tk, Tj);
+        sp.signatures["C"] = make_sig("C", FlowRole::StreamOut, Edge::None, {-1, -1}, 0, 1, Ti, Tj);
+        sp.network = {FabricTopology::Hexagonal, true, {{1, 0}, {0, 1}, {-1, -1}}};
+    }
+
+    // wavefront timing per compute op (clamped trailing tiles handled)
     const auto& ops = l0.ops();
     for (std::size_t i = 0; i < ops.size(); ++i) {
-        const TileOp& op = ops[i];
-        switch (op.kind) {
-            case TileOpKind::Feed: {
-                const TileCoord& t = op.inputs.at(0);
-                const TensorOperand& operand = l0.operand(t.operand);
-                const Dim rows = operand.row_end(t.ti) - operand.row_begin(t.ti);
-                const Dim cols = operand.col_end(t.tj) - operand.col_begin(t.tj);
-                StreamSignature s;
-                s.port = op.port;
-                s.rows = rows; s.cols = cols;
-                s.skew_row = 1; s.skew_col = 1; s.rate = 1.0; s.is_output = false;
-                if (t.operand == a) {           // A[i,k] -> West, lane = row i
-                    s.edge = Edge::West; s.lane_axis = LaneAxis::Row; s.lanes = rows;
-                } else {                         // B[k,j] -> North, lane = col j
-                    s.edge = Edge::North; s.lane_axis = LaneAxis::Col; s.lanes = cols;
-                }
-                sp.streams[i] = s;
-                break;
-            }
-            case TileOpKind::Drain: {            // C[i,j] -> South, lane = col j
-                const TileCoord& t = op.outputs.at(0);
-                const TensorOperand& operand = l0.operand(t.operand);
-                const Dim rows = operand.row_end(t.ti) - operand.row_begin(t.ti);
-                const Dim cols = operand.col_end(t.tj) - operand.col_begin(t.tj);
-                StreamSignature s;
-                s.port = op.port;
-                s.edge = Edge::South; s.lane_axis = LaneAxis::Col; s.lanes = cols;
-                s.rows = rows; s.cols = cols;
-                s.skew_row = 1; s.skew_col = 1; s.rate = 1.0; s.is_output = true;
-                sp.streams[i] = s;
-                break;
-            }
-            case TileOpKind::MatMulAccum: {
-                const TileCoord& ac = op.inputs.at(0);   // A tile: cols = K depth
-                const TensorOperand& A = l0.operand(ac.operand);
-                const TileCoord& cc = op.outputs.at(0);
-                const TensorOperand& Cop = l0.operand(cc.operand);
-                WavefrontTiming w;
-                w.array_rows = Cop.row_end(cc.ti) - Cop.row_begin(cc.ti);
-                w.array_cols = Cop.col_end(cc.tj) - Cop.col_begin(cc.tj);
-                w.k_depth = A.col_end(ac.tj) - A.col_begin(ac.tj);
-                sp.computes[i] = w;
-                break;
-            }
-            default:
-                break;   // matmul L0 has no other op kinds
-        }
+        if (ops[i].kind != TileOpKind::MatMulAccum) continue;
+        const TileCoord& ac = ops[i].inputs.at(0);
+        const TileCoord& cc = ops[i].outputs.at(0);
+        const TensorOperand& Aop = l0.operand(ac.operand);
+        const TensorOperand& Cop = l0.operand(cc.operand);
+        WavefrontTiming w;
+        w.array_rows = Cop.row_end(cc.ti) - Cop.row_begin(cc.ti);
+        w.array_cols = Cop.col_end(cc.tj) - Cop.col_begin(cc.tj);
+        w.k_depth = Aop.col_end(ac.tj) - Aop.col_begin(ac.tj);
+        sp.computes[i] = w;
     }
     return sp;
 }

--- a/include/sw/kpu/program/stream/derive/matmul_streams.hpp
+++ b/include/sw/kpu/program/stream/derive/matmul_streams.hpp
@@ -1,0 +1,89 @@
+// ============================================================================
+// include/sw/kpu/program/stream/derive/matmul_streams.hpp
+// Derive L1 stream signatures for an L0 matmul TileProgram.
+//
+// Output-stationary systolic schedule σ(i,j,k)=i+j+k (docs/plans/l1-stream-signatures.md):
+//   A[i,k] streams in at the West edge  (lane = row i,  time = i+k),
+//   B[k,j] streams in at the North edge (lane = col j,  time = j+k),
+//   C[i,j] drains at the South edge     (lane = col j,  time = i+j+(K-1)),
+//   one tile-compute has latency (R-1)+(S-1)+(K-1)+1.
+//
+// Increment-1 assumption: each tile fits the physical array (R×S = Ti×Tj, K = Tk).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2025 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/program/stream/stream_signature.hpp>
+
+#include <string>
+
+namespace sw::kpu::program::stream {
+
+// Derive the L1 layer for a matmul L0 program built by derive_matmul_tile_program.
+// `a`/`b`/`c` name the operands (defaults match the deriver). Values are untouched.
+inline StreamProgram derive_matmul_streams(const TileProgram& l0,
+                                           const std::string& a = "A",
+                                           [[maybe_unused]] const std::string& b = "B",
+                                           const std::string& c = "C") {
+    StreamProgram sp;
+    const TensorOperand& C = l0.operand(c);
+    sp.array_rows = C.tile_rows;    // nominal physical array = the C tile shape
+    sp.array_cols = C.tile_cols;
+
+    const auto& ops = l0.ops();
+    for (std::size_t i = 0; i < ops.size(); ++i) {
+        const TileOp& op = ops[i];
+        switch (op.kind) {
+            case TileOpKind::Feed: {
+                const TileCoord& t = op.inputs.at(0);
+                const TensorOperand& operand = l0.operand(t.operand);
+                const Dim rows = operand.row_end(t.ti) - operand.row_begin(t.ti);
+                const Dim cols = operand.col_end(t.tj) - operand.col_begin(t.tj);
+                StreamSignature s;
+                s.port = op.port;
+                s.rows = rows; s.cols = cols;
+                s.skew_row = 1; s.skew_col = 1; s.rate = 1.0; s.is_output = false;
+                if (t.operand == a) {           // A[i,k] -> West, lane = row i
+                    s.edge = Edge::West; s.lane_axis = LaneAxis::Row; s.lanes = rows;
+                } else {                         // B[k,j] -> North, lane = col j
+                    s.edge = Edge::North; s.lane_axis = LaneAxis::Col; s.lanes = cols;
+                }
+                sp.streams[i] = s;
+                break;
+            }
+            case TileOpKind::Drain: {            // C[i,j] -> South, lane = col j
+                const TileCoord& t = op.outputs.at(0);
+                const TensorOperand& operand = l0.operand(t.operand);
+                const Dim rows = operand.row_end(t.ti) - operand.row_begin(t.ti);
+                const Dim cols = operand.col_end(t.tj) - operand.col_begin(t.tj);
+                StreamSignature s;
+                s.port = op.port;
+                s.edge = Edge::South; s.lane_axis = LaneAxis::Col; s.lanes = cols;
+                s.rows = rows; s.cols = cols;
+                s.skew_row = 1; s.skew_col = 1; s.rate = 1.0; s.is_output = true;
+                sp.streams[i] = s;
+                break;
+            }
+            case TileOpKind::MatMulAccum: {
+                const TileCoord& ac = op.inputs.at(0);   // A tile: cols = K depth
+                const TensorOperand& A = l0.operand(ac.operand);
+                const TileCoord& cc = op.outputs.at(0);
+                const TensorOperand& Cop = l0.operand(cc.operand);
+                WavefrontTiming w;
+                w.array_rows = Cop.row_end(cc.ti) - Cop.row_begin(cc.ti);
+                w.array_cols = Cop.col_end(cc.tj) - Cop.col_begin(cc.tj);
+                w.k_depth = A.col_end(ac.tj) - A.col_begin(ac.tj);
+                sp.computes[i] = w;
+                break;
+            }
+            default:
+                break;   // matmul L0 has no other op kinds
+        }
+    }
+    return sp;
+}
+
+} // namespace sw::kpu::program::stream

--- a/include/sw/kpu/program/stream/stream_signature.hpp
+++ b/include/sw/kpu/program/stream/stream_signature.hpp
@@ -1,0 +1,127 @@
+// ============================================================================
+// include/sw/kpu/program/stream/stream_signature.hpp
+// L1 stream signatures — the spatial/temporal (timing) layer over an L0 TileProgram.
+//
+// For each L0 Feed/Drain (a tile <-> fabric-port injection), L1 records HOW the tile's
+// elements become an element stream at an array edge (lane assignment + wavefront skew
+// + rate); for each compute op it records the systolic wavefront latency. L1 never
+// changes values — it is derived from L0 + the array mapping. See
+// docs/plans/l1-stream-signatures.md and kpu-program-model.md §3.
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2025 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#pragma once
+
+#include <sw/kpu/program/tile_program.hpp>
+
+#include <map>
+#include <string>
+
+namespace sw::kpu::program::stream {
+
+using program::Dim;
+using program::TileProgram;
+
+// Array boundary the stream injects into / extracts from.
+enum class Edge { West, North, South, East };
+inline const char* to_string(Edge e) {
+    switch (e) {
+        case Edge::West:  return "West";
+        case Edge::North: return "North";
+        case Edge::South: return "South";
+        case Edge::East:  return "East";
+    }
+    return "?";
+}
+
+// Which tile axis maps to the array-edge lane index.
+enum class LaneAxis { Row, Col };
+
+// ============================================================================
+// StreamSignature — how one tile's rows*cols elements stream at an array edge.
+//
+// Element (r,c) of the tile injects on lane = (r if Row axis else c), at relative
+// time t0 + skew_row*r + skew_col*c, at `rate` elements/cycle/lane.
+// ============================================================================
+struct StreamSignature {
+    std::string port;               // L0 logical port name (West/North/South)
+    Edge edge = Edge::West;
+    LaneAxis lane_axis = LaneAxis::Row;
+    Dim lanes = 0;                  // array-edge cells fed in parallel
+    Dim rows = 0, cols = 0;         // tile element extent
+    int skew_row = 1, skew_col = 1; // affine injection-time skew
+    double rate = 1.0;              // elements / cycle / lane
+    bool is_output = false;         // Drain (extract) vs Feed (inject)
+
+    Dim element_count() const { return rows * cols; }
+
+    Dim lane_of(Dim r, Dim c) const { return lane_axis == LaneAxis::Row ? r : c; }
+    int time_of(Dim r, Dim c) const {
+        return skew_row * static_cast<int>(r) + skew_col * static_cast<int>(c);
+    }
+    // cycles from first to last element injection within the tile.
+    int time_span() const {
+        const int r = rows > 0 ? static_cast<int>(rows) - 1 : 0;
+        const int c = cols > 0 ? static_cast<int>(cols) - 1 : 0;
+        return skew_row * r + skew_col * c;
+    }
+};
+
+// ============================================================================
+// WavefrontTiming — systolic latency of one tile-compute on an R×S array
+// reducing over k_depth, with the output-stationary schedule σ(i,j,k)=i+j+k.
+// ============================================================================
+struct WavefrontTiming {
+    Dim array_rows = 0, array_cols = 0, k_depth = 0;
+
+    // latency = (R-1) + (S-1) + (K-1) + 1  =  fill + reduce + drain
+    Dim latency() const {
+        auto m = [](Dim x) { return x > 0 ? x - 1 : 0; };
+        return m(array_rows) + m(array_cols) + m(k_depth) + 1;
+    }
+};
+
+// ============================================================================
+// StreamProgram — the L1 layer over an L0 TileProgram, keyed by L0 op index.
+// ============================================================================
+struct StreamProgram {
+    std::map<std::size_t, StreamSignature> streams;   // op index -> feed/drain signature
+    std::map<std::size_t, WavefrontTiming> computes;  // op index -> wavefront timing
+    Dim array_rows = 0, array_cols = 0;               // inferred physical array
+
+    std::string disassemble(const TileProgram& l0) const;
+};
+
+// ---- disassembly -----------------------------------------------------------
+inline std::string StreamProgram::disassemble(const TileProgram& l0) const {
+    std::string s = "StreamProgram (array " + std::to_string(array_rows) + "x" +
+                    std::to_string(array_cols) + ")\n";
+    const auto& ops = l0.ops();
+    for (std::size_t i = 0; i < ops.size(); ++i) {
+        auto st = streams.find(i);
+        if (st != streams.end()) {
+            const auto& sg = st->second;
+            const auto& op = ops[i];
+            const auto tile = op.outputs.empty()
+                ? (op.inputs.empty() ? std::string() : op.inputs[0].to_string())
+                : op.outputs[0].to_string();
+            s += "  " + std::to_string(i) + ": " + (sg.is_output ? "OUT " : "IN  ") + tile +
+                 " @" + to_string(sg.edge) + " lanes=" + std::to_string(sg.lanes) +
+                 " skew(" + std::to_string(sg.skew_row) + "," + std::to_string(sg.skew_col) +
+                 ") span=" + std::to_string(sg.time_span()) +
+                 " elems=" + std::to_string(sg.element_count()) + "\n";
+        }
+        auto ct = computes.find(i);
+        if (ct != computes.end()) {
+            const auto& w = ct->second;
+            s += "  " + std::to_string(i) + ": COMPUTE " + ops[i].outputs[0].to_string() +
+                 " wavefront " + std::to_string(w.array_rows) + "x" + std::to_string(w.array_cols) +
+                 "x" + std::to_string(w.k_depth) + " latency=" + std::to_string(w.latency()) + "\n";
+        }
+    }
+    return s;
+}
+
+} // namespace sw::kpu::program::stream

--- a/include/sw/kpu/program/stream/stream_signature.hpp
+++ b/include/sw/kpu/program/stream/stream_signature.hpp
@@ -2,10 +2,10 @@
 // include/sw/kpu/program/stream/stream_signature.hpp
 // L1 stream signatures — the spatial/temporal (timing) layer over an L0 TileProgram.
 //
-// For each L0 Feed/Drain (a tile <-> fabric-port injection), L1 records HOW the tile's
-// elements become an element stream at an array edge (lane assignment + wavefront skew
-// + rate); for each compute op it records the systolic wavefront latency. L1 never
-// changes values — it is derived from L0 + the array mapping. See
+// The streams are a FUNCTION OF THE SPACE-TIME MAPPING (which operand is stationary),
+// so L1 is parameterized by a SpaceTimeMap (schedule vector τ + projection u) and also
+// records the NETWORK the resulting streams require (a 2-D mesh vs. a hexagonal
+// overlay). L1 never changes values — it is derived from L0 + the mapping. See
 // docs/plans/l1-stream-signatures.md and kpu-program-model.md §3.
 //
 // SPDX-License-Identifier: MIT
@@ -16,110 +16,165 @@
 
 #include <sw/kpu/program/tile_program.hpp>
 
+#include <array>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace sw::kpu::program::stream {
 
 using program::Dim;
 using program::TileProgram;
 
-// Array boundary the stream injects into / extracts from.
-enum class Edge { West, North, South, East };
+// 3-D integer vector over the matmul iteration axes (i, j, k).
+using Vec3 = std::array<int, 3>;
+
+inline int dot(const Vec3& a, const Vec3& b) { return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]; }
+// parallel (same or opposite direction) for the axis/[1,1,1] vectors we use.
+inline bool parallel(const Vec3& a, const Vec3& b) {
+    // cross product == 0
+    return a[1]*b[2] - a[2]*b[1] == 0 &&
+           a[2]*b[0] - a[0]*b[2] == 0 &&
+           a[0]*b[1] - a[1]*b[0] == 0;
+}
+
+// ============================================================================
+// SpaceTimeMap — schedule τ (time = τ·x) + projection u (collapsed/stationary axis).
+// A variable with propagation direction e_V is stationary iff u ∥ e_V.
+// ============================================================================
+struct SpaceTimeMap {
+    Vec3 tau  = {1, 1, 1};   // schedule vector
+    Vec3 proj = {0, 0, 1};   // projection direction (which axis is projected out)
+    std::string name = "output-stationary";
+
+    static SpaceTimeMap output_stationary() { return {{1,1,1}, {0,0,1}, "output-stationary"}; }
+    static SpaceTimeMap b_stationary()      { return {{1,1,1}, {1,0,0}, "weight(B)-stationary"}; }
+    static SpaceTimeMap a_stationary()      { return {{1,1,1}, {0,1,0}, "A-stationary"}; }
+    static SpaceTimeMap fully_streaming()   { return {{1,1,1}, {1,1,1}, "fully-streaming(hex)"}; }
+
+    // schedule/projection aligned (τ ∥ u) → the contention-free hexagonal case.
+    bool aligned() const { return parallel(tau, proj); }
+};
+
+// Matmul variable propagation directions (the axis each is invariant along).
+inline Vec3 propagation_dir(const std::string& var) {
+    if (var == "A") return {0, 1, 0};   // A[i,k] invariant along j
+    if (var == "B") return {1, 0, 0};   // B[k,j] invariant along i
+    return {0, 0, 1};                    // C[i,j] accumulates along k
+}
+
+// ---- streams & network -----------------------------------------------------
+enum class Edge { West, North, South, East, None };
 inline const char* to_string(Edge e) {
     switch (e) {
         case Edge::West:  return "West";
         case Edge::North: return "North";
         case Edge::South: return "South";
         case Edge::East:  return "East";
+        case Edge::None:  return "None";
     }
     return "?";
 }
 
-// Which tile axis maps to the array-edge lane index.
-enum class LaneAxis { Row, Col };
+enum class FlowRole { Stationary, StreamIn, StreamOut };
+inline const char* to_string(FlowRole r) {
+    switch (r) {
+        case FlowRole::Stationary: return "STATIONARY";
+        case FlowRole::StreamIn:   return "STREAM_IN";
+        case FlowRole::StreamOut:  return "STREAM_OUT";
+    }
+    return "?";
+}
+
+enum class FabricTopology { Mesh2D, Hexagonal };
+inline const char* to_string(FabricTopology f) {
+    return f == FabricTopology::Mesh2D ? "Mesh2D" : "Hexagonal";
+}
 
 // ============================================================================
-// StreamSignature — how one tile's rows*cols elements stream at an array edge.
-//
-// Element (r,c) of the tile injects on lane = (r if Row axis else c), at relative
-// time t0 + skew_row*r + skew_col*c, at `rate` elements/cycle/lane.
+// StreamSignature — how one variable's tile streams (or stays) in the array.
+// element (r,c) of a tile injects on `lane` at relative time
+//   t0 + lane_skew·(lane) + element_stride·(sequence-index)   (schedule-derived).
 // ============================================================================
 struct StreamSignature {
-    std::string port;               // L0 logical port name (West/North/South)
-    Edge edge = Edge::West;
-    LaneAxis lane_axis = LaneAxis::Row;
-    Dim lanes = 0;                  // array-edge cells fed in parallel
-    Dim rows = 0, cols = 0;         // tile element extent
-    int skew_row = 1, skew_col = 1; // affine injection-time skew
-    double rate = 1.0;              // elements / cycle / lane
-    bool is_output = false;         // Drain (extract) vs Feed (inject)
+    std::string var;                 // "A" / "B" / "C"
+    FlowRole role = FlowRole::StreamIn;
+    Edge edge = Edge::West;          // entry (StreamIn) / exit (StreamOut) edge
+    std::array<int, 2> flow = {0, 0}; // array-space step per cycle {d_row, d_col}
+    int lane_skew = 0;               // per-lane start offset
+    int element_stride = 1;          // cycles between consecutive elements on a lane
+    Dim lanes = 0;
+    Dim rows = 0, cols = 0;          // tile element extent
+    double rate = 1.0;               // effective elements/cycle/lane = 1/element_stride
 
+    int bubble() const { return element_stride > 0 ? element_stride - 1 : 0; }
     Dim element_count() const { return rows * cols; }
-
-    Dim lane_of(Dim r, Dim c) const { return lane_axis == LaneAxis::Row ? r : c; }
-    int time_of(Dim r, Dim c) const {
-        return skew_row * static_cast<int>(r) + skew_col * static_cast<int>(c);
-    }
-    // cycles from first to last element injection within the tile.
-    int time_span() const {
-        const int r = rows > 0 ? static_cast<int>(rows) - 1 : 0;
-        const int c = cols > 0 ? static_cast<int>(cols) - 1 : 0;
-        return skew_row * r + skew_col * c;
-    }
+    bool dense() const { return element_stride == 1; }
 };
 
-// ============================================================================
-// WavefrontTiming — systolic latency of one tile-compute on an R×S array
-// reducing over k_depth, with the output-stationary schedule σ(i,j,k)=i+j+k.
-// ============================================================================
+// Systolic wavefront latency of one tile-compute on an R×S array reducing over
+// k_depth, schedule σ(i,j,k)=i+j+k: (R-1)+(S-1)+(K-1)+1 = fill + reduce + drain.
 struct WavefrontTiming {
     Dim array_rows = 0, array_cols = 0, k_depth = 0;
-
-    // latency = (R-1) + (S-1) + (K-1) + 1  =  fill + reduce + drain
     Dim latency() const {
         auto m = [](Dim x) { return x > 0 ? x - 1 : 0; };
         return m(array_rows) + m(array_cols) + m(k_depth) + 1;
     }
 };
 
+// The interconnect the chosen mapping's streams require.
+struct NetworkOverlay {
+    FabricTopology required = FabricTopology::Mesh2D;
+    bool needs_overlay_on_mesh = false;                  // Hexagonal on a 2-D mesh fabric
+    std::vector<std::array<int, 2>> stream_directions;   // distinct array flow directions
+};
+
 // ============================================================================
-// StreamProgram — the L1 layer over an L0 TileProgram, keyed by L0 op index.
+// StreamProgram — the L1 layer over an L0 matmul TileProgram for one SpaceTimeMap.
 // ============================================================================
 struct StreamProgram {
-    std::map<std::size_t, StreamSignature> streams;   // op index -> feed/drain signature
-    std::map<std::size_t, WavefrontTiming> computes;  // op index -> wavefront timing
-    Dim array_rows = 0, array_cols = 0;               // inferred physical array
+    SpaceTimeMap map;
+    std::map<std::string, StreamSignature> signatures;   // by variable name
+    NetworkOverlay network;
+    std::map<std::size_t, WavefrontTiming> computes;     // by L0 op index
+    Dim array_rows = 0, array_cols = 0;
 
-    std::string disassemble(const TileProgram& l0) const;
+    const StreamSignature* signature(const std::string& var) const {
+        auto it = signatures.find(var);
+        return it == signatures.end() ? nullptr : &it->second;
+    }
+
+    std::string disassemble() const;
 };
 
 // ---- disassembly -----------------------------------------------------------
-inline std::string StreamProgram::disassemble(const TileProgram& l0) const {
-    std::string s = "StreamProgram (array " + std::to_string(array_rows) + "x" +
-                    std::to_string(array_cols) + ")\n";
-    const auto& ops = l0.ops();
-    for (std::size_t i = 0; i < ops.size(); ++i) {
-        auto st = streams.find(i);
-        if (st != streams.end()) {
-            const auto& sg = st->second;
-            const auto& op = ops[i];
-            const auto tile = op.outputs.empty()
-                ? (op.inputs.empty() ? std::string() : op.inputs[0].to_string())
-                : op.outputs[0].to_string();
-            s += "  " + std::to_string(i) + ": " + (sg.is_output ? "OUT " : "IN  ") + tile +
-                 " @" + to_string(sg.edge) + " lanes=" + std::to_string(sg.lanes) +
-                 " skew(" + std::to_string(sg.skew_row) + "," + std::to_string(sg.skew_col) +
-                 ") span=" + std::to_string(sg.time_span()) +
-                 " elems=" + std::to_string(sg.element_count()) + "\n";
+inline std::string StreamProgram::disassemble() const {
+    std::string s = "StreamProgram [" + map.name + "] array " +
+                    std::to_string(array_rows) + "x" + std::to_string(array_cols) +
+                    "  network=" + to_string(network.required) +
+                    (network.needs_overlay_on_mesh ? " (overlay-on-mesh)" : "") + "\n";
+    for (const auto& var : {std::string("A"), std::string("B"), std::string("C")}) {
+        auto it = signatures.find(var);
+        if (it == signatures.end()) continue;
+        const auto& sg = it->second;
+        s += "  " + var + ": " + to_string(sg.role);
+        if (sg.role != FlowRole::Stationary) {
+            s += " @" + std::string(to_string(sg.edge)) +
+                 " flow(" + std::to_string(sg.flow[0]) + "," + std::to_string(sg.flow[1]) + ")" +
+                 " skew=" + std::to_string(sg.lane_skew) +
+                 " stride=" + std::to_string(sg.element_stride) +
+                 " bubble=" + std::to_string(sg.bubble()) +
+                 " lanes=" + std::to_string(sg.lanes);
         }
-        auto ct = computes.find(i);
-        if (ct != computes.end()) {
-            const auto& w = ct->second;
-            s += "  " + std::to_string(i) + ": COMPUTE " + ops[i].outputs[0].to_string() +
-                 " wavefront " + std::to_string(w.array_rows) + "x" + std::to_string(w.array_cols) +
-                 "x" + std::to_string(w.k_depth) + " latency=" + std::to_string(w.latency()) + "\n";
-        }
+        s += "\n";
+    }
+    // one representative wavefront
+    if (!computes.empty()) {
+        const auto& w = computes.begin()->second;
+        s += "  compute wavefront " + std::to_string(w.array_rows) + "x" +
+             std::to_string(w.array_cols) + "x" + std::to_string(w.k_depth) +
+             " latency=" + std::to_string(w.latency()) + " (x" +
+             std::to_string(computes.size()) + ")\n";
     }
     return s;
 }

--- a/tests/program/CMakeLists.txt
+++ b/tests/program/CMakeLists.txt
@@ -23,3 +23,12 @@ kpu_add_component_test(test_tile_characterize "program"
 set_tests_properties(test_tile_characterize PROPERTIES
     LABELS "program;characterize;v0.9"
 )
+
+# L1 stream signatures (spatial/temporal layer over L0)
+kpu_add_component_test(test_stream_signature "program"
+    test_stream_signature.cpp
+)
+
+set_tests_properties(test_stream_signature PROPERTIES
+    LABELS "program;stream;v0.9"
+)

--- a/tests/program/test_stream_signature.cpp
+++ b/tests/program/test_stream_signature.cpp
@@ -1,0 +1,157 @@
+// ============================================================================
+// tests/program/test_stream_signature.cpp
+// L1 stream signatures: matmul derivation (output-stationary systolic schedule),
+// wavefront latency, and value-orthogonality (L1 does not change L0 results).
+//
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2025 Stillwater Supercomputing, Inc.
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sw/kpu/program/derive/matmul_tile_program.hpp>
+#include <sw/kpu/program/tile_program_reference.hpp>
+#include <sw/kpu/program/stream/derive/matmul_streams.hpp>
+
+#include <cmath>
+#include <vector>
+
+using namespace sw::kpu::program;
+using namespace sw::kpu::program::stream;
+
+namespace {
+StreamSignature sig_for(const StreamProgram& sp, const TileProgram& l0,
+                        TileOpKind kind, const std::string& port) {
+    const auto& ops = l0.ops();
+    for (const auto& [idx, s] : sp.streams)
+        if (ops[idx].kind == kind && s.port == port) return s;
+    FAIL("no stream signature for the requested op/port");
+    return {};   // unreachable
+}
+} // namespace
+
+TEST_CASE("matmul L1: A/B/C stream signatures match the output-stationary schedule",
+          "[program][stream]") {
+    const Dim N = 64, T = 16;   // 4x4x4 tile grid; each tile fits a 16x16 array
+    TileProgram l0 = derive_matmul_tile_program(N, N, N, T, T, T);
+    StreamProgram sp = derive_matmul_streams(l0);
+
+    CHECK(sp.array_rows == T);
+    CHECK(sp.array_cols == T);
+
+    // counts: feeds = 2 * mt*nt*kt, drains = mt*nt, computes = mt*nt*kt
+    CHECK(sp.streams.size() == static_cast<std::size_t>(2 * 4 * 4 * 4 + 4 * 4));
+    CHECK(sp.computes.size() == static_cast<std::size_t>(4 * 4 * 4));
+
+    // A -> West, lane = row, skew (1,1)
+    const StreamSignature A = sig_for(sp, l0, TileOpKind::Feed, "West");
+    CHECK(A.edge == Edge::West);
+    CHECK(A.lane_axis == LaneAxis::Row);
+    CHECK(A.lanes == T);
+    CHECK(A.rows == T);
+    CHECK(A.cols == T);
+    CHECK(A.skew_row == 1);
+    CHECK(A.skew_col == 1);
+    CHECK_FALSE(A.is_output);
+    CHECK(A.element_count() == T * T);
+    CHECK(A.time_span() == 2 * (T - 1));          // (i+k) span over the tile
+    CHECK(A.lane_of(3, 5) == 3);                   // lane = row index
+    CHECK(A.time_of(3, 5) == 8);                   // t = i + k
+
+    // B -> North, lane = col
+    const StreamSignature B = sig_for(sp, l0, TileOpKind::Feed, "North");
+    CHECK(B.edge == Edge::North);
+    CHECK(B.lane_axis == LaneAxis::Col);
+    CHECK(B.lanes == T);
+    CHECK(B.lane_of(3, 5) == 5);                   // lane = col index
+    CHECK(B.time_of(3, 5) == 8);                   // t = j + k
+
+    // C drain -> South (output)
+    const StreamSignature C = sig_for(sp, l0, TileOpKind::Drain, "South");
+    CHECK(C.edge == Edge::South);
+    CHECK(C.is_output);
+    CHECK(C.lane_axis == LaneAxis::Col);
+}
+
+TEST_CASE("matmul L1: wavefront latency is the systolic fill+reduce+drain", "[program][stream]") {
+    const Dim T = 16;
+    TileProgram l0 = derive_matmul_tile_program(64, 64, 64, T, T, T);
+    StreamProgram sp = derive_matmul_streams(l0);
+
+    // every compute is a full 16x16x16 tile -> latency (16-1)*3 + 1 = 46
+    for (const auto& [idx, w] : sp.computes) {
+        (void)idx;
+        CHECK(w.array_rows == T);
+        CHECK(w.array_cols == T);
+        CHECK(w.k_depth == T);
+        CHECK(w.latency() == static_cast<Dim>(3 * (T - 1) + 1));
+        // physically shaped: a wavefront costs far more than a single MAC cycle
+        CHECK(w.latency() > 1);
+    }
+}
+
+TEST_CASE("matmul L1: clamped trailing tiles size the wavefront correctly", "[program][stream]") {
+    // N=40, T=16 -> 3x3x3 grid, trailing tile dim = 8.
+    const Dim N = 40, T = 16;
+    TileProgram l0 = derive_matmul_tile_program(N, N, N, T, T, T);
+    StreamProgram sp = derive_matmul_streams(l0);
+
+    // find the compute writing the corner tile C[2,2] with the trailing A K-slice tk=2
+    const auto& ops = l0.ops();
+    bool saw_corner = false;
+    for (const auto& [idx, w] : sp.computes) {
+        const auto& out = ops[idx].outputs[0];
+        const auto& ain = ops[idx].inputs[0];
+        if (out.ti == 2 && out.tj == 2 && ain.tj == 2) {   // all trailing -> 8x8x8
+            CHECK(w.array_rows == 8);
+            CHECK(w.array_cols == 8);
+            CHECK(w.k_depth == 8);
+            CHECK(w.latency() == static_cast<Dim>(3 * 7 + 1));
+            saw_corner = true;
+        }
+    }
+    CHECK(saw_corner);
+}
+
+TEST_CASE("matmul L1 is value-orthogonal (derivation does not change L0 results)",
+          "[program][stream]") {
+    const Dim M = 6, N = 4, K = 8, Ti = 2, Tj = 2, Tk = 4;
+    TileProgram l0 = derive_matmul_tile_program(M, N, K, Ti, Tj, Tk);
+
+    std::vector<float> A(static_cast<std::size_t>(M) * K), B(static_cast<std::size_t>(K) * N);
+    for (Dim i = 0; i < M; ++i)
+        for (Dim k = 0; k < K; ++k) A[static_cast<std::size_t>(i) * K + k] = float((i + 2 * k) % 7);
+    for (Dim k = 0; k < K; ++k)
+        for (Dim j = 0; j < N; ++j) B[static_cast<std::size_t>(k) * N + j] = float((3 * k + j) % 5);
+    l0.operand("A").values = A;
+    l0.operand("B").values = B;
+
+    // deriving L1 must not touch the L0 program (it takes it by const&)
+    StreamProgram sp = derive_matmul_streams(l0);
+    CHECK(!sp.streams.empty());
+
+    TileProgramReference ref;
+    ref.run(l0);
+
+    float max_err = 0.0f;
+    const auto& C = l0.operand("C").values;
+    for (Dim i = 0; i < M; ++i)
+        for (Dim j = 0; j < N; ++j) {
+            float acc = 0.0f;
+            for (Dim k = 0; k < K; ++k) acc += A[std::size_t(i) * K + k] * B[std::size_t(k) * N + j];
+            max_err = std::max(max_err, std::fabs(acc - C[std::size_t(i) * N + j]));
+        }
+    CHECK(max_err == 0.0f);
+}
+
+TEST_CASE("StreamProgram disassembly lists the stream layer", "[program][stream]") {
+    TileProgram l0 = derive_matmul_tile_program(32, 32, 32, 16, 16, 16);
+    StreamProgram sp = derive_matmul_streams(l0);
+    const std::string text = sp.disassemble(l0);
+    CHECK(text.find("StreamProgram") != std::string::npos);
+    CHECK(text.find("@West") != std::string::npos);
+    CHECK(text.find("@North") != std::string::npos);
+    CHECK(text.find("@South") != std::string::npos);
+    CHECK(text.find("wavefront") != std::string::npos);
+    CHECK(text.find("latency=") != std::string::npos);
+}

--- a/tests/program/test_stream_signature.cpp
+++ b/tests/program/test_stream_signature.cpp
@@ -1,7 +1,8 @@
 // ============================================================================
 // tests/program/test_stream_signature.cpp
-// L1 stream signatures: matmul derivation (output-stationary systolic schedule),
-// wavefront latency, and value-orthogonality (L1 does not change L0 results).
+// L1 stream signatures: the space-time-mapping taxonomy (which operand is
+// stationary), the output-stationary result-evacuation bubble, the mesh-vs-hex
+// network requirement, wavefront latency, and value-orthogonality.
 //
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024-2025 Stillwater Supercomputing, Inc.
@@ -19,92 +20,111 @@
 using namespace sw::kpu::program;
 using namespace sw::kpu::program::stream;
 
-namespace {
-StreamSignature sig_for(const StreamProgram& sp, const TileProgram& l0,
-                        TileOpKind kind, const std::string& port) {
-    const auto& ops = l0.ops();
-    for (const auto& [idx, s] : sp.streams)
-        if (ops[idx].kind == kind && s.port == port) return s;
-    FAIL("no stream signature for the requested op/port");
-    return {};   // unreachable
-}
-} // namespace
-
-TEST_CASE("matmul L1: A/B/C stream signatures match the output-stationary schedule",
-          "[program][stream]") {
-    const Dim N = 64, T = 16;   // 4x4x4 tile grid; each tile fits a 16x16 array
-    TileProgram l0 = derive_matmul_tile_program(N, N, N, T, T, T);
-    StreamProgram sp = derive_matmul_streams(l0);
-
-    CHECK(sp.array_rows == T);
-    CHECK(sp.array_cols == T);
-
-    // counts: feeds = 2 * mt*nt*kt, drains = mt*nt, computes = mt*nt*kt
-    CHECK(sp.streams.size() == static_cast<std::size_t>(2 * 4 * 4 * 4 + 4 * 4));
-    CHECK(sp.computes.size() == static_cast<std::size_t>(4 * 4 * 4));
-
-    // A -> West, lane = row, skew (1,1)
-    const StreamSignature A = sig_for(sp, l0, TileOpKind::Feed, "West");
-    CHECK(A.edge == Edge::West);
-    CHECK(A.lane_axis == LaneAxis::Row);
-    CHECK(A.lanes == T);
-    CHECK(A.rows == T);
-    CHECK(A.cols == T);
-    CHECK(A.skew_row == 1);
-    CHECK(A.skew_col == 1);
-    CHECK_FALSE(A.is_output);
-    CHECK(A.element_count() == T * T);
-    CHECK(A.time_span() == 2 * (T - 1));          // (i+k) span over the tile
-    CHECK(A.lane_of(3, 5) == 3);                   // lane = row index
-    CHECK(A.time_of(3, 5) == 8);                   // t = i + k
-
-    // B -> North, lane = col
-    const StreamSignature B = sig_for(sp, l0, TileOpKind::Feed, "North");
-    CHECK(B.edge == Edge::North);
-    CHECK(B.lane_axis == LaneAxis::Col);
-    CHECK(B.lanes == T);
-    CHECK(B.lane_of(3, 5) == 5);                   // lane = col index
-    CHECK(B.time_of(3, 5) == 8);                   // t = j + k
-
-    // C drain -> South (output)
-    const StreamSignature C = sig_for(sp, l0, TileOpKind::Drain, "South");
-    CHECK(C.edge == Edge::South);
-    CHECK(C.is_output);
-    CHECK(C.lane_axis == LaneAxis::Col);
-}
-
-TEST_CASE("matmul L1: wavefront latency is the systolic fill+reduce+drain", "[program][stream]") {
+TEST_CASE("output-stationary: A/B stream in, C evacuates North with a bubble", "[program][stream]") {
     const Dim T = 16;
     TileProgram l0 = derive_matmul_tile_program(64, 64, 64, T, T, T);
-    StreamProgram sp = derive_matmul_streams(l0);
+    StreamProgram sp = derive_matmul_streams(l0, SpaceTimeMap::output_stationary());
 
-    // every compute is a full 16x16x16 tile -> latency (16-1)*3 + 1 = 46
-    for (const auto& [idx, w] : sp.computes) {
-        (void)idx;
-        CHECK(w.array_rows == T);
-        CHECK(w.array_cols == T);
-        CHECK(w.k_depth == T);
-        CHECK(w.latency() == static_cast<Dim>(3 * (T - 1) + 1));
-        // physically shaped: a wavefront costs far more than a single MAC cycle
-        CHECK(w.latency() > 1);
-    }
+    const StreamSignature* A = sp.signature("A");
+    const StreamSignature* B = sp.signature("B");
+    const StreamSignature* C = sp.signature("C");
+    REQUIRE((A && B && C));
+
+    // A -> West, streams in, dense
+    CHECK(A->role == FlowRole::StreamIn);
+    CHECK(A->edge == Edge::West);
+    CHECK(A->dense());
+    CHECK(A->lanes == T);
+
+    // B -> North, streams in, dense
+    CHECK(B->role == FlowRole::StreamIn);
+    CHECK(B->edge == Edge::North);
+    CHECK(B->dense());
+
+    // C -> evacuates NORTH (not South — that collides with B and sibling C),
+    // and picks up a bubble because it traverses the filled array.
+    CHECK(C->role == FlowRole::StreamOut);
+    CHECK(C->edge == Edge::North);
+    CHECK(C->flow == std::array<int, 2>{-1, 0});   // northbound
+    CHECK(C->element_stride == 2);
+    CHECK(C->bubble() == 1);
+    CHECK_FALSE(C->dense());
+
+    // output-stationary fits a plain 2-D mesh
+    CHECK(sp.network.required == FabricTopology::Mesh2D);
+    CHECK_FALSE(sp.network.needs_overlay_on_mesh);
 }
 
-TEST_CASE("matmul L1: clamped trailing tiles size the wavefront correctly", "[program][stream]") {
-    // N=40, T=16 -> 3x3x3 grid, trailing tile dim = 8.
-    const Dim N = 40, T = 16;
-    TileProgram l0 = derive_matmul_tile_program(N, N, N, T, T, T);
-    StreamProgram sp = derive_matmul_streams(l0);
+TEST_CASE("weight(B)-stationary: B is held, C exits East dense", "[program][stream]") {
+    const Dim T = 16;
+    TileProgram l0 = derive_matmul_tile_program(64, 64, 64, T, T, T);
+    StreamProgram sp = derive_matmul_streams(l0, SpaceTimeMap::b_stationary());
 
-    // find the compute writing the corner tile C[2,2] with the trailing A K-slice tk=2
+    CHECK(sp.signature("B")->role == FlowRole::Stationary);
+    CHECK(sp.signature("A")->role == FlowRole::StreamIn);
+    const StreamSignature* C = sp.signature("C");
+    CHECK(C->role == FlowRole::StreamOut);
+    CHECK(C->edge == Edge::East);
+    CHECK(C->dense());                       // accumulate-and-exit, no traversal bubble
+    CHECK(C->bubble() == 0);
+    CHECK(sp.network.required == FabricTopology::Mesh2D);
+}
+
+TEST_CASE("A-stationary: A is held, mesh network", "[program][stream]") {
+    TileProgram l0 = derive_matmul_tile_program(64, 64, 64, 16, 16, 16);
+    StreamProgram sp = derive_matmul_streams(l0, SpaceTimeMap::a_stationary());
+    CHECK(sp.signature("A")->role == FlowRole::Stationary);
+    CHECK(sp.signature("B")->role == FlowRole::StreamIn);
+    CHECK(sp.signature("C")->role == FlowRole::StreamOut);
+    CHECK(sp.network.required == FabricTopology::Mesh2D);
+}
+
+TEST_CASE("fully-streaming: hexagonal network, all operands stream, no bubbles",
+          "[program][stream]") {
+    TileProgram l0 = derive_matmul_tile_program(64, 64, 64, 16, 16, 16);
+    SpaceTimeMap hex = SpaceTimeMap::fully_streaming();
+    StreamProgram sp = derive_matmul_streams(l0, hex);
+
+    // τ ∥ proj = [1,1,1]  -> aligned, contention-free
+    CHECK(hex.aligned());
+
+    // no operand is stationary
+    CHECK(sp.signature("A")->role != FlowRole::Stationary);
+    CHECK(sp.signature("B")->role != FlowRole::Stationary);
+    CHECK(sp.signature("C")->role == FlowRole::StreamOut);
+
+    // aligned schedule -> every stream is dense (no bubbles)
+    CHECK(sp.signature("A")->dense());
+    CHECK(sp.signature("B")->dense());
+    CHECK(sp.signature("C")->dense());
+
+    // three stream directions -> hexagonal, needing an overlay on a 2-D mesh
+    CHECK(sp.network.required == FabricTopology::Hexagonal);
+    CHECK(sp.network.needs_overlay_on_mesh);
+    CHECK(sp.network.stream_directions.size() == 3u);
+}
+
+TEST_CASE("wavefront latency is the systolic fill+reduce+drain (incl. clamped tiles)",
+          "[program][stream]") {
+    const Dim T = 16;
+    // full 16^3 tiles
+    StreamProgram full = derive_matmul_streams(derive_matmul_tile_program(64, 64, 64, T, T, T));
+    for (const auto& [idx, w] : full.computes) {
+        (void)idx;
+        CHECK(w.latency() == static_cast<Dim>(3 * (T - 1) + 1));   // 46
+        CHECK(w.latency() > 1);                                    // physically shaped, not lumped
+    }
+
+    // N=40 -> trailing 8x8x8 corner tile
+    TileProgram l0 = derive_matmul_tile_program(40, 40, 40, T, T, T);
+    StreamProgram sp = derive_matmul_streams(l0);
     const auto& ops = l0.ops();
     bool saw_corner = false;
     for (const auto& [idx, w] : sp.computes) {
         const auto& out = ops[idx].outputs[0];
         const auto& ain = ops[idx].inputs[0];
-        if (out.ti == 2 && out.tj == 2 && ain.tj == 2) {   // all trailing -> 8x8x8
+        if (out.ti == 2 && out.tj == 2 && ain.tj == 2) {
             CHECK(w.array_rows == 8);
-            CHECK(w.array_cols == 8);
             CHECK(w.k_depth == 8);
             CHECK(w.latency() == static_cast<Dim>(3 * 7 + 1));
             saw_corner = true;
@@ -113,7 +133,7 @@ TEST_CASE("matmul L1: clamped trailing tiles size the wavefront correctly", "[pr
     CHECK(saw_corner);
 }
 
-TEST_CASE("matmul L1 is value-orthogonal (derivation does not change L0 results)",
+TEST_CASE("L1 is value-orthogonal (derivation does not change L0 results)",
           "[program][stream]") {
     const Dim M = 6, N = 4, K = 8, Ti = 2, Tj = 2, Tk = 4;
     TileProgram l0 = derive_matmul_tile_program(M, N, K, Ti, Tj, Tk);
@@ -126,9 +146,9 @@ TEST_CASE("matmul L1 is value-orthogonal (derivation does not change L0 results)
     l0.operand("A").values = A;
     l0.operand("B").values = B;
 
-    // deriving L1 must not touch the L0 program (it takes it by const&)
-    StreamProgram sp = derive_matmul_streams(l0);
-    CHECK(!sp.streams.empty());
+    // deriving any mapping's L1 must not touch the L0 program (const&)
+    StreamProgram sp = derive_matmul_streams(l0, SpaceTimeMap::fully_streaming());
+    CHECK(!sp.signatures.empty());
 
     TileProgramReference ref;
     ref.run(l0);
@@ -144,14 +164,16 @@ TEST_CASE("matmul L1 is value-orthogonal (derivation does not change L0 results)
     CHECK(max_err == 0.0f);
 }
 
-TEST_CASE("StreamProgram disassembly lists the stream layer", "[program][stream]") {
+TEST_CASE("StreamProgram disassembly names mapping, roles, bubbles, and network",
+          "[program][stream]") {
     TileProgram l0 = derive_matmul_tile_program(32, 32, 32, 16, 16, 16);
-    StreamProgram sp = derive_matmul_streams(l0);
-    const std::string text = sp.disassemble(l0);
-    CHECK(text.find("StreamProgram") != std::string::npos);
-    CHECK(text.find("@West") != std::string::npos);
-    CHECK(text.find("@North") != std::string::npos);
-    CHECK(text.find("@South") != std::string::npos);
-    CHECK(text.find("wavefront") != std::string::npos);
-    CHECK(text.find("latency=") != std::string::npos);
+    const std::string os = derive_matmul_streams(l0, SpaceTimeMap::output_stationary()).disassemble();
+    CHECK(os.find("output-stationary") != std::string::npos);
+    CHECK(os.find("network=Mesh2D") != std::string::npos);
+    CHECK(os.find("bubble=1") != std::string::npos);
+    CHECK(os.find("wavefront") != std::string::npos);
+
+    const std::string hx = derive_matmul_streams(l0, SpaceTimeMap::fully_streaming()).disassemble();
+    CHECK(hx.find("Hexagonal") != std::string::npos);
+    CHECK(hx.find("overlay-on-mesh") != std::string::npos);
 }


### PR DESCRIPTION
## Summary

**Phase 0 increment 2** (#230): the **L1 stream-signature** layer over the L0 `TileProgram`. L1 turns each L0 tile-into-port (`Feed`/`Drain`) into an **element stream** and each tile-compute into a **systolic wavefront** — giving physically-shaped timing **without changing values** (L0 stays the functional reference; `L0+L1` is the timing model).

## The systolic model
Output-stationary schedule `σ(i,j,k) = i + j + k` (design note: `docs/plans/l1-stream-signatures.md`):

| Stream | Edge | Lane | Injection time |
|---|---|---|---|
| `A[i,k]` | **West** | row `i` | `i + k` |
| `B[k,j]` | **North** | col `j` | `j + k` |
| `C[i,j]` | **South** (drain) | col `j` | `i + j + (K−1)` |

One `T×T×T` tile-compute has latency `(R−1)+(S−1)+(K−1)+1` — e.g. **46** for T=16 (fill + reduce + drain), instead of a lumped MAC cost. Disassembly of a 32³/T=16 program:
```
StreamProgram (array 16x16)
  0: IN  A[0,0] @West  lanes=16 skew(1,1) span=30 elems=256
  1: IN  B[0,0] @North lanes=16 skew(1,1) span=30 elems=256
  2: COMPUTE C[0,0] wavefront 16x16x16 latency=46
  6: OUT C[0,0] @South lanes=16 skew(1,1) span=30 elems=256
```

## Components (`include/sw/kpu/program/stream/`)
- **`stream_signature.hpp`** — `StreamSignature` (edge, lanes, per-element lane + wavefront skew, rate), `WavefrontTiming` (fill+reduce+drain latency), `StreamProgram` (keyed by L0 op index) + `disassemble()`.
- **`derive/matmul_streams.hpp`** — the matmul derivation (assumes each tile fits the array; larger-tile sub-blocking is a follow-on).

## Tests
`tests/program/test_stream_signature.cpp` — signature/skew/lane correctness, wavefront latency (incl. **clamped trailing tiles**), and **value-orthogonality** (deriving L1 doesn't change the L0 result). 357 assertions.

## Next increments
Wiring `WavefrontTiming::latency()` into the characterization DAG (physically-shaped compute cost), the non-matmul schedules (TRSM/GETRF/QR via the domain_flow polyhedral engine), and driving the cycle-accurate CSP model from L1 (§5 of the design note).

Additive only (new `stream/` headers + one test + CMake/CHANGELOG). Relates to #230, #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)