### PR TITLE
feat(230): sweep dataflow in the characterization harness (L1-timed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dataflow sweep in the characterization harness (`--dataflow`).** The
+  characterization DAG now accepts an optional L1 `StreamProgram`
+  (`characterize_program(prog, dev, l1)` / `TileDag(..., l1)`): with it, compute ops
+  take their systolic **wavefront latency** and the C drain is stretched by its
+  **bubble**, so the schedule becomes systolic and **dataflow-sensitive**. `Metrics`
+  gains `dataflow`/`stationary`/`c_bubble`/`network`. `tile_characterize --dataflow
+  output-stationary|weight-stationary|a-stationary|fully-streaming` (aliases
+  `os`/`ws`/`as`/`hex`, matmul only) sweeps the array space-time mapping alongside
+  size/tile/compute-tiles/topology, surfacing the tradeoff: output-stationary is
+  Mesh2D-friendly but pays a drain bubble (slower makespan); weight/A-stationary drain
+  densely; fully-streaming (hex) is dense/contention-free but requires a
+  `Hexagonal+overlay` network. The no-L1 path is unchanged (backward-compatible).
+  Test + README recipe added.
+
 - **L1 stream signatures — the spatial/temporal layer over L0, parameterized by the
   space-time mapping (Phase 0 increment 2, #230).** L1 turns each L0 tile-into-port into
   an **element stream** and each tile-compute into a **systolic wavefront**, giving

--- a/examples/characterize/README.md
+++ b/examples/characterize/README.md
@@ -41,6 +41,7 @@ build/examples/characterize/tile_characterize \
 | `--tiles T[,T...]` | tile dimension(s) | `32` |
 | `--compute-tiles C[,C...]` | CF tile count(s) — the **concurrency sweep** | `1,4,16` |
 | `--topology single\|news\|checkerboard[,...]` | spatial layout (sets movement lanes) | `single` |
+| `--dataflow output-stationary\|weight-stationary\|a-stationary\|fully-streaming[,...]` | **array dataflow** (L1 space-time mapping; matmul only; aliases `os`/`ws`/`as`/`hex`) | `output-stationary` |
 | `--macs-per-cycle` `--bytes-per-cycle` `--pj-per-mac` `--pj-per-byte` | device cost knobs | `256 / 64 / 1 / 20` |
 | `--l3-tiles N` | L3 budget in tiles for feasibility (`0` = unbounded) | `0` |
 | `--csv FILE` `--json FILE` | write the full metric table | — |
@@ -49,33 +50,40 @@ build/examples/characterize/tile_characterize \
 | `--no-validate` | skip the functional oracle check | (validate on) |
 
 The **list-valued** factor flags (`--sizes`, `--tiles`, `--compute-tiles`,
-`--topology`) are comma-separated → a **full-factorial** sweep (one row per cell).
-`--algo` selects a single algorithm per run.
+`--topology`, `--dataflow`) are comma-separated → a **full-factorial** sweep (one row
+per cell). `--algo` selects a single algorithm per run.
+
+When a `--dataflow` is given for matmul, the schedule is timed by the **L1 stream
+signatures** (`docs/plans/l1-stream-signatures.md`) — compute ops take their systolic
+wavefront latency and the C drain is stretched by its bubble — so the makespan and the
+`stat`/`bub`/`network` columns become **dataflow-sensitive**.
 
 ## 3. Read the output
 
 Each row is one experiment cell:
 
 ```text
-algo   size tile  CF topology      macs        AI    crit_path   makespan  cmp_util  bound  energy_pJ    err
-matmul  128   32   1 checkerboard   2.1e+06   7.11       576.0    14976.0     0.55   mov    1.4e+07        0
-matmul  128   32  16 checkerboard   2.1e+06   7.11       576.0      768.0     0.67   mov    1.4e+07        0
+algo   size tile  CF topology    dataflow          stat bub network            makespan  cmp_util  bound  energy_pJ    err
+matmul  256   32   4 single     output-stationary C      1 Mesh2D               36864.0     0.33   mov   1.07e+08        0
+matmul  256   32   4 single     weight-stationary B      0 Mesh2D               34816.0     0.35   mov   1.07e+08        0
+matmul  256   32   4 single     fully-streaming   -      0 Hexagonal+overlay    34816.0     0.35   mov   1.07e+08        0
 ```
 
 | Column | Meaning |
 |---|---|
-| `macs` | total multiply-accumulates (exact) |
-| `AI` | arithmetic intensity = flops / byte moved (higher = more reuse) |
-| `crit_path` | modeled makespan at **unlimited** compute tiles (dependency-limited floor) |
-| `makespan` | list-scheduled modeled cycles on this device |
-| `cmp_util` | compute-tile utilization on this device |
+| `dataflow` | the array space-time mapping (which operand is held stationary) |
+| `stat` | the stationary operand (`C`/`B`/`A`; `-` for fully-streaming) |
+| `bub` | the C-drain **bubble** (`1` for output-stationary, `0` for the dense dataflows) |
+| `network` | required fabric — `Mesh2D` or `Hexagonal+overlay` |
+| `makespan` | list-scheduled cycles (systolic + dataflow-sensitive when `--dataflow` is set) |
+| `cmp_util` | compute-tile utilization |
 | `bound` | `cmp` = compute-bound, `mov` = movement-bound |
 | `energy_pJ` | modeled total energy (compute + movement + leakage) |
 | `err` | functional `max_err` vs. the oracle (`0` for integer matmul; ~`1e-6` for LU); `-1` if `--no-validate` |
 
 **`err` is the correctness check** — a nonzero-beyond-tolerance `err` means the tile
-program computed the wrong answer. The CSV/JSON carry the full metric set (peak live
-tiles, movement bytes, lower bound, movement utilization, feasibility, …).
+program computed the wrong answer. The CSV/JSON carry the full metric set (macs,
+arithmetic intensity, critical path, peak live tiles, movement bytes, feasibility, …).
 
 ## 4. See the tile sequence
 
@@ -128,6 +136,13 @@ tile_characterize --algo matmul --sizes 256 --tiles 16,32,64 --compute-tiles 16 
 
 # (d) Feasibility: does the working set fit the L3 budget?
 tile_characterize --algo matmul --sizes 256 --tiles 32 --compute-tiles 16 --l3-tiles 8
+
+# (e) Dataflow choice: which array mapping (stationary operand + network)?
+#     output-stationary is mesh-friendly but pays a drain bubble; weight/A-stationary
+#     drain densely; fully-streaming (hex) is dense/contention-free but needs a hex
+#     network overlay. Watch the stat / bub / network / makespan columns.
+tile_characterize --algo matmul --sizes 256 --tiles 32 --compute-tiles 4 \
+    --dataflow output-stationary,weight-stationary,a-stationary,fully-streaming
 ```
 
 ## 7. Caveats

--- a/examples/characterize/tile_characterize.cpp
+++ b/examples/characterize/tile_characterize.cpp
@@ -130,12 +130,19 @@ DeviceDescriptor make_device(const std::string& topo, Dim cf,
     return d;
 }
 
-// dataflow name (or alias) -> space-time mapping
+bool known_dataflow(const std::string& n) {
+    return n == "output-stationary" || n == "os" ||
+           n == "weight-stationary" || n == "ws" ||
+           n == "a-stationary"      || n == "as" ||
+           n == "fully-streaming"   || n == "hex";
+}
+
+// dataflow name (or alias) -> space-time mapping (caller must pre-validate via known_dataflow)
 stream::SpaceTimeMap map_for(const std::string& name) {
     if (name == "weight-stationary" || name == "ws") return stream::SpaceTimeMap::b_stationary();
     if (name == "a-stationary"      || name == "as") return stream::SpaceTimeMap::a_stationary();
     if (name == "fully-streaming"   || name == "hex") return stream::SpaceTimeMap::fully_streaming();
-    return stream::SpaceTimeMap::output_stationary();   // "output-stationary" / "os" / default
+    return stream::SpaceTimeMap::output_stationary();   // "output-stationary" / "os"
 }
 
 } // namespace
@@ -176,6 +183,14 @@ int main(int argc, char** argv) {
     const bool disasm = has_flag(a, "--disasm");
 
     // dataflow sweep applies to matmul (L1 systolic timing); LU has no stream deriver.
+    if (algo != "lu")
+        for (const auto& df : dataflows)
+            if (!known_dataflow(df)) {
+                std::cerr << "error: unknown --dataflow '" << df << "' "
+                             "(expected output-stationary|weight-stationary|a-stationary|"
+                             "fully-streaming, or os/ws/as/hex)\n";
+                return 2;
+            }
     const std::vector<std::string> dfs = (algo == "lu")
         ? std::vector<std::string>{"-"} : dataflows;
 
@@ -213,7 +228,7 @@ int main(int argc, char** argv) {
 
                         if (disasm && !did_disasm) { std::cout << "\n" << prog.disassemble() << "\n"; did_disasm = true; }
                         if (!trace_path.empty() && !did_trace) {
-                            write_chrome_trace(prog, dev, trace_path);
+                            write_chrome_trace(prog, dev, trace_path, l1p);
                             std::cout << "[trace] wrote " << trace_path << " (chrome://tracing)\n";
                             did_trace = true;
                         }

--- a/examples/characterize/tile_characterize.cpp
+++ b/examples/characterize/tile_characterize.cpp
@@ -23,6 +23,7 @@
 #include <sw/kpu/program/derive/matmul_tile_program.hpp>
 #include <sw/kpu/program/derive/lu_tile_program.hpp>
 #include <sw/kpu/program/characterize/characterization.hpp>
+#include <sw/kpu/program/stream/derive/matmul_streams.hpp>
 
 #include <cmath>
 #include <cstdint>
@@ -129,6 +130,14 @@ DeviceDescriptor make_device(const std::string& topo, Dim cf,
     return d;
 }
 
+// dataflow name (or alias) -> space-time mapping
+stream::SpaceTimeMap map_for(const std::string& name) {
+    if (name == "weight-stationary" || name == "ws") return stream::SpaceTimeMap::b_stationary();
+    if (name == "a-stationary"      || name == "as") return stream::SpaceTimeMap::a_stationary();
+    if (name == "fully-streaming"   || name == "hex") return stream::SpaceTimeMap::fully_streaming();
+    return stream::SpaceTimeMap::output_stationary();   // "output-stationary" / "os" / default
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -141,6 +150,8 @@ int main(int argc, char** argv) {
             "  --tiles T[,T...]           tile dimension(s)      (default 32)\n"
             "  --compute-tiles C[,C...]   CF tile count(s)       (default 1,4,16)\n"
             "  --topology single|news|checkerboard[,...] (default single)\n"
+            "  --dataflow output-stationary|weight-stationary|a-stationary|fully-streaming[,...]\n"
+            "             (matmul only; aliases os/ws/as/hex; systolic L1 timing + network)\n"
             "  --macs-per-cycle F  --bytes-per-cycle F  --pj-per-mac F  --pj-per-byte F\n"
             "  --l3-tiles N               L3 capacity in tiles for feasibility (0=unbounded)\n"
             "  --csv FILE   --json FILE   --trace FILE (first cell)  --disasm  --no-validate\n";
@@ -152,6 +163,7 @@ int main(int argc, char** argv) {
     const auto tiles = parse_ints(arg(a, "--tiles", "32"));
     const auto cfs   = parse_ints(arg(a, "--compute-tiles", "1,4,16"));
     const auto topos = parse_strs(arg(a, "--topology", "single"));
+    const auto dataflows = parse_strs(arg(a, "--dataflow", "output-stationary"));  // matmul only
     const double macs_pc  = std::stod(arg(a, "--macs-per-cycle", "256"));
     const double bytes_pc = std::stod(arg(a, "--bytes-per-cycle", "64"));
     const double pj_mac   = std::stod(arg(a, "--pj-per-mac", "1.0"));
@@ -163,12 +175,19 @@ int main(int argc, char** argv) {
     const std::string trace_path = arg(a, "--trace", "");
     const bool disasm = has_flag(a, "--disasm");
 
+    // dataflow sweep applies to matmul (L1 systolic timing); LU has no stream deriver.
+    const std::vector<std::string> dfs = (algo == "lu")
+        ? std::vector<std::string>{"-"} : dataflows;
+
     std::ostringstream csv, json;
-    csv << "algo,size,tile,compute_tiles,topology,func_max_err," << metrics_csv_header() << "\n";
+    csv << "algo,size,tile,compute_tiles,topology,dataflow,stationary,c_bubble,network,func_max_err,"
+        << metrics_csv_header() << "\n";
     json << "[\n";
 
-    std::cout << "algo   size tile  CF topology      macs        AI    crit_path   makespan  cmp_util  bound  energy_pJ    err\n";
-    std::cout << "----------------------------------------------------------------------------------------------------------------\n";
+    std::cout << "algo   size tile  CF topology    dataflow          stat bub network            "
+                 "makespan  cmp_util  bound  energy_pJ    err\n";
+    std::cout << "------------------------------------------------------------------------------------"
+                 "-------------------------------------\n";
 
     bool did_trace = false, did_disasm = false, first_json = true;
     for (const auto& topo : topos)
@@ -176,7 +195,6 @@ int main(int argc, char** argv) {
             for (Dim tile : tiles) {
                 if (tile > size) continue;
                 for (Dim cf : cfs) {
-                    // build the program
                     TileProgram prog =
                         (algo == "lu") ? derive_lu_tile_program(size, tile)
                                        : derive_matmul_tile_program(size, size, size, tile, tile, tile);
@@ -186,42 +204,52 @@ int main(int argc, char** argv) {
                                              : validate_matmul(prog, size, size, size);
 
                     DeviceDescriptor dev = make_device(topo, cf, macs_pc, bytes_pc, pj_mac, pj_byte, l3_tiles);
-                    Metrics m = characterize_program(prog, dev);
 
-                    // first cell: dump the tile sequence / trace on request
-                    if (disasm && !did_disasm) { std::cout << "\n" << prog.disassemble() << "\n"; did_disasm = true; }
-                    if (!trace_path.empty() && !did_trace) {
-                        write_chrome_trace(prog, dev, trace_path);
-                        std::cout << "[trace] wrote " << trace_path << " (chrome://tracing)\n";
-                        did_trace = true;
+                    for (const auto& df : dfs) {
+                        stream::StreamProgram l1;
+                        const stream::StreamProgram* l1p = nullptr;
+                        if (algo != "lu") { l1 = stream::derive_matmul_streams(prog, map_for(df)); l1p = &l1; }
+                        Metrics m = characterize_program(prog, dev, l1p);
+
+                        if (disasm && !did_disasm) { std::cout << "\n" << prog.disassemble() << "\n"; did_disasm = true; }
+                        if (!trace_path.empty() && !did_trace) {
+                            write_chrome_trace(prog, dev, trace_path);
+                            std::cout << "[trace] wrote " << trace_path << " (chrome://tracing)\n";
+                            did_trace = true;
+                        }
+
+                        char line[320];
+                        std::snprintf(line, sizeof(line),
+                            "%-6s %4u %4u %3u %-10s %-17s %-4s %3d %-18s %9.1f %8.2f %5s %10.3g %8.1g\n",
+                            algo.c_str(), size, tile, cf, topo.c_str(), df.c_str(),
+                            m.stationary.empty() ? "-" : m.stationary.c_str(), m.c_bubble,
+                            m.network.empty() ? "-" : m.network.c_str(),
+                            m.makespan_cycles, m.compute_util, m.compute_bound ? "cmp" : "mov",
+                            m.energy_total_pj, err);
+                        std::cout << line;
+
+                        csv << algo << ',' << size << ',' << tile << ',' << cf << ',' << topo << ','
+                            << df << ',' << (m.stationary.empty() ? "-" : m.stationary) << ','
+                            << m.c_bubble << ',' << (m.network.empty() ? "-" : m.network) << ','
+                            << err << ',' << metrics_csv_row(m) << "\n";
+                        if (!first_json) json << ",\n";
+                        first_json = false;
+                        json << "  {\"algo\":\"" << algo << "\",\"size\":" << size << ",\"tile\":" << tile
+                             << ",\"compute_tiles\":" << cf << ",\"topology\":\"" << topo
+                             << "\",\"dataflow\":\"" << df << "\",\"stationary\":\"" << m.stationary
+                             << "\",\"c_bubble\":" << m.c_bubble << ",\"network\":\"" << m.network
+                             << "\",\"func_max_err\":" << err
+                             << ",\"macs\":" << m.total_macs << ",\"arith_intensity\":" << m.arithmetic_intensity
+                             << ",\"critical_path\":" << m.critical_path_cycles
+                             << ",\"makespan\":" << m.makespan_cycles
+                             << ",\"lower_bound\":" << m.lower_bound_cycles
+                             << ",\"compute_util\":" << m.compute_util
+                             << ",\"movement_util\":" << m.movement_util
+                             << ",\"compute_bound\":" << (m.compute_bound ? "true" : "false")
+                             << ",\"peak_live_tiles\":" << m.peak_live_tiles
+                             << ",\"energy_total_pj\":" << m.energy_total_pj
+                             << ",\"feasible\":" << (m.feasible ? "true" : "false") << "}";
                     }
-
-                    char line[256];
-                    std::snprintf(line, sizeof(line),
-                        "%-6s %4u %4u %3u %-12s %9.3g %6.2f %11.1f %10.1f %8.2f %5s %10.3g %8.1g\n",
-                        algo.c_str(), size, tile, cf, topo.c_str(),
-                        m.total_macs, m.arithmetic_intensity, m.critical_path_cycles,
-                        m.makespan_cycles, m.compute_util, m.compute_bound ? "cmp" : "mov",
-                        m.energy_total_pj, err);
-                    std::cout << line;
-
-                    csv << algo << ',' << size << ',' << tile << ',' << cf << ',' << topo << ','
-                        << err << ',' << metrics_csv_row(m) << "\n";
-                    if (!first_json) json << ",\n";
-                    first_json = false;
-                    json << "  {\"algo\":\"" << algo << "\",\"size\":" << size << ",\"tile\":" << tile
-                         << ",\"compute_tiles\":" << cf << ",\"topology\":\"" << topo
-                         << "\",\"func_max_err\":" << err
-                         << ",\"macs\":" << m.total_macs << ",\"arith_intensity\":" << m.arithmetic_intensity
-                         << ",\"critical_path\":" << m.critical_path_cycles
-                         << ",\"makespan\":" << m.makespan_cycles
-                         << ",\"lower_bound\":" << m.lower_bound_cycles
-                         << ",\"compute_util\":" << m.compute_util
-                         << ",\"movement_util\":" << m.movement_util
-                         << ",\"compute_bound\":" << (m.compute_bound ? "true" : "false")
-                         << ",\"peak_live_tiles\":" << m.peak_live_tiles
-                         << ",\"energy_total_pj\":" << m.energy_total_pj
-                         << ",\"feasible\":" << (m.feasible ? "true" : "false") << "}";
                 }
             }
     json << "\n]\n";

--- a/include/sw/kpu/program/characterize/characterization.hpp
+++ b/include/sw/kpu/program/characterize/characterization.hpp
@@ -51,6 +51,12 @@ struct Metrics {
 
     // feasibility
     bool feasible = true;                // peak_live_tiles fits L3 (if bounded)
+
+    // dataflow (populated only when an L1 StreamProgram is supplied)
+    std::string dataflow;                // space-time mapping name
+    std::string stationary;              // stationary operand ("" = none/hex)
+    int c_bubble = 0;                    // C-drain bubble (0 = dense)
+    std::string network;                 // required fabric ("Mesh2D" / "Hexagonal(+overlay)")
 };
 
 // Peak number of simultaneously-live tiles over program order (footprint proxy):
@@ -91,7 +97,10 @@ inline std::size_t distinct_tiles(const TileProgram& prog) {
 
 // Compute all metrics for a program on a device (does not run the functional
 // reference — the harness owns correctness because it knows the algorithm/oracle).
-inline Metrics characterize_program(const TileProgram& prog, const DeviceDescriptor& dev) {
+// Supplying an L1 StreamProgram makes the schedule systolic + dataflow-sensitive and
+// populates the dataflow metrics.
+inline Metrics characterize_program(const TileProgram& prog, const DeviceDescriptor& dev,
+                                    const stream::StreamProgram* l1 = nullptr) {
     Metrics m;
     m.ops = prog.ops().size();
     m.feeds  = prog.count(TileOpKind::Feed);
@@ -99,8 +108,16 @@ inline Metrics characterize_program(const TileProgram& prog, const DeviceDescrip
     m.computes = prog.count(TileOpKind::MatMulAccum) + prog.count(TileOpKind::LuDiagFactor) +
                  prog.count(TileOpKind::TrsmLowerLeft) + prog.count(TileOpKind::TrsmUpperRight);
 
-    TileDag dag(prog, dev);
+    TileDag dag(prog, dev, l1);
     auto sch = dag.list_schedule();
+
+    if (l1) {
+        m.dataflow = l1->map.name;
+        m.stationary = l1->map.stationary_operand();   // from the projection (C is held then drained)
+        if (const auto* c = l1->signature("C")) m.c_bubble = c->bubble();
+        m.network = stream::to_string(l1->network.required);
+        if (l1->network.needs_overlay_on_mesh) m.network += "+overlay";
+    }
 
     m.total_macs = dag.total_macs();
     m.total_move_bytes = dag.total_move_bytes();

--- a/include/sw/kpu/program/characterize/characterization.hpp
+++ b/include/sw/kpu/program/characterize/characterization.hpp
@@ -169,8 +169,9 @@ inline std::string metrics_csv_row(const Metrics& m) {
 // so the tile program's organization and ordering are directly observable. Time
 // unit = modeled cycles.
 inline void write_chrome_trace(const TileProgram& prog, const DeviceDescriptor& dev,
-                               const std::string& path) {
-    TileDag dag(prog, dev);
+                               const std::string& path,
+                               const stream::StreamProgram* l1 = nullptr) {
+    TileDag dag(prog, dev, l1);   // same schedule (incl. L1 dataflow timing) as reported
     dag.list_schedule();
     std::ofstream f(path);
     if (!f) {

--- a/include/sw/kpu/program/characterize/tile_dag.hpp
+++ b/include/sw/kpu/program/characterize/tile_dag.hpp
@@ -19,6 +19,7 @@
 
 #include <sw/kpu/program/tile_program.hpp>
 #include <sw/kpu/program/characterize/device_model.hpp>
+#include <sw/kpu/program/stream/stream_signature.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -46,7 +47,14 @@ struct DagNode {
 
 class TileDag {
 public:
-    TileDag(const TileProgram& prog, const DeviceDescriptor& dev) : dev_(dev) {
+    // Without an L1 StreamProgram, compute/movement durations use the first-order
+    // lumped model (device_model.hpp). With one, compute ops take their systolic
+    // WAVEFRONT latency and Drain ops are stretched by the C-stream bubble — so the
+    // schedule becomes systolic and DATAFLOW-sensitive (output-stationary pays the
+    // drain-bubble penalty; weight/A-stationary and hex drain densely).
+    TileDag(const TileProgram& prog, const DeviceDescriptor& dev,
+            const stream::StreamProgram* l1 = nullptr)
+        : dev_(dev), l1_(l1) {
         build_(prog);
     }
 
@@ -144,7 +152,35 @@ public:
 
 private:
     DeviceDescriptor dev_;
+    const stream::StreamProgram* l1_ = nullptr;
     std::vector<DagNode> nodes_;
+
+    // L1-timed duration (systolic cycles): compute = wavefront latency; Drain = the
+    // C stream drained down its lanes at the C signature's element stride (the bubble
+    // stretches it); Feed = the tile filled at one element/cycle/lane.
+    double l1_duration_(const TileOp& op, std::size_t idx, double fallback) const {
+        if (op.kind == TileOpKind::MatMulAccum) {
+            auto it = l1_->computes.find(idx);
+            if (it != l1_->computes.end()) return static_cast<double>(it->second.latency());
+        } else if (op.kind == TileOpKind::Drain) {
+            if (const auto* c = l1_->signature("C")) {
+                const double per_lane = c->lanes > 0
+                    ? static_cast<double>(c->element_count()) / c->lanes : 0.0;
+                return c->element_stride * per_lane;   // bubble (stride>1) stretches the drain
+            }
+        } else if (op.kind == TileOpKind::Feed) {
+            // dense fill: element_count / lanes cycles (stride 1). A stationary operand
+            // still preloads into the array (lanes==0), so cost it over its rows rather
+            // than falling back to the byte model (which would wrongly penalize it).
+            const std::string& t = op.inputs.empty() ? std::string() : op.inputs[0].operand;
+            if (const auto* s = l1_->signature(t)) {
+                const double lanes = s->lanes > 0 ? static_cast<double>(s->lanes)
+                                   : (s->rows > 0 ? static_cast<double>(s->rows) : 1.0);
+                return static_cast<double>(s->element_count()) / lanes;
+            }
+        }
+        return fallback;
+    }
 
     double height_(std::size_t i, std::vector<double>& memo) const {
         if (memo[i] >= 0) return memo[i];
@@ -237,6 +273,9 @@ private:
             nodes_[i].duration = nodes_[i].work.is_compute
                 ? nodes_[i].work.macs / std::max(1.0, dev_.fabric_macs_per_cycle)
                 : nodes_[i].work.bytes / std::max(1.0, dev_.bytes_per_cycle);
+
+            // L1-timed override: systolic wavefront for compute, bubble-scaled drain.
+            if (l1_) nodes_[i].duration = l1_duration_(op, i, nodes_[i].duration);
 
             // classify reads / writes
             std::vector<const TileCoord*> reads, writes;

--- a/include/sw/kpu/program/characterize/tile_dag.hpp
+++ b/include/sw/kpu/program/characterize/tile_dag.hpp
@@ -157,26 +157,33 @@ private:
 
     // L1-timed duration (systolic cycles): compute = wavefront latency; Drain = the
     // C stream drained down its lanes at the C signature's element stride (the bubble
-    // stretches it); Feed = the tile filled at one element/cycle/lane.
-    double l1_duration_(const TileOp& op, std::size_t idx, double fallback) const {
+    // stretches it); Feed = the tile filled at one element/cycle/lane. Movement timing
+    // uses the op's ACTUAL (clamped) tile extent, not the nominal signature shape, so
+    // trailing tiles at non-divisible dimensions are timed correctly.
+    double l1_duration_(const TileProgram& prog, const TileOp& op,
+                        std::size_t idx, double fallback) const {
         if (op.kind == TileOpKind::MatMulAccum) {
             auto it = l1_->computes.find(idx);
-            if (it != l1_->computes.end()) return static_cast<double>(it->second.latency());
-        } else if (op.kind == TileOpKind::Drain) {
+            return it != l1_->computes.end() ? static_cast<double>(it->second.latency()) : fallback;
+        }
+        // boundary Feed/Drain: numerator = this op's actual element count
+        const TileCoord& tile = op.inputs.empty() ? op.outputs[0] : op.inputs[0];
+        Dim rows = 0, cols = 0;
+        extent(prog, tile, rows, cols);
+        const double elements = static_cast<double>(rows) * cols;
+        if (op.kind == TileOpKind::Drain) {
             if (const auto* c = l1_->signature("C")) {
-                const double per_lane = c->lanes > 0
-                    ? static_cast<double>(c->element_count()) / c->lanes : 0.0;
-                return c->element_stride * per_lane;   // bubble (stride>1) stretches the drain
+                const double lanes = c->lanes > 0 ? static_cast<double>(c->lanes)
+                                   : (cols > 0 ? static_cast<double>(cols) : 1.0);
+                return c->element_stride * (elements / lanes);   // bubble stretches the drain
             }
         } else if (op.kind == TileOpKind::Feed) {
-            // dense fill: element_count / lanes cycles (stride 1). A stationary operand
-            // still preloads into the array (lanes==0), so cost it over its rows rather
-            // than falling back to the byte model (which would wrongly penalize it).
-            const std::string& t = op.inputs.empty() ? std::string() : op.inputs[0].operand;
-            if (const auto* s = l1_->signature(t)) {
+            // A stationary operand still preloads into the array (lanes==0), so cost it
+            // over its rows rather than falling back to the byte model.
+            if (const auto* s = l1_->signature(tile.operand)) {
                 const double lanes = s->lanes > 0 ? static_cast<double>(s->lanes)
-                                   : (s->rows > 0 ? static_cast<double>(s->rows) : 1.0);
-                return static_cast<double>(s->element_count()) / lanes;
+                                   : (rows > 0 ? static_cast<double>(rows) : 1.0);
+                return elements / lanes;
             }
         }
         return fallback;
@@ -275,7 +282,7 @@ private:
                 : nodes_[i].work.bytes / std::max(1.0, dev_.bytes_per_cycle);
 
             // L1-timed override: systolic wavefront for compute, bubble-scaled drain.
-            if (l1_) nodes_[i].duration = l1_duration_(op, i, nodes_[i].duration);
+            if (l1_) nodes_[i].duration = l1_duration_(prog, op, i, nodes_[i].duration);
 
             // classify reads / writes
             std::vector<const TileCoord*> reads, writes;

--- a/include/sw/kpu/program/stream/stream_signature.hpp
+++ b/include/sw/kpu/program/stream/stream_signature.hpp
@@ -54,6 +54,16 @@ struct SpaceTimeMap {
 
     // schedule/projection aligned (τ ∥ u) → the contention-free hexagonal case.
     bool aligned() const { return parallel(tau, proj); }
+
+    // The operand held stationary is the one whose propagation direction is ∥ u
+    // (C for proj=k, B for proj=i, A for proj=j; "" when nothing is stationary/hex).
+    std::string stationary_operand() const {
+        if (proj == Vec3{1, 1, 1}) return "";
+        if (proj == Vec3{0, 0, 1}) return "C";
+        if (proj == Vec3{1, 0, 0}) return "B";
+        if (proj == Vec3{0, 1, 0}) return "A";
+        return "";
+    }
 };
 
 // Matmul variable propagation directions (the axis each is invariant along).

--- a/tests/program/test_tile_characterize.cpp
+++ b/tests/program/test_tile_characterize.cpp
@@ -12,6 +12,7 @@
 #include <sw/kpu/program/derive/matmul_tile_program.hpp>
 #include <sw/kpu/program/derive/lu_tile_program.hpp>
 #include <sw/kpu/program/characterize/characterization.hpp>
+#include <sw/kpu/program/stream/derive/matmul_streams.hpp>
 
 using namespace sw::kpu::program;
 using namespace sw::kpu::program::characterize;
@@ -87,6 +88,37 @@ TEST_CASE("characterize reports structural + modeled metrics", "[program][charac
     CHECK(m.makespan_cycles >= m.lower_bound_cycles);   // schedule >= lower bound
     CHECK(m.energy_total_pj > 0.0);
     CHECK(m.energy_total_pj == Approx(m.energy_compute_pj + m.energy_move_pj + m.energy_leak_pj));
+}
+
+TEST_CASE("dataflow sweep: L1 makes the schedule systolic + dataflow-sensitive",
+          "[program][characterize]") {
+    TileProgram prog = derive_matmul_tile_program(128, 128, 128, 32, 32, 32);
+    // enough compute tiles that the drain (not compute) shapes the makespan
+    DeviceDescriptor d = DeviceDescriptor::checkerboard(16);
+
+    stream::StreamProgram os = stream::derive_matmul_streams(prog, stream::SpaceTimeMap::output_stationary());
+    stream::StreamProgram ws = stream::derive_matmul_streams(prog, stream::SpaceTimeMap::b_stationary());
+    stream::StreamProgram hx = stream::derive_matmul_streams(prog, stream::SpaceTimeMap::fully_streaming());
+
+    Metrics mo = characterize_program(prog, d, &os);
+    Metrics mw = characterize_program(prog, d, &ws);
+    Metrics mh = characterize_program(prog, d, &hx);
+
+    // dataflow metrics are populated from L1
+    CHECK(mo.stationary == "C");
+    CHECK(mw.stationary == "B");
+    CHECK(mo.c_bubble == 1);          // output-stationary pays a drain bubble
+    CHECK(mw.c_bubble == 0);          // weight-stationary drains densely
+    CHECK(mo.network == "Mesh2D");
+    CHECK(mh.network.find("Hexagonal") != std::string::npos);
+
+    // the drain bubble makes output-stationary slower than the dense dataflows
+    CHECK(mo.makespan_cycles > mw.makespan_cycles);
+
+    // without L1 the dataflow fields stay empty (backward-compatible path)
+    Metrics plain = characterize_program(prog, d);
+    CHECK(plain.dataflow.empty());
+    CHECK(plain.makespan_cycles > 0.0);
 }
 
 TEST_CASE("feasibility gates on L3 tile capacity", "[program][characterize]") {


### PR DESCRIPTION
## Summary

The characterization harness can now **sweep the array dataflow** (which operand is held stationary), driven by the L1 stream signatures — the domain-flow analogue of choosing a CUTLASS/systolic dataflow.

The characterization DAG accepts an optional L1 `StreamProgram` (`characterize_program(prog, dev, l1)` / `TileDag(..., l1)`). With it, compute ops take their **systolic wavefront latency** and the C drain is stretched by its **bubble**, so the schedule is systolic and **dataflow-sensitive**. `Metrics` gains `dataflow` / `stationary` / `c_bubble` / `network`.

```console
tile_characterize --algo matmul --sizes 256 --tiles 32 --compute-tiles 4 \
    --dataflow output-stationary,weight-stationary,a-stationary,fully-streaming
```
```
dataflow          stat bub network            makespan  bound
output-stationary C      1 Mesh2D               36864.0   mov
weight-stationary B      0 Mesh2D               34816.0   mov
a-stationary      A      0 Mesh2D               34816.0   mov
fully-streaming   -      0 Hexagonal+overlay    34816.0   mov
```

## The tradeoff it surfaces
- **output-stationary** — Mesh2D-friendly, but pays a **drain bubble** (C evacuates North through the filled array) → slower makespan.
- **weight/A-stationary** — drain densely (no bubble), Mesh2D.
- **fully-streaming (hex)** — dense & contention-free (`u=τ=[1,1,1]` aligned), but requires a **`Hexagonal+overlay`** network.

`--dataflow` sweeps alongside size / tile / compute-tiles / topology (matmul only; aliases `os`/`ws`/`as`/`hex`). The **no-L1 path is unchanged** (backward-compatible lumped model).

## Also
- `SpaceTimeMap::stationary_operand()` (read from the projection — output-stationary's C is held-then-drained, role `StreamOut`).
- Fixed the L1 Feed cost for stationary operands (was hitting the byte-model fallback and wrongly penalizing weight-stationary).

## Tests
`test_tile_characterize.cpp` — dataflow metrics populate, output-stationary `c_bubble=1` and slower makespan than weight-stationary, hex network, and the no-L1 path stays empty/valid. README recipe (e) added.

Relates to #230, #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dataflow` support for matmul characterization, including output-, weight-, activation-stationary, and fully streaming options.
  * Characterization results now include dataflow, stationary operand, drain bubble, and required network details.
  * Makespan results can reflect dataflow-specific latency and network behavior.

* **Documentation**
  * Added CLI guidance, output descriptions, and a dataflow sweep recipe to the characterization documentation.

* **Tests**
  * Added coverage for dataflow sweeps and expected performance differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->